### PR TITLE
chore(git): 忽略根目录 tmp 临时目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ pnpm-lock.yaml
 
 # Local scratch file accidentally generated during development
 /bento-summary.html
+
+# Scratch/intermediate working directory
+/tmp/


### PR DESCRIPTION
将根目录 tmp/ 加入 .gitignore。该目录用于存放临时中间产物（如 skill_metadata.json），不应进入版本库，避免 git status 出现杂散未跟踪文件噪音。