### PR TITLE
feat (sns): calc img path for sns

### DIFF
--- a/frontend/pages/sns.vue
+++ b/frontend/pages/sns.vue
@@ -609,10 +609,17 @@ const getSnsMediaUrl = (post, m, idx, rawUrl) => {
         if (h) parts.set('height', h)
         if (/^\d+$/.test(ts)) parts.set('total_size', ts)
         parts.set('idx', String(Number(sizeIdx) || 0))
+        const pid = String(post?.id || '').trim()
+        if (pid) parts.set('post_id', pid)
+
+        const mid = String(m?.id || '').trim()
+        if (mid) parts.set('media_id', mid)
+
+        const mtype = String(m?.type || '').trim()
+        if (mtype) parts.set('media_type', mtype)
+
         if (pick) parts.set('pick', pick)
         if (!pick && snsAvoidOtherPicked.value) {
-          const pid = String(post?.id || '').trim()
-          if (pid) parts.set('post_id', pid)
           parts.set('avoid_picked', '1')
           parts.set('pv', String(snsMediaOverrideRev.value || '0'))
         }


### PR DESCRIPTION
## 纯算法实现朋友圈缓存图片路径计算

#### 背景
目前朋友圈图片通过时间窗口猜测，对于微信长期不登录的用户和朋友圈图片数量较多的用户，会出现非常多匹配错误

#### 实现
该PR通过数据库中存储的xml数据，计算图片缓存路径，精准无误且大幅度降低时间复杂度

#### 问题
仍然没有解决图片无法查看的问题，但是猜测和wxam(wxgf)格式相关