### PR TITLE
fix(onboarding): 防止首次须知永久卡在准备页

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wechat-data-analysis-desktop",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wechat-data-analysis-desktop",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "dependencies": {
         "electron-updater": "^6.7.3",
         "ffmpeg-static": "^5.3.0"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wechat-data-analysis-desktop",
   "private": true,
-  "version": "2.0.10",
+  "version": "2.0.11",
   "main": "src/main.cjs",
   "scripts": {
     "dev": "node scripts/dev.cjs",

--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -59,7 +59,10 @@
       aria-label="正在准备首次使用说明"
     >
       <img src="/logo.png" alt="" aria-hidden="true" />
-      <span>正在准备使用须知…</span>
+      <div class="first-use-route-guard-copy">
+        <span>正在准备使用须知…</span>
+        <a :href="firstUseAgreementHref" @click="openFirstUseAgreement">直接打开使用须知</a>
+      </div>
     </div>
   </div>
 </template>
@@ -83,9 +86,22 @@ const privacyStore = usePrivacyStore()
 const chatAccounts = useChatAccountsStore()
 const { selectedAccount, selectedDataSourceStatus } = storeToRefs(chatAccounts)
 const noAccountGuideOpen = ref(false)
-const firstUseRouteResolved = ref(false)
+const isAgreementRoute = (path = route.path) => {
+  const normalized = String(path || '').replace(/\/+$/, '') || '/'
+  return normalized === '/agreement'
+}
+const firstUseRouteResolved = ref(isAgreementRoute())
+const firstUseAgreementHref = computed(() => (
+  `/agreement?redirect=${encodeURIComponent(String(route.fullPath || '/'))}`
+))
 let firstUseGuardReady = false
 let firstUseNavigationPending = false
+
+const openFirstUseAgreement = (event) => {
+  if (!process.client || typeof window === 'undefined') return
+  event?.preventDefault?.()
+  window.location.replace(firstUseAgreementHref.value)
+}
 
 const accountDataRoutePrefixes = [
   '/chat',
@@ -181,7 +197,7 @@ const updateDprVar = () => {
 
 const enforceFirstUseRoute = async () => {
   if (!process.client || !firstUseGuardReady) return
-  if (route.path === '/agreement' || isFirstUseAgreementAccepted()) {
+  if (isAgreementRoute() || isFirstUseAgreementAccepted()) {
     firstUseRouteResolved.value = true
     return
   }
@@ -189,14 +205,22 @@ const enforceFirstUseRoute = async () => {
   firstUseRouteResolved.value = false
   if (firstUseNavigationPending) return
   firstUseNavigationPending = true
+  const hardNavigationTimer = window.setTimeout(() => {
+    if (!isAgreementRoute() && !isFirstUseAgreementAccepted()) {
+      window.location.replace(firstUseAgreementHref.value)
+    }
+  }, 1500)
   try {
     await navigateTo({
       path: '/agreement',
       query: { redirect: route.fullPath || '/' }
     }, { replace: true })
+  } catch {
+    window.location.replace(firstUseAgreementHref.value)
   } finally {
+    window.clearTimeout(hardNavigationTimer)
     firstUseNavigationPending = false
-    firstUseRouteResolved.value = route.path === '/agreement' || isFirstUseAgreementAccepted()
+    firstUseRouteResolved.value = isAgreementRoute() || isFirstUseAgreementAccepted()
   }
 }
 
@@ -275,7 +299,7 @@ const showSidebar = computed(() => {
   if (path === '/' || path === '/import') return false
   if (path === '/decrypt' || path === '/detection-result' || path === '/decrypt-result') return false
   if (path === '/landing' || path === '/site') return false
-  if (path === '/agreement') return false
+  if (isAgreementRoute(path)) return false
   return !(path === '/wrapped' || path.startsWith('/wrapped/'))
 })
 </script>
@@ -339,6 +363,26 @@ html[data-theme='dark'] .theme-app-shell-wrapped {
   background: var(--app-surface-bg, #ffffff);
   color: var(--app-text-secondary, #5f5f5f);
   font-size: 14px;
+}
+
+html[data-first-use-route='agreement'] .first-use-route-guard,
+html[data-first-use-accepted='true'] .first-use-route-guard {
+  display: none;
+}
+
+.first-use-route-guard-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+}
+
+.first-use-route-guard-copy a {
+  color: var(--app-accent, #07c160);
+  font-size: 13px;
+  font-weight: 650;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .first-use-route-guard img {

--- a/frontend/lib/first-use-bootstrap-script.js
+++ b/frontend/lib/first-use-bootstrap-script.js
@@ -1,0 +1,134 @@
+export const createFirstUseBootstrapScript = ({
+  storageKey,
+  version,
+  countdownMilliseconds = 20_000,
+} = {}) => {
+  const serializedStorageKey = JSON.stringify(String(storageKey || 'ui.first_use_agreement'))
+  const serializedVersion = JSON.stringify(String(version || ''))
+  const serializedCountdown = JSON.stringify(Math.max(0, Number(countdownMilliseconds) || 0))
+
+  return `;(function () {
+  'use strict';
+
+  var storageKey = ${serializedStorageKey};
+  var agreementVersion = ${serializedVersion};
+  var countdownMilliseconds = ${serializedCountdown};
+  var pathname = String(window.location.pathname || '/');
+  var isAgreementRoute = /^\\/agreement\\/?$/.test(pathname);
+
+  function readAcceptance() {
+    try {
+      var stored = JSON.parse(window.localStorage.getItem(storageKey) || 'null');
+      return !!stored && stored.version === agreementVersion && !!stored.acceptedAt;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function currentRedirect() {
+    return String(window.location.pathname || '/')
+      + String(window.location.search || '')
+      + String(window.location.hash || '');
+  }
+
+  function normalizeRedirect(value) {
+    var target = String(value || '').trim();
+    if (target.indexOf('/') !== 0 || target.indexOf('//') === 0 || target.indexOf('/agreement') === 0) {
+      return '/';
+    }
+    return target;
+  }
+
+  if (!isAgreementRoute) {
+    document.documentElement.removeAttribute('data-first-use-route');
+    if (!readAcceptance()) {
+      var agreementUrl = '/agreement?redirect=' + encodeURIComponent(currentRedirect());
+      window.location.replace(agreementUrl);
+      return;
+    }
+    document.documentElement.setAttribute('data-first-use-accepted', 'true');
+    return;
+  }
+
+  document.documentElement.removeAttribute('data-first-use-accepted');
+  document.documentElement.setAttribute('data-first-use-route', 'agreement');
+  var countdownStartedAt = Date.now();
+
+  function installAgreementFallback() {
+    var page = document.querySelector('.first-use-page');
+    if (!page || page.getAttribute('data-first-use-mounted') === 'true') return;
+
+    var routeGuard = document.querySelector('.first-use-route-guard');
+    if (routeGuard) routeGuard.hidden = true;
+
+    var button = document.querySelector('[data-testid="first-use-confirm"]');
+    if (!button) return;
+
+    var buttonLabel = button.querySelector('span');
+    var statusCopy = document.querySelector('.first-use-footer-status p');
+    var statusDot = document.querySelector('.first-use-status-dot');
+    var intervalId = null;
+
+    function stopFallback() {
+      if (intervalId !== null) window.clearInterval(intervalId);
+      intervalId = null;
+    }
+
+    function updateFallback() {
+      if (page.getAttribute('data-first-use-mounted') === 'true') {
+        stopFallback();
+        return;
+      }
+
+      var remaining = Math.max(0, countdownMilliseconds - (Date.now() - countdownStartedAt));
+      var remainingSeconds = Math.ceil(remaining / 1000);
+      if (remaining <= 0) {
+        button.disabled = false;
+        if (buttonLabel) buttonLabel.textContent = '我已阅读全部内容并同意';
+        if (statusCopy) statusCopy.textContent = '重点和边界都看完了，确认后开工。';
+        if (statusDot) statusDot.classList.add('ready');
+        stopFallback();
+        return;
+      }
+
+      button.disabled = true;
+      if (buttonLabel) buttonLabel.textContent = '请阅读（' + remainingSeconds + ' 秒）';
+      if (statusCopy) statusCopy.textContent = '请先读完关键内容，' + remainingSeconds + ' 秒后可确认。';
+    }
+
+    button.addEventListener('click', function (event) {
+      if (page.getAttribute('data-first-use-mounted') === 'true') return;
+      if (button.disabled || Date.now() - countdownStartedAt < countdownMilliseconds) {
+        event.preventDefault();
+        return;
+      }
+
+      try {
+        window.localStorage.setItem(storageKey, JSON.stringify({
+          version: agreementVersion,
+          acceptedAt: new Date().toISOString()
+        }));
+      } catch (_error) {}
+
+      var redirect = '/';
+      try {
+        redirect = normalizeRedirect(new URL(window.location.href).searchParams.get('redirect'));
+      } catch (_error) {}
+      document.documentElement.removeAttribute('data-first-use-route');
+      document.documentElement.setAttribute('data-first-use-accepted', 'true');
+      window.location.replace(redirect);
+    });
+
+    updateFallback();
+    if (button.disabled) intervalId = window.setInterval(updateFallback, 200);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () {
+      window.setTimeout(installAgreementFallback, 1200);
+    }, { once: true });
+  } else {
+    window.setTimeout(installAgreementFallback, 1200);
+  }
+})();`
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,8 +1,19 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import {
+  FIRST_USE_AGREEMENT_STORAGE_KEY,
+  FIRST_USE_AGREEMENT_VERSION,
+} from './lib/first-use-agreement'
+import { createFirstUseBootstrapScript } from './lib/first-use-bootstrap-script'
+
 const frontendHost = String(process.env.NUXT_HOST || '').trim()
 const frontendPort = Number.parseInt(String(process.env.NUXT_PORT || process.env.PORT || '3000').trim(), 10)
 const backendPort = String(process.env.WECHAT_TOOL_PORT || '10392').trim() || '10392'
 const devProxyTarget = `http://127.0.0.1:${backendPort}/api`
+const firstUseBootstrapScript = createFirstUseBootstrapScript({
+  storageKey: FIRST_USE_AGREEMENT_STORAGE_KEY,
+  version: FIRST_USE_AGREEMENT_VERSION,
+  countdownMilliseconds: 20_000,
+})
 
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
@@ -56,6 +67,13 @@ export default defineNuxtConfig({
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { name: 'description', content: '微信4.x版本数据库解密工具' }
+      ],
+      script: [
+        {
+          key: 'first-use-bootstrap',
+          innerHTML: firstUseBootstrapScript,
+          tagPosition: 'head',
+        }
       ],
       link: [
         { rel: 'icon', type: 'image/png', href: '/logo.png' }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
+    "test": "node --test tests/*.test.mjs",
     "postinstall": "nuxt prepare"
   },
   "dependencies": {

--- a/frontend/pages/agreement.vue
+++ b/frontend/pages/agreement.vue
@@ -376,12 +376,15 @@ const confirmAgreement = async () => {
   if (!canConfirm.value) return
 
   persistFirstUseAgreementAcceptance()
+  document.documentElement.removeAttribute('data-first-use-route')
+  document.documentElement.setAttribute('data-first-use-accepted', 'true')
   await navigateTo(normalizeFirstUseRedirect(route.query.redirect), { replace: true })
 }
 
 useHead({ title: '使用须知与免责声明 - 微信数据分析工具' })
 
 onMounted(() => {
+  pageRef.value?.setAttribute('data-first-use-mounted', 'true')
   document.addEventListener('visibilitychange', handleVisibilityChange)
   startCountdown()
   titleRef.value?.focus?.()
@@ -389,6 +392,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  pageRef.value?.removeAttribute('data-first-use-mounted')
   annotationsDisposed = true
   removeRoughAnnotations()
   document.removeEventListener('visibilitychange', handleVisibilityChange)

--- a/frontend/tests/first-use-bootstrap.test.mjs
+++ b/frontend/tests/first-use-bootstrap.test.mjs
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import { createFirstUseBootstrapScript } from '../lib/first-use-bootstrap-script.js'
+
+const STORAGE_KEY = 'ui.first_use_agreement'
+const VERSION = '2026-08-12.3'
+const bootstrapScript = createFirstUseBootstrapScript({
+  storageKey: STORAGE_KEY,
+  version: VERSION,
+  countdownMilliseconds: 20_000,
+})
+
+const createHarness = ({ pathname = '/', search = '', hash = '', stored = null } = {}) => {
+  let now = 0
+  let intervalCallback = null
+  let clickCallback = null
+  const replacements = []
+  const rootAttributes = new Map()
+  const pageAttributes = new Map()
+  const storage = new Map()
+  if (stored !== null) storage.set(STORAGE_KEY, stored)
+
+  const label = { textContent: '请阅读（20 秒）' }
+  const statusCopy = { textContent: '请先读完关键内容，20 秒后可确认。' }
+  const statusDot = {
+    classes: new Set(),
+    classList: {
+      add(value) {
+        statusDot.classes.add(value)
+      },
+    },
+  }
+  const button = {
+    disabled: true,
+    querySelector: (selector) => selector === 'span' ? label : null,
+    addEventListener(event, callback) {
+      if (event === 'click') clickCallback = callback
+    },
+  }
+  const page = {
+    getAttribute: (name) => pageAttributes.get(name) || null,
+    setAttribute: (name, value) => pageAttributes.set(name, String(value)),
+  }
+  const guard = { hidden: false }
+  const documentElement = {
+    setAttribute: (name, value) => rootAttributes.set(name, String(value)),
+    removeAttribute: (name) => rootAttributes.delete(name),
+  }
+  const document = {
+    readyState: 'complete',
+    documentElement,
+    addEventListener() {},
+    querySelector(selector) {
+      return {
+        '.first-use-page': page,
+        '.first-use-route-guard': guard,
+        '[data-testid="first-use-confirm"]': button,
+        '.first-use-footer-status p': statusCopy,
+        '.first-use-status-dot': statusDot,
+      }[selector] || null
+    },
+  }
+
+  class FakeDate extends Date {
+    constructor(...args) {
+      super(...(args.length ? args : [now]))
+    }
+
+    static now() {
+      return now
+    }
+  }
+
+  const location = {
+    pathname,
+    search,
+    hash,
+    href: `http://127.0.0.1:10393${pathname}${search}${hash}`,
+    replace(value) {
+      replacements.push(String(value))
+    },
+  }
+  const window = {
+    location,
+    localStorage: {
+      getItem: (key) => storage.has(key) ? storage.get(key) : null,
+      setItem: (key, value) => storage.set(key, String(value)),
+    },
+    setTimeout(callback) {
+      callback()
+      return 1
+    },
+    setInterval(callback) {
+      intervalCallback = callback
+      return 2
+    },
+    clearInterval() {
+      intervalCallback = null
+    },
+  }
+
+  vm.runInNewContext(bootstrapScript, {
+    Date: FakeDate,
+    JSON,
+    Math,
+    String,
+    URL,
+    document,
+    encodeURIComponent,
+    window,
+  })
+
+  return {
+    advance(milliseconds) {
+      now += milliseconds
+      intervalCallback?.()
+    },
+    click() {
+      assert.equal(typeof clickCallback, 'function')
+      clickCallback({ preventDefault() {} })
+    },
+    button,
+    guard,
+    label,
+    pageAttributes,
+    replacements,
+    rootAttributes,
+    statusCopy,
+    statusDot,
+    storage,
+  }
+}
+
+test('unaccepted root redirects before the Nuxt client mounts', () => {
+  const harness = createHarness()
+
+  assert.deepEqual(harness.replacements, ['/agreement?redirect=%2F'])
+  assert.equal(harness.rootAttributes.has('data-first-use-accepted'), false)
+})
+
+test('accepted state skips the notice and hides the hydration guard', () => {
+  const harness = createHarness({
+    stored: JSON.stringify({ version: VERSION, acceptedAt: '2026-08-12T00:00:00.000Z' }),
+  })
+
+  assert.deepEqual(harness.replacements, [])
+  assert.equal(harness.rootAttributes.get('data-first-use-accepted'), 'true')
+})
+
+test('malformed renderer storage safely falls back to the notice', () => {
+  const harness = createHarness({ stored: '{bad json' })
+
+  assert.deepEqual(harness.replacements, ['/agreement?redirect=%2F'])
+})
+
+test('agreement remains readable and confirmable when Nuxt never mounts', () => {
+  const harness = createHarness({ pathname: '/agreement', search: '?redirect=%2Fchat' })
+
+  assert.equal(harness.rootAttributes.get('data-first-use-route'), 'agreement')
+  assert.equal(harness.guard.hidden, true)
+  assert.equal(harness.button.disabled, true)
+
+  harness.advance(20_000)
+  assert.equal(harness.button.disabled, false)
+  assert.equal(harness.label.textContent, '我已阅读全部内容并同意')
+  assert.equal(harness.statusCopy.textContent, '重点和边界都看完了，确认后开工。')
+  assert.equal(harness.statusDot.classes.has('ready'), true)
+
+  harness.click()
+  const acceptance = JSON.parse(harness.storage.get(STORAGE_KEY))
+  assert.equal(acceptance.version, VERSION)
+  assert.ok(acceptance.acceptedAt)
+  assert.deepEqual(harness.replacements, ['/chat'])
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wechat-decrypt-tool"
-version = "2.0.10"
+version = "2.0.11"
 description = "Modern WeChat database decryption tool with React frontend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wechat_decrypt_tool/__init__.py
+++ b/src/wechat_decrypt_tool/__init__.py
@@ -1,5 +1,5 @@
 """微信数据库解密工具
 """
 
-__version__ = "2.0.10"
+__version__ = "2.0.11"
 __author__ = "WeChat Decrypt Tool"

--- a/tests/test_first_use_agreement_frontend.py
+++ b/tests/test_first_use_agreement_frontend.py
@@ -134,15 +134,33 @@ def test_notice_covers_version_login_and_hook_risks():
         assert text in source
 
 
-def test_app_uses_a_hydration_safe_initial_route_guard():
+def test_app_uses_a_route_aware_guard_with_a_hard_navigation_fallback():
     source = read_frontend("app.vue")
     index = read_frontend("pages/index.vue")
 
-    assert "const firstUseRouteResolved = ref(false)" in source
+    assert "const firstUseRouteResolved = ref(isAgreementRoute())" in source
     assert "await nextTick()" in source
     assert "await enforceFirstUseRoute()" in source
     assert "正在准备使用须知" in source
+    assert "直接打开使用须知" in source
+    assert '<a :href="firstUseAgreementHref"' in source
+    assert "window.location.replace(firstUseAgreementHref.value)" in source
     assert "if (!isFirstUseAgreementAccepted()) return" in index
+
+
+def test_inline_bootstrap_can_reach_and_accept_the_notice_without_nuxt_mounting():
+    config = read_frontend("nuxt.config.ts")
+    bootstrap = read_frontend("lib/first-use-bootstrap-script.js")
+    agreement = read_frontend("pages/agreement.vue")
+
+    assert "createFirstUseBootstrapScript" in config
+    assert "innerHTML: firstUseBootstrapScript" in config
+    assert "tagPosition: 'head'" in config
+    assert "window.location.replace(agreementUrl)" in bootstrap
+    assert "data-first-use-mounted" in bootstrap
+    assert "window.localStorage.setItem(storageKey" in bootstrap
+    assert "button.disabled = false" in bootstrap
+    assert "pageRef.value?.setAttribute('data-first-use-mounted', 'true')" in agreement
 
 
 def test_first_use_route_guard_does_not_wait_on_remote_stylesheets():

--- a/uv.lock
+++ b/uv.lock
@@ -924,7 +924,7 @@ wheels = [
 
 [[package]]
 name = "wechat-decrypt-tool"
-version = "2.0.10"
+version = "2.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## 变更

- 在 Nuxt 客户端挂载前用原生启动脚本检查首次使用状态并直达须知。
- 须知路由按路径立即解除 SSR 遮罩，并保留“直接打开使用须知”和硬导航兜底。
- 即使 Nuxt 客户端分块没有执行，须知仍可展示、完成 20 秒倒计时、保存确认并返回。
- 同步版本号到 `2.0.11`。

## 根因

v2.0.10 的首次使用遮罩初始始终为未解析状态，只有 Nuxt `onMounted` 完成路由守卫后才会消失。特定设备的客户端启动没有走到该阶段时，后端与静态资源虽然全部返回 200，遮罩仍会永久覆盖已预渲染的须知内容。

## 验证

- `npm test`：11/11 通过。
- `python -m pytest tests/test_first_use_agreement_frontend.py -q`：13/13 通过。
- `npm run generate`：静态构建成功，34 条路由完成预渲染。
- 浏览器故障注入：主动阻断 6 个 `/_nuxt/*.js` 分块，仍能进入须知、解除遮罩、完成倒计时、确认并写入版本 `2026-08-12.3`。
