### PR TITLE
feat: integrate protected WeChat native transcription

### DIFF
--- a/.github/workflows/windows-source-runtime-promotion.yml
+++ b/.github/workflows/windows-source-runtime-promotion.yml
@@ -19,9 +19,12 @@ on:
         description: Exact native-core build ID
         required: true
         type: string
+      native_core_source_public_sha256:
+        description: SHA-256 of the exact private source-public Producer ZIP
+        required: true
+        type: string
 
 permissions:
-  actions: read
   contents: write
 
 concurrency:
@@ -56,6 +59,7 @@ jobs:
           NATIVE_RUN_ID: ${{ inputs.native_core_run_id }}
           NATIVE_REVISION: ${{ inputs.native_core_source_revision }}
           NATIVE_BUILD_ID: ${{ inputs.native_core_build_id }}
+          NATIVE_SOURCE_PUBLIC_SHA256: ${{ inputs.native_core_source_public_sha256 }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
@@ -71,6 +75,9 @@ jobs:
           if ($env:NATIVE_RUN_ID -cnotmatch '^[1-9][0-9]*$') { throw 'Invalid Producer run ID.' }
           if ($env:NATIVE_REVISION -cnotmatch '^[0-9a-f]{40}$') { throw 'Invalid Producer revision.' }
           if ($env:NATIVE_BUILD_ID -cnotmatch '^[A-Za-z0-9._-]{8,128}$') { throw 'Invalid build ID.' }
+          if ($env:NATIVE_SOURCE_PUBLIC_SHA256 -cnotmatch '^[0-9a-f]{64}$') {
+            throw 'Invalid source-public Producer ZIP SHA-256.'
+          }
           if ($env:NATIVE_BUILD_ID -match '(^|[._-])(dev|debug|test|local|snapshot|staging)([._-]|$)') {
             throw 'Non-production build ID is forbidden.'
           }
@@ -84,31 +91,52 @@ jobs:
             if ($digest -cnotmatch '^[0-9A-Fa-f]{64}$') { throw 'Invalid signer pin.' }
           }
 
-      - name: Download exact private Producer artifact
+      - name: Download exact private Producer Release asset
         shell: powershell
         timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.WCE_NATIVE_CORE_ARTIFACT_READ_TOKEN }}
           NATIVE_RUN_ID: ${{ inputs.native_core_run_id }}
+          NATIVE_BUILD_ID: ${{ inputs.native_core_build_id }}
+          NATIVE_SOURCE_PUBLIC_SHA256: ${{ inputs.native_core_source_public_sha256 }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           if (-not $env:GH_TOKEN) { throw 'Private Producer read token is required.' }
+          $releaseTag = "windows-native-$env:NATIVE_BUILD_ID"
+          $assetName = "wechatdb-native-windows-x64-source-public-$env:NATIVE_BUILD_ID.zip"
+          $archive = Join-Path $env:RUNNER_TEMP $assetName
           $destination = Join-Path $env:RUNNER_TEMP 'source-native-core'
           $downloaded = $false
           foreach ($attempt in 1..3) {
-            if (Test-Path -LiteralPath $destination) {
-              Remove-Item -LiteralPath $destination -Recurse -Force
-            }
-            New-Item -ItemType Directory -Path $destination | Out-Null
-            gh run download $env:NATIVE_RUN_ID `
+            Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
+            gh release download $releaseTag `
               --repo $env:WCE_NATIVE_CORE_ARTIFACT_REPOSITORY `
-              --name wechatdb-native-windows-x64-source-public `
-              --dir $destination
-            if ($LASTEXITCODE -eq 0) { $downloaded = $true; break }
+              --pattern $assetName `
+              --output $archive
+            if ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $archive -PathType Leaf)) {
+              $downloaded = $true
+              break
+            }
             Start-Sleep -Seconds (10 * $attempt)
           }
-          if (-not $downloaded) { throw 'Unable to download exact source-public Producer artifact.' }
+          if (-not $downloaded) { throw 'Unable to download exact source-public Producer Release asset.' }
+          $actualArchiveSha256 = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualArchiveSha256 -cne $env:NATIVE_SOURCE_PUBLIC_SHA256) {
+            throw 'Source-public Producer Release asset SHA-256 does not match the pinned input.'
+          }
+          if (Test-Path -LiteralPath $destination) {
+            Remove-Item -LiteralPath $destination -Recurse -Force
+          }
+          Expand-Archive -LiteralPath $archive -DestinationPath $destination
+          $provenancePath = Join-Path $destination 'provenance.json'
+          if (-not (Test-Path -LiteralPath $provenancePath -PathType Leaf)) {
+            throw 'Producer Release asset is missing provenance.json.'
+          }
+          $provenance = Get-Content -LiteralPath $provenancePath -Raw | ConvertFrom-Json
+          if ([string]$provenance.build.workflowRunId -cne $env:NATIVE_RUN_ID) {
+            throw 'Producer provenance workflowRunId does not match the requested run ID.'
+          }
           "WCE_SOURCE_PUBLIC_NATIVE_CORE_DIR=$destination" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Verify source-public native-core Producer artifact

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,13 @@ pnpm-lock.yaml
 /src/wechat_decrypt_tool/native/wechatdb_native_build.json
 /src/wechat_decrypt_tool/native/macos/db-key/
 
+# Retired standalone WeChat ASR artifacts. The private implementation is now
+# embedded in the signed native-core client/broker artifact set.
+/native/wechat_native_asr_bridge/
+/src/wechat_decrypt_tool/native/wechat_native_asr_manifest.json
+/src/wechat_decrypt_tool/native/wechat_native_asr_python_transport.py
+/src/wechat_decrypt_tool/native/wechat_native_asr_weixin_hook.dll
+
 # Local diagnostics and rollout notes
 /*.log
 /NATIVE_CORE_ROLLOUT.md

--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@
 
 > Excel 格式生成 `.xlsx` 文件；聊天记录、朋友圈和收藏会将对应格式文件与必要资源一起打包为 ZIP。
 
+### Windows 微信原生语音转文字（固定版本）
+
+项目正在接入一条仅面向 Windows x64 固定版本的微信原生语音转文字路径。底层固定 hook 与适配器此前已用两条不同会话中尚无转写缓存的语音完成真实产品链路验收；本次融合进 native-core 的签名制品已经完成构建、离线验证和交付门禁，但仍须在全新微信进程中重新完成产品 E2E 后，才能作为正式兼容性证明。它调用微信客户端内部的在线 ASR 流程（在线检查、音频上传和结果轮询），不是离线识别，也不会把微信内部接口包装成独立的本地模型服务；可用性、网络访问和账号状态仍受微信客户端及其在线服务约束。
+
+这条路径按账号、会话和消息标识直接发起请求，设计目标是不打开目标聊天、不定位语音气泡，也不需要人工点击“转文字”。运行时仍必须保持微信客户端已启动并登录，且当前登录账号必须与正在读取的数据账号一致。目前只允许精确匹配以下客户端构建：
+
+- 微信 `4.1.12.26`（Windows x64）
+- `Weixin.dll` SHA-256：`4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46`
+
+主操作不会在原生路径失败或不可用时自动回退到 Whisper，避免用户在不知情时切换识别来源。成功结果以**明文**持久化到账号目录的 `_cache/native_voice_transcripts.sqlite3`；需要按本地聊天数据同等敏感级别保护、备份或删除该文件。
+
+远端 hook 与固定版本适配器已编入现有签名的 `wechatdb_client.dll`，控制器由 `wechatdb_broker.exe` 持有；每次开始、轮询和关闭任务都经过 native-core 会话、一次性 nonce 和独立的 `native-asr` 在线授权。该功能不属于离线默认权限，也不再分发独立 hook 或明文 Python controller。
+
+原生 hook 首次使用后会随当前微信进程驻留，直到微信完全退出，目的是避免微信异步回调落入已经卸载的 DLL。不要在同一微信进程内尝试卸载或重复注入；如果 bridge 已经加载后又重启了本项目后端，必须先完全退出并重新启动微信，再使用原生转写。
+
 ### 本地语音转文字（Whisper）
 
 聊天页可以在保留原语音播放的同时，按需将语音识别为中文；HTML、JSON、TXT 和 Excel 导出也可以选择把转写文字与原语音一起写入归档。转写结果按账号、消息 ID、音频内容和模型缓存在账号目录的 `_cache/voice_transcripts.sqlite3`，重复查看或导出不会再次识别。
@@ -207,7 +222,7 @@ npm run dev
 
 首次启动会通过公开 HTTPS 从本仓库固定 Release 下载对应平台的受限原生运行时，并在校验归档 SHA-256、内部文件清单、签名配置和 45 天有效期后缓存。macOS 缓存位于 `~/Library/Caches/WeChatDataAnalysis/source-native-core`，Windows 缓存位于 `%LOCALAPPDATA%\WeChatDataAnalysis\source-native-core`。这一过程不需要 GitHub CLI、GitHub 账号、Token 或私有 Producer 仓库权限。固定运行时过期后执行 `git pull` 获取新的公开固定版本；程序不会接受过期、被修改或平台不匹配的缓存。
 
-`src/wechat_decrypt_tool/native/` 下的 DLL、Broker 和 manifest 被 `.gitignore` 排除是预期设计：源码启动器会把经过固定摘要验证的制品放入用户缓存并通过受控环境变量交给后端，不会把私有 native-core 源码或可误提交的二进制直接放进 Git 工作树。
+私有实时数据库 native-core 的 `wechatdb_client.dll`、`wechatdb_broker.exe`、`wechatdb_native_build.json` 等文件被 `.gitignore` 排除是预期设计：源码启动器会把经过固定摘要验证的制品放入用户缓存并通过受控环境变量交给后端，不会把私有 native-core 源码或可误提交的二进制直接放进 Git 工作树。Windows 微信原生 ASR 已融合进同一组 native-core 制品，不再额外打包独立 hook、manifest 或 Python controller；目标微信版本与内部 ABI 由私有 producer 构建并随 client/broker 的签名、精确摘要和授权策略一起验证。
 
 仅开发不依赖实时数据库的 Web 界面时，也可以分别启动后端和前端。该方式不会执行桌面端原生运行时预检，不应用于验证实时聊天读取：
 

--- a/desktop/resources/native-core-source-windows.json
+++ b/desktop/resources/native-core-source-windows.json
@@ -3,9 +3,9 @@
   "platform": "win32",
   "architecture": "x64",
   "publisherRepository": "LifeArchiveProject/WeChatDataAnalysis",
-  "releaseTag": "windows-source-runtime-20260809-8e355001-71122b5b",
+  "releaseTag": "windows-source-runtime-20260816-dfd3ebe2-31937143227",
   "assetName": "wechatdataanalysis-windows-source-runtime-x64-v1.tar.gz",
-  "assetSha256": "aa041a31015ab243179c56343e67c4250011193663d9b2a5497c07771140e315",
-  "runtimeManifestSha256": "50e35244f9ffb75f03e2dbff69c77bd1f85886b7a9ddb24c3539020646461137",
-  "expiresAtUnix": 1790145553
+  "assetSha256": "c3ca8fef41c9b83bd1c620a07b80df3e7b67c329bfd38ca570613f050f0f8ad5",
+  "runtimeManifestSha256": "e9b7b381a12ad90c93b6e18718aa17fa85d837baf6054d8e4cb8af576802a661",
+  "expiresAtUnix": 1790757765
 }

--- a/desktop/scripts/build-backend.cjs
+++ b/desktop/scripts/build-backend.cjs
@@ -12,6 +12,10 @@ const {
 const {
   resolveIntegrityNativeArtifact,
 } = require("./integrity-native-packaging.cjs");
+const {
+  assertWindowsNativeAsrCapability,
+  windowsNativeAsrManifestErrors,
+} = require("../src/windows-native-asr-capability.cjs");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const entry = path.join(repoRoot, "src", "wechat_decrypt_tool", "backend_entry.py");
@@ -41,6 +45,11 @@ const LEGACY_WCDB_FILE_NAMES = new Set([
   "WCDB.dll",
   "libwcdb_api.dylib",
   "libWCDB.dylib",
+]);
+const RETIRED_STANDALONE_ASR_FILE_NAMES = new Set([
+  "wechat_native_asr_manifest.json",
+  "wechat_native_asr_python_transport.py",
+  "wechat_native_asr_weixin_hook.dll",
 ]);
 const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
 const FALSE_VALUES = new Set(["", "0", "false", "no", "off"]);
@@ -87,6 +96,9 @@ function nativeCoreManifestErrors(manifest) {
   }
   if (manifest.schemaVersion === 2 && Object.prototype.hasOwnProperty.call(manifest, "platform")) {
     errors.push("schemaVersion 2 must not declare platform");
+  }
+  if (manifest.schemaVersion === 2) {
+    errors.push(...windowsNativeAsrManifestErrors(manifest));
   }
   if (typeof manifest.buildId !== "string" || manifest.buildId.trim() === "") {
     errors.push("buildId must be a non-empty string");
@@ -288,6 +300,10 @@ function resolveNativeCoreArtifacts({ env = process.env, platform = process.plat
     );
   }
 
+  if (platform === "win32") {
+    assertWindowsNativeAsrCapability({ nativeDir: artifactDir, manifest });
+  }
+
   return { artifactDir, allowDevelopment, manifest, names, required };
 }
 
@@ -305,7 +321,19 @@ function prepareRuntimeNativeDir(sourceDir, destinationDir) {
         return false;
       }
       const name = path.basename(relative);
-      return !NATIVE_CORE_FILE_NAMES.has(name) && !LEGACY_WCDB_FILE_NAMES.has(name);
+      const pathSegments = normalizedRelative.split("/");
+      if (pathSegments.includes("__pycache__") || name.endsWith(".pyc")) {
+        return false;
+      }
+      if (
+        name.startsWith("wechat_native_asr_python_transport.") ||
+        name.startsWith("win32_native_voice_bridge.")
+      ) {
+        return false;
+      }
+      return !NATIVE_CORE_FILE_NAMES.has(name) &&
+        !LEGACY_WCDB_FILE_NAMES.has(name) &&
+        !RETIRED_STANDALONE_ASR_FILE_NAMES.has(name);
     },
   });
 }

--- a/desktop/scripts/native-core-before-pack.cjs
+++ b/desktop/scripts/native-core-before-pack.cjs
@@ -6,6 +6,9 @@ const {
   nativeCoreArtifactNames,
   nativeCoreProductionManifestErrors,
 } = require("./build-backend.cjs");
+const {
+  assertWindowsNativeAsrCapability,
+} = require("../src/windows-native-asr-capability.cjs");
 
 const desktopRoot = path.resolve(__dirname, "..");
 const LEGACY_WCDB_PATHS = [
@@ -178,6 +181,9 @@ function validatePackagedBackend({
     throw new Error(
       `Packaged backend rejected a non-production wechatdb native core: ${errors.join("; ")}`
     );
+  }
+  if (platform === "win32") {
+    assertWindowsNativeAsrCapability({ nativeDir, manifest });
   }
   return { backendDir, manifest, nativeDir, platform };
 }

--- a/desktop/scripts/windows-source-runtime-promotion.cjs
+++ b/desktop/scripts/windows-source-runtime-promotion.cjs
@@ -4,6 +4,9 @@ const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
+const {
+  assertWindowsNativeAsrCapability,
+} = require("../src/windows-native-asr-capability.cjs");
 
 const PROFILE = "windows-source-public";
 const ASSET_NAME = "wechatdataanalysis-windows-source-runtime-x64-v1.tar.gz";
@@ -134,6 +137,7 @@ function validateSourcePublicCore(coreDir, nowUnix) {
     manifest.buildExpiresAtUnix,
     nowUnix
   );
+  assertWindowsNativeAsrCapability({ nativeDir: coreDir, manifest });
   return {
     artifactName: provenance.artifactName,
     buildId,

--- a/desktop/src/windows-native-asr-capability.cjs
+++ b/desktop/src/windows-native-asr-capability.cjs
@@ -1,0 +1,248 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const WINDOWS_NATIVE_ASR_ABI_VERSION = 1;
+const WINDOWS_NATIVE_ASR_FEATURE_BIT = 16;
+const WINDOWS_NATIVE_ASR_TARGET = Object.freeze({
+  wechatVersion: "4.1.12.26",
+  weixinSha256: "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46",
+});
+const WINDOWS_NATIVE_ASR_EXPORTS = Object.freeze([
+  "wce_native_asr_get_status",
+  "wce_native_asr_begin",
+  "wce_native_asr_poll",
+  "wce_native_asr_close",
+]);
+const MAX_CLIENT_BYTES = 64 * 1024 * 1024;
+const MAX_EXPORT_FUNCTIONS = 65_536;
+const MAX_EXPORT_NAMES = 65_536;
+const MAX_EXPORT_NAME_BYTES = 512;
+
+function peError(message) {
+  return new Error(`Invalid Windows native-core client PE: ${message}`);
+}
+
+function requireRange(buffer, offset, size, label) {
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(size) ||
+    offset < 0 ||
+    size < 0 ||
+    offset > buffer.length - size
+  ) {
+    throw peError(`${label} is outside the file`);
+  }
+}
+
+function readCString(buffer, offset, label) {
+  requireRange(buffer, offset, 1, label);
+  const limit = Math.min(buffer.length, offset + MAX_EXPORT_NAME_BYTES + 1);
+  const terminator = buffer.indexOf(0, offset);
+  if (terminator < 0 || terminator >= limit || terminator === offset) {
+    throw peError(`${label} is not a bounded non-empty string`);
+  }
+  const value = buffer.toString("ascii", offset, terminator);
+  if (!/^[\x21-\x7e]+$/.test(value)) {
+    throw peError(`${label} contains non-ASCII or control bytes`);
+  }
+  return value;
+}
+
+function readWindowsPeExportNames(clientPath, fsImpl = fs) {
+  const resolved = path.resolve(String(clientPath || ""));
+  let stat;
+  try {
+    stat = fsImpl.statSync(resolved);
+  } catch {
+    throw peError(`cannot read ${path.basename(resolved)}`);
+  }
+  if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_CLIENT_BYTES) {
+    throw peError("file size is invalid");
+  }
+
+  const buffer = fsImpl.readFileSync(resolved);
+  if (!Buffer.isBuffer(buffer) || buffer.length !== stat.size) {
+    throw peError("file read was incomplete");
+  }
+  requireRange(buffer, 0, 0x40, "DOS header");
+  if (buffer.readUInt16LE(0) !== 0x5a4d) throw peError("DOS signature is missing");
+
+  const peOffset = buffer.readUInt32LE(0x3c);
+  requireRange(buffer, peOffset, 24, "PE header");
+  if (buffer.readUInt32LE(peOffset) !== 0x00004550) {
+    throw peError("PE signature is missing");
+  }
+
+  const coffOffset = peOffset + 4;
+  const sectionCount = buffer.readUInt16LE(coffOffset + 2);
+  const optionalSize = buffer.readUInt16LE(coffOffset + 16);
+  if (sectionCount <= 0 || sectionCount > 96) throw peError("section count is invalid");
+
+  const optionalOffset = coffOffset + 20;
+  requireRange(buffer, optionalOffset, optionalSize, "optional header");
+  const magic = buffer.readUInt16LE(optionalOffset);
+  let directoryOffset;
+  let numberOfDirectoriesOffset;
+  if (magic === 0x20b) {
+    directoryOffset = optionalOffset + 112;
+    numberOfDirectoriesOffset = optionalOffset + 108;
+  } else if (magic === 0x10b) {
+    directoryOffset = optionalOffset + 96;
+    numberOfDirectoriesOffset = optionalOffset + 92;
+  } else {
+    throw peError("optional-header magic is unsupported");
+  }
+  requireRange(buffer, numberOfDirectoriesOffset, 4, "data-directory count");
+  if (buffer.readUInt32LE(numberOfDirectoriesOffset) < 1) {
+    throw peError("export directory is absent");
+  }
+  requireRange(buffer, directoryOffset, 8, "export data directory");
+  const exportRva = buffer.readUInt32LE(directoryOffset);
+  const exportSize = buffer.readUInt32LE(directoryOffset + 4);
+  if (exportRva === 0 || exportSize < 40) throw peError("export directory is absent");
+
+  const sectionTableOffset = optionalOffset + optionalSize;
+  requireRange(buffer, sectionTableOffset, sectionCount * 40, "section table");
+  const sections = [];
+  for (let index = 0; index < sectionCount; index += 1) {
+    const offset = sectionTableOffset + index * 40;
+    const virtualSize = buffer.readUInt32LE(offset + 8);
+    const virtualAddress = buffer.readUInt32LE(offset + 12);
+    const rawSize = buffer.readUInt32LE(offset + 16);
+    const rawOffset = buffer.readUInt32LE(offset + 20);
+    if (rawSize > 0) {
+      requireRange(buffer, rawOffset, rawSize, `section ${index} raw data`);
+    }
+    sections.push({
+      virtualAddress,
+      virtualSpan: Math.max(virtualSize, rawSize),
+      rawSize,
+      rawOffset,
+    });
+  }
+
+  const rvaToOffset = (rva, size, label) => {
+    for (const section of sections) {
+      if (rva < section.virtualAddress) continue;
+      const delta = rva - section.virtualAddress;
+      if (delta > section.virtualSpan || size > section.virtualSpan - delta) continue;
+      if (delta > section.rawSize || size > section.rawSize - delta) {
+        throw peError(`${label} is not backed by file data`);
+      }
+      const offset = section.rawOffset + delta;
+      requireRange(buffer, offset, size, label);
+      return offset;
+    }
+    throw peError(`${label} RVA is outside mapped sections`);
+  };
+
+  const exportOffset = rvaToOffset(exportRva, 40, "export directory");
+  const numberOfFunctions = buffer.readUInt32LE(exportOffset + 20);
+  const numberOfNames = buffer.readUInt32LE(exportOffset + 24);
+  const functionsRva = buffer.readUInt32LE(exportOffset + 28);
+  const namesRva = buffer.readUInt32LE(exportOffset + 32);
+  const ordinalsRva = buffer.readUInt32LE(exportOffset + 36);
+  if (numberOfFunctions > MAX_EXPORT_FUNCTIONS) {
+    throw peError("export-function count is too large");
+  }
+  if (numberOfNames > MAX_EXPORT_NAMES) throw peError("export-name count is too large");
+  if (numberOfNames === 0 || namesRva === 0) return new Set();
+  if (numberOfFunctions === 0 || functionsRva === 0 || ordinalsRva === 0) {
+    throw peError("export tables are incomplete");
+  }
+
+  const functionsOffset = rvaToOffset(
+    functionsRva,
+    numberOfFunctions * 4,
+    "export-function table"
+  );
+  const namesOffset = rvaToOffset(namesRva, numberOfNames * 4, "export-name table");
+  const ordinalsOffset = rvaToOffset(
+    ordinalsRva,
+    numberOfNames * 2,
+    "export-ordinal table"
+  );
+  const names = new Set();
+  for (let index = 0; index < numberOfNames; index += 1) {
+    const ordinal = buffer.readUInt16LE(ordinalsOffset + index * 2);
+    if (ordinal >= numberOfFunctions) {
+      throw peError(`export ordinal ${index} is outside the function table`);
+    }
+    const functionRva = buffer.readUInt32LE(functionsOffset + ordinal * 4);
+    if (functionRva === 0) {
+      throw peError(`export function ${index} has a null RVA`);
+    }
+    rvaToOffset(functionRva, 1, `export function ${index}`);
+    const nameRva = buffer.readUInt32LE(namesOffset + index * 4);
+    const nameOffset = rvaToOffset(nameRva, 1, `export name ${index}`);
+    names.add(readCString(buffer, nameOffset, `export name ${index}`));
+  }
+  return names;
+}
+
+function windowsNativeAsrManifestErrors(manifest) {
+  const errors = [];
+  if (manifest?.nativeAsrAbiVersion !== WINDOWS_NATIVE_ASR_ABI_VERSION) {
+    errors.push(`nativeAsrAbiVersion must equal ${WINDOWS_NATIVE_ASR_ABI_VERSION}`);
+  }
+  if (manifest?.nativeAsrFeatureBit !== WINDOWS_NATIVE_ASR_FEATURE_BIT) {
+    errors.push(`nativeAsrFeatureBit must equal ${WINDOWS_NATIVE_ASR_FEATURE_BIT}`);
+  }
+  const target = manifest?.nativeAsrTarget;
+  if (!target || Array.isArray(target) || typeof target !== "object") {
+    errors.push("nativeAsrTarget must be an object");
+  } else {
+    const targetKeys = Object.keys(target).sort();
+    if (
+      targetKeys.length !== 2 ||
+      targetKeys[0] !== "wechatVersion" ||
+      targetKeys[1] !== "weixinSha256"
+    ) {
+      errors.push("nativeAsrTarget must contain exactly wechatVersion and weixinSha256");
+    }
+    if (target.wechatVersion !== WINDOWS_NATIVE_ASR_TARGET.wechatVersion) {
+      errors.push(
+        `nativeAsrTarget.wechatVersion must equal ${WINDOWS_NATIVE_ASR_TARGET.wechatVersion}`
+      );
+    }
+    if (target.weixinSha256 !== WINDOWS_NATIVE_ASR_TARGET.weixinSha256) {
+      errors.push(
+        `nativeAsrTarget.weixinSha256 must equal ${WINDOWS_NATIVE_ASR_TARGET.weixinSha256}`
+      );
+    }
+  }
+  return errors;
+}
+
+function assertWindowsNativeAsrCapability({ nativeDir, manifest, fsImpl = fs }) {
+  const manifestErrors = windowsNativeAsrManifestErrors(manifest);
+  if (manifestErrors.length > 0) {
+    throw new Error(`Windows native-core manifest ${manifestErrors.join("; ")}`);
+  }
+  const clientPath = path.join(path.resolve(String(nativeDir || "")), "wechatdb_client.dll");
+  const exports = readWindowsPeExportNames(clientPath, fsImpl);
+  const missing = WINDOWS_NATIVE_ASR_EXPORTS.filter((name) => !exports.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `Windows native-core client is missing fused ASR ABI exports: ${missing.join(", ")}`
+    );
+  }
+  return Object.freeze({
+    abiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+    featureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
+    target: WINDOWS_NATIVE_ASR_TARGET,
+    exports: WINDOWS_NATIVE_ASR_EXPORTS,
+  });
+}
+
+module.exports = {
+  WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  WINDOWS_NATIVE_ASR_EXPORTS,
+  WINDOWS_NATIVE_ASR_TARGET,
+  assertWindowsNativeAsrCapability,
+  readWindowsPeExportNames,
+  windowsNativeAsrManifestErrors,
+};

--- a/desktop/src/windows-source-native-core-bootstrap.cjs
+++ b/desktop/src/windows-source-native-core-bootstrap.cjs
@@ -7,6 +7,9 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const { resolveNativeCoreRuntimePolicy } = require("./native-core-runtime.cjs");
+const {
+  assertWindowsNativeAsrCapability,
+} = require("./windows-native-asr-capability.cjs");
 
 const ENV_SOURCE_NATIVE_CORE_CACHE_DIR = "WCE_NATIVE_CORE_SOURCE_CACHE_DIR";
 const DEFAULT_CONFIG_PATH = path.resolve(
@@ -439,6 +442,10 @@ function validateWindowsSourceRuntimeDirectory(
   if (policy.artifactState !== "source-public") {
     throw new Error("Windows source-runtime native-core is not the restricted source-public profile");
   }
+  assertWindowsNativeAsrCapability({
+    nativeDir: paths.nativeDir,
+    manifest: policy.manifest,
+  });
   return { ...paths, manifest, pin, policy };
 }
 

--- a/desktop/tests/native-core-before-pack.test.cjs
+++ b/desktop/tests/native-core-before-pack.test.cjs
@@ -11,6 +11,13 @@ const {
   stageWindowsPrivatePkiEvidence,
   validatePackagedBackend,
 } = require("../scripts/native-core-before-pack.cjs");
+const {
+  WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_EXPORTS,
+  WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  WINDOWS_NATIVE_ASR_TARGET,
+} = require("../src/windows-native-asr-capability.cjs");
+const { buildWindowsPeWithExports } = require("./pe-export-fixture.cjs");
 
 const BUILD_ISSUED_AT_UNIX = Math.floor(Date.now() / 1000) - 60;
 const BUILD_LIFETIME_SECONDS = 45 * 24 * 60 * 60;
@@ -37,9 +44,16 @@ const PRODUCTION_MANIFEST = Object.freeze({
   securityCheckpointSetId: "WCE-AI-CHECKPOINT-SET-V3",
   securityCheckpointCount: 7,
   securityCheckpointSetSha256: "bb".repeat(32),
+  nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+  nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
 });
 
-function makeBackend(platform, manifest = PRODUCTION_MANIFEST) {
+function makeBackend(
+  platform,
+  manifest = PRODUCTION_MANIFEST,
+  { clientExports = WINDOWS_NATIVE_ASR_EXPORTS } = {}
+) {
   const backendDir = fs.mkdtempSync(path.join(os.tmpdir(), "wda-before-pack-"));
   const nativeDir = path.join(backendDir, "native");
   fs.mkdirSync(nativeDir, { recursive: true });
@@ -49,7 +63,11 @@ function makeBackend(platform, manifest = PRODUCTION_MANIFEST) {
   );
   for (const name of nativeCoreArtifactNames(platform)) {
     if (name === "wechatdb_native_build.json") continue;
-    fs.writeFileSync(path.join(nativeDir, name), name);
+    const content =
+      platform === "win32" && name === "wechatdb_client.dll"
+        ? buildWindowsPeWithExports(clientExports)
+        : name;
+    fs.writeFileSync(path.join(nativeDir, name), content);
   }
   fs.writeFileSync(
     path.join(nativeDir, "wechatdb_native_build.json"),
@@ -67,6 +85,20 @@ test("beforePack accepts a complete production backend trio", () => {
     } finally {
       fs.rmSync(backendDir, { recursive: true, force: true });
     }
+  }
+});
+
+test("beforePack rejects a client that declares ASR but lacks the fused exports", () => {
+  const backendDir = makeBackend("win32", PRODUCTION_MANIFEST, {
+    clientExports: ["wce_client_abi_version"],
+  });
+  try {
+    assert.throws(
+      () => validatePackagedBackend({ backendDir, platform: "win32" }),
+      /missing fused ASR ABI exports: wce_native_asr_get_status, wce_native_asr_begin, wce_native_asr_poll, wce_native_asr_close/
+    );
+  } finally {
+    fs.rmSync(backendDir, { recursive: true, force: true });
   }
 });
 

--- a/desktop/tests/native-core-packaging.test.cjs
+++ b/desktop/tests/native-core-packaging.test.cjs
@@ -11,6 +11,13 @@ const {
   resolveNativeCoreArtifacts,
   stageNativeCoreArtifacts,
 } = require("../scripts/build-backend.cjs");
+const {
+  WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_EXPORTS,
+  WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  WINDOWS_NATIVE_ASR_TARGET,
+} = require("../src/windows-native-asr-capability.cjs");
+const { buildWindowsPeWithExports } = require("./pe-export-fixture.cjs");
 
 const BUILD_ISSUED_AT_UNIX = Math.floor(Date.now() / 1000) - 60;
 const BUILD_LIFETIME_SECONDS = 45 * 24 * 60 * 60;
@@ -37,6 +44,9 @@ const PRODUCTION_MANIFEST = Object.freeze({
   securityCheckpointSetId: "WCE-AI-CHECKPOINT-SET-V3",
   securityCheckpointCount: 7,
   securityCheckpointSetSha256: "bb".repeat(32),
+  nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+  nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
 });
 
 const DEVELOPMENT_MANIFEST = Object.freeze({
@@ -57,6 +67,9 @@ const DEVELOPMENT_MANIFEST = Object.freeze({
   securityCheckpointSetId: "WCE-AI-CHECKPOINT-SET-V3",
   securityCheckpointCount: 7,
   securityCheckpointSetSha256: "bb".repeat(32),
+  nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+  nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
 });
 
 const MACOS_DEVELOPMENT_MANIFEST = Object.freeze({
@@ -94,11 +107,20 @@ function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "wda-native-package-"));
 }
 
-function writeArtifactSet(root, platform, manifest, { omit = [] } = {}) {
+function writeArtifactSet(
+  root,
+  platform,
+  manifest,
+  { clientExports = WINDOWS_NATIVE_ASR_EXPORTS, omit = [] } = {}
+) {
   fs.mkdirSync(root, { recursive: true });
   for (const name of nativeCoreArtifactNames(platform)) {
     if (omit.includes(name) || name === "wechatdb_native_build.json") continue;
-    fs.writeFileSync(path.join(root, name), `fixture:${name}`);
+    const content =
+      platform === "win32" && name === "wechatdb_client.dll"
+        ? buildWindowsPeWithExports(clientExports)
+        : `fixture:${name}`;
+    fs.writeFileSync(path.join(root, name), content);
   }
   if (!omit.includes("wechatdb_native_build.json")) {
     fs.writeFileSync(path.join(root, "wechatdb_native_build.json"), JSON.stringify(manifest));
@@ -128,6 +150,7 @@ test("runtime staging filters checked-out native and legacy WCDB files", () => {
   const source = path.join(root, "source");
   const destination = path.join(root, "stage");
   fs.mkdirSync(path.join(source, "nested"), { recursive: true });
+  fs.mkdirSync(path.join(source, "__pycache__"), { recursive: true });
   fs.writeFileSync(path.join(source, "ordinary.dll"), "ordinary");
   fs.writeFileSync(path.join(source, "wechatdb_client.dll"), "unchecked");
   fs.writeFileSync(path.join(source, "wechatdb_broker.exe"), "unchecked");
@@ -136,6 +159,13 @@ test("runtime staging filters checked-out native and legacy WCDB files", () => {
   fs.writeFileSync(path.join(source, "WCDB.dll"), "legacy-dependency");
   fs.writeFileSync(path.join(source, "libwcdb_api.dylib"), "legacy-macos");
   fs.writeFileSync(path.join(source, "libWCDB.dylib"), "legacy-macos-dependency");
+  fs.writeFileSync(path.join(source, "wechat_native_asr_manifest.json"), "retired");
+  fs.writeFileSync(path.join(source, "wechat_native_asr_python_transport.py"), "retired");
+  fs.writeFileSync(path.join(source, "wechat_native_asr_weixin_hook.dll"), "retired");
+  fs.writeFileSync(
+    path.join(source, "__pycache__", "wechat_native_asr_python_transport.cpython-312.pyc"),
+    "retired-bytecode"
+  );
   fs.writeFileSync(path.join(source, "nested", "resource.bin"), "nested");
 
   try {
@@ -149,6 +179,10 @@ test("runtime staging filters checked-out native and legacy WCDB files", () => {
     assert.equal(fs.existsSync(path.join(destination, "WCDB.dll")), false);
     assert.equal(fs.existsSync(path.join(destination, "libwcdb_api.dylib")), false);
     assert.equal(fs.existsSync(path.join(destination, "libWCDB.dylib")), false);
+    assert.equal(fs.existsSync(path.join(destination, "wechat_native_asr_manifest.json")), false);
+    assert.equal(fs.existsSync(path.join(destination, "wechat_native_asr_python_transport.py")), false);
+    assert.equal(fs.existsSync(path.join(destination, "wechat_native_asr_weixin_hook.dll")), false);
+    assert.equal(fs.existsSync(path.join(destination, "__pycache__")), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -209,6 +243,50 @@ test("production staging copies the complete Windows trio", () => {
     for (const name of nativeCoreArtifactNames("win32")) {
       assert.ok(fs.statSync(path.join(destination, name)).isFile(), name);
     }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Windows staging rejects a manifest without the fused ASR contract", () => {
+  const root = makeTempDir();
+  const artifactDir = path.join(root, "artifacts");
+  const legacyManifest = { ...PRODUCTION_MANIFEST };
+  delete legacyManifest.nativeAsrAbiVersion;
+  delete legacyManifest.nativeAsrFeatureBit;
+  delete legacyManifest.nativeAsrTarget;
+  writeArtifactSet(artifactDir, "win32", legacyManifest);
+
+  try {
+    assert.throws(
+      () =>
+        resolveNativeCoreArtifacts({
+          env: { WCE_NATIVE_CORE_ARTIFACT_DIR: artifactDir },
+          platform: "win32",
+        }),
+      /nativeAsrAbiVersion must equal 1.*nativeAsrFeatureBit must equal 16.*nativeAsrTarget must be an object/
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Windows staging rejects an otherwise valid client without fused ASR exports", () => {
+  const root = makeTempDir();
+  const artifactDir = path.join(root, "artifacts");
+  writeArtifactSet(artifactDir, "win32", PRODUCTION_MANIFEST, {
+    clientExports: ["wce_client_abi_version"],
+  });
+
+  try {
+    assert.throws(
+      () =>
+        resolveNativeCoreArtifacts({
+          env: { WCE_NATIVE_CORE_ARTIFACT_DIR: artifactDir },
+          platform: "win32",
+        }),
+      /missing fused ASR ABI exports: wce_native_asr_get_status, wce_native_asr_begin, wce_native_asr_poll, wce_native_asr_close/
+    );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/desktop/tests/pe-export-fixture.cjs
+++ b/desktop/tests/pe-export-fixture.cjs
@@ -1,0 +1,79 @@
+"use strict";
+
+function buildWindowsPeWithExports(exportNames) {
+  if (!Array.isArray(exportNames) || exportNames.length === 0 || exportNames.length > 32) {
+    throw new Error("exportNames must contain between 1 and 32 names");
+  }
+  const names = exportNames.map((name) => String(name));
+  if (names.some((name) => !/^[\x21-\x7e]{1,128}$/.test(name))) {
+    throw new Error("fixture export names must be bounded printable ASCII");
+  }
+
+  const buffer = Buffer.alloc(0xa00);
+  const peOffset = 0x80;
+  const coffOffset = peOffset + 4;
+  const optionalOffset = coffOffset + 20;
+  const optionalSize = 0xf0;
+  const sectionOffset = optionalOffset + optionalSize;
+  const sectionRva = 0x1000;
+  const sectionRawOffset = 0x200;
+  const toRva = (rawOffset) => sectionRva + rawOffset - sectionRawOffset;
+
+  buffer.writeUInt16LE(0x5a4d, 0);
+  buffer.writeUInt32LE(peOffset, 0x3c);
+  buffer.writeUInt32LE(0x00004550, peOffset);
+  buffer.writeUInt16LE(0x8664, coffOffset);
+  buffer.writeUInt16LE(1, coffOffset + 2);
+  buffer.writeUInt16LE(optionalSize, coffOffset + 16);
+  buffer.writeUInt16LE(0x2022, coffOffset + 18);
+
+  buffer.writeUInt16LE(0x20b, optionalOffset);
+  buffer.writeBigUInt64LE(0x180000000n, optionalOffset + 24);
+  buffer.writeUInt32LE(0x1000, optionalOffset + 32);
+  buffer.writeUInt32LE(0x200, optionalOffset + 36);
+  buffer.writeUInt32LE(0x2000, optionalOffset + 56);
+  buffer.writeUInt32LE(0x200, optionalOffset + 60);
+  buffer.writeUInt32LE(16, optionalOffset + 108);
+  buffer.writeUInt32LE(sectionRva, optionalOffset + 112);
+  buffer.writeUInt32LE(0x500, optionalOffset + 116);
+
+  buffer.write(".rdata\0\0", sectionOffset, "ascii");
+  buffer.writeUInt32LE(0x800, sectionOffset + 8);
+  buffer.writeUInt32LE(sectionRva, sectionOffset + 12);
+  buffer.writeUInt32LE(0x800, sectionOffset + 16);
+  buffer.writeUInt32LE(sectionRawOffset, sectionOffset + 20);
+  buffer.writeUInt32LE(0x40000040, sectionOffset + 36);
+
+  const exportDirectoryOffset = sectionRawOffset;
+  const functionsOffset = 0x240;
+  const namesOffset = 0x2c0;
+  const ordinalsOffset = 0x340;
+  const dllNameOffset = 0x380;
+  let stringOffset = 0x3a0;
+  const codeOffset = 0x900;
+
+  buffer.writeUInt32LE(toRva(dllNameOffset), exportDirectoryOffset + 12);
+  buffer.writeUInt32LE(1, exportDirectoryOffset + 16);
+  buffer.writeUInt32LE(names.length, exportDirectoryOffset + 20);
+  buffer.writeUInt32LE(names.length, exportDirectoryOffset + 24);
+  buffer.writeUInt32LE(toRva(functionsOffset), exportDirectoryOffset + 28);
+  buffer.writeUInt32LE(toRva(namesOffset), exportDirectoryOffset + 32);
+  buffer.writeUInt32LE(toRva(ordinalsOffset), exportDirectoryOffset + 36);
+  buffer.write("wechatdb_client.dll\0", dllNameOffset, "ascii");
+
+  names.forEach((name, index) => {
+    const encoded = Buffer.from(`${name}\0`, "ascii");
+    if (stringOffset + encoded.length >= codeOffset) {
+      throw new Error("fixture export strings exceed the synthetic PE section");
+    }
+    buffer.writeUInt32LE(toRva(codeOffset + index), functionsOffset + index * 4);
+    buffer.writeUInt32LE(toRva(stringOffset), namesOffset + index * 4);
+    buffer.writeUInt16LE(index, ordinalsOffset + index * 2);
+    encoded.copy(buffer, stringOffset);
+    buffer[codeOffset + index] = 0xc3;
+    stringOffset += encoded.length;
+  });
+  return buffer;
+}
+
+module.exports = { buildWindowsPeWithExports };

--- a/desktop/tests/windows-source-native-core-bootstrap.test.cjs
+++ b/desktop/tests/windows-source-native-core-bootstrap.test.cjs
@@ -16,6 +16,13 @@ const {
   applySourceRuntimeEnvironment,
   ensureSourceNativeCore,
 } = require("../src/source-native-core-bootstrap.cjs");
+const {
+  WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_EXPORTS,
+  WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  WINDOWS_NATIVE_ASR_TARGET,
+} = require("../src/windows-native-asr-capability.cjs");
+const { buildWindowsPeWithExports } = require("./pe-export-fixture.cjs");
 
 const NOW_UNIX = 1786162000;
 const ISSUED_AT_UNIX = NOW_UNIX - 60;
@@ -51,10 +58,13 @@ const NATIVE_MANIFEST = Object.freeze({
   securityCheckpointSetSha256: "55".repeat(32),
   sourceRuntime: true,
   windowsHostVerification: "same-user-direct-parent",
+  nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+  nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
 });
 
 const PAYLOADS = new Map([
-  ["native-core/wechatdb_client.dll", Buffer.from("client")],
+  ["native-core/wechatdb_client.dll", buildWindowsPeWithExports(WINDOWS_NATIVE_ASR_EXPORTS)],
   ["native-core/wechatdb_broker.exe", Buffer.from("broker")],
   [
     "native-core/wechatdb_native_build.json",
@@ -114,13 +124,16 @@ function writeConfig(root, pin = PIN) {
   return file;
 }
 
-function writeRuntime(root) {
-  for (const [relative, content] of PAYLOADS) {
+function writeRuntime(
+  root,
+  { payloads = PAYLOADS, runtimeManifestRaw = RUNTIME_MANIFEST_RAW } = {}
+) {
+  for (const [relative, content] of payloads) {
     const file = path.join(root, ...relative.split("/"));
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.writeFileSync(file, content);
   }
-  fs.writeFileSync(path.join(root, "runtime-manifest.json"), RUNTIME_MANIFEST_RAW);
+  fs.writeFileSync(path.join(root, "runtime-manifest.json"), runtimeManifestRaw);
 }
 
 function fixtureTools() {
@@ -190,6 +203,32 @@ test("Windows source bootstrap downloads publicly once and reuses verified cache
     assert.equal(second.runtimeDir, first.runtimeDir);
   }));
 
+test("Windows source cache rejects a hash-verified legacy client without fused ASR exports", () =>
+  withTempRoot((root) => {
+    const payloads = new Map(PAYLOADS);
+    payloads.set(
+      "native-core/wechatdb_client.dll",
+      buildWindowsPeWithExports(["wce_client_abi_version"])
+    );
+    const runtimeManifest = {
+      ...RUNTIME_MANIFEST,
+      files: Object.fromEntries(
+        [...payloads].map(([name, value]) => [
+          name,
+          { sha256: sha256(value), size: value.length, executable: name.endsWith(".exe") },
+        ])
+      ),
+    };
+    const runtimeManifestRaw = Buffer.from(`${JSON.stringify(runtimeManifest, null, 2)}\n`);
+    const pin = { ...PIN, runtimeManifestSha256: sha256(runtimeManifestRaw) };
+    writeRuntime(root, { payloads, runtimeManifestRaw });
+
+    assert.throws(
+      () => validateWindowsSourceRuntimeDirectory(root, pin, { nowUnix: NOW_UNIX }),
+      /missing fused ASR ABI exports: wce_native_asr_get_status, wce_native_asr_begin, wce_native_asr_poll, wce_native_asr_close/
+    );
+  }));
+
 test("Windows source bootstrap rejects an expired pin before network access", () =>
   withTempRoot((root) => {
     assert.throws(
@@ -216,12 +255,12 @@ test("tracked Windows source pin selects the exact immutable public Release asse
   assert.equal(
     publicReleaseUrl(trackedPin),
     "https://github.com/LifeArchiveProject/WeChatDataAnalysis/releases/download/" +
-      "windows-source-runtime-20260809-8e355001-71122b5b/" +
+      "windows-source-runtime-20260816-dfd3ebe2-31937143227/" +
       "wechatdataanalysis-windows-source-runtime-x64-v1.tar.gz"
   );
-  assert.equal(trackedPin.assetSha256, "aa041a31015ab243179c56343e67c4250011193663d9b2a5497c07771140e315");
-  assert.equal(trackedPin.runtimeManifestSha256, "50e35244f9ffb75f03e2dbff69c77bd1f85886b7a9ddb24c3539020646461137");
-  assert.equal(trackedPin.expiresAtUnix, 1790145553);
+  assert.equal(trackedPin.assetSha256, "c3ca8fef41c9b83bd1c620a07b80df3e7b67c329bfd38ca570613f050f0f8ad5");
+  assert.equal(trackedPin.runtimeManifestSha256, "e9b7b381a12ad90c93b6e18718aa17fa85d837baf6054d8e4cb8af576802a661");
+  assert.equal(trackedPin.expiresAtUnix, 1790757765);
 });
 
 test("generic source bootstrap wires the verified Windows directory without macOS-only variables", () =>

--- a/desktop/tests/windows-source-runtime-promotion.test.cjs
+++ b/desktop/tests/windows-source-runtime-promotion.test.cjs
@@ -11,6 +11,13 @@ const {
   PROFILE,
   stageWindowsSourceRuntimeBundle,
 } = require("../scripts/windows-source-runtime-promotion.cjs");
+const {
+  WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_EXPORTS,
+  WINDOWS_NATIVE_ASR_FEATURE_BIT,
+  WINDOWS_NATIVE_ASR_TARGET,
+} = require("../src/windows-native-asr-capability.cjs");
+const { buildWindowsPeWithExports } = require("./pe-export-fixture.cjs");
 
 const NOW = 1_786_000_100;
 const ISSUED = 1_786_000_000;
@@ -28,10 +35,10 @@ function write(file, value) {
   );
 }
 
-function fixture() {
+function fixture({ clientExports = WINDOWS_NATIVE_ASR_EXPORTS } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "wda-windows-source-promotion-"));
   const coreDir = path.join(root, "core");
-  write(path.join(coreDir, "wechatdb_client.dll"), "client");
+  write(path.join(coreDir, "wechatdb_client.dll"), buildWindowsPeWithExports(clientExports));
   write(path.join(coreDir, "wechatdb_broker.exe"), "broker");
   write(path.join(coreDir, "wechatdb_native_build.json"), {
     schemaVersion: 2,
@@ -50,6 +57,9 @@ function fixture() {
     offlineExportSealFormat: "WES2",
     securityCheckpointSetId: "WCE-AI-CHECKPOINT-SET-V3",
     securityCheckpointCount: 7,
+    nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+    nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
+    nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
   });
   const provenance = {
     schemaVersion: 1,
@@ -114,7 +124,24 @@ test("Windows promotion rejects packaged native-core artifacts", () => {
   }
 });
 
-test("Windows promotion workflow verifies Producer output before public no-auth download", () => {
+test("Windows promotion rejects a source runtime without fused ASR exports", () => {
+  const value = fixture({ clientExports: ["wce_client_abi_version"] });
+  try {
+    assert.throws(
+      () => stageWindowsSourceRuntimeBundle({
+        coreDir: value.coreDir,
+        stageDir: path.join(value.root, "stage"),
+        releaseTag: "windows-source-runtime-20260808-aaaaaaaa",
+        nowUnix: NOW,
+      }),
+      /missing fused ASR ABI exports/
+    );
+  } finally {
+    fs.rmSync(value.root, { recursive: true, force: true });
+  }
+});
+
+test("Windows promotion workflow verifies the exact Producer Release asset before public no-auth download", () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, "..", "..", ".github", "workflows", "windows-source-runtime-promotion.yml"),
     "utf8"
@@ -126,6 +153,31 @@ test("Windows promotion workflow verifies Producer output before public no-auth 
   assert.ok(publish > verify);
   assert.ok(publicDownload > publish);
   assert.match(workflow, /WCE_NATIVE_CORE_ARTIFACT_READ_TOKEN/);
+  assert.match(workflow, /windows-native-\$env:NATIVE_BUILD_ID/);
+  assert.match(
+    workflow,
+    /wechatdb-native-windows-x64-source-public-\$env:NATIVE_BUILD_ID\.zip/
+  );
+  assert.match(workflow, /gh release download \$releaseTag/);
+  assert.match(workflow, /native_core_source_public_sha256/);
+  assert.match(
+    workflow,
+    /Get-FileHash -LiteralPath \$archive -Algorithm SHA256/
+  );
+  assert.match(
+    workflow,
+    /\$actualArchiveSha256 -cne \$env:NATIVE_SOURCE_PUBLIC_SHA256/
+  );
+  assert.ok(
+    workflow.indexOf("$actualArchiveSha256 =")
+      < workflow.indexOf("Expand-Archive -LiteralPath $archive")
+  );
+  assert.match(workflow, /Expand-Archive -LiteralPath \$archive -DestinationPath \$destination/);
+  assert.match(
+    workflow,
+    /\[string\]\$provenance\.build\.workflowRunId -cne \$env:NATIVE_RUN_ID/
+  );
+  assert.doesNotMatch(workflow, /gh run download/);
   assert.match(workflow, /refs\/tags\/\$env:WCE_SOURCE_RUNTIME_RELEASE_TAG/);
   assert.match(workflow, /--verify-tag/);
   assert.match(workflow, /\$ErrorActionPreference = 'SilentlyContinue'[\s\S]*gh release view/);

--- a/frontend/assets/css/chat.css
+++ b/frontend/assets/css/chat.css
@@ -329,6 +329,36 @@
   margin: 0;
 }
 
+.wechat-voice-transcript__source {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.2;
+  opacity: 0.62;
+  white-space: nowrap;
+}
+
+.wechat-voice-transcript__source::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  flex: none;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.wechat-voice-transcript__source--wechat::before {
+  background: var(--text-secondary);
+}
+
+.wechat-voice-transcript__source--project::before {
+  background: var(--app-accent);
+}
+
 .wechat-voice-transcript--error .wechat-voice-transcript__error {
   opacity: 0.85;
 }

--- a/frontend/components/chat/ChatHistoryFloatingWindows.vue
+++ b/frontend/components/chat/ChatHistoryFloatingWindows.vue
@@ -317,17 +317,24 @@ export default defineComponent({
       try { await navigator.clipboard.writeText(String(url || '')) } catch {}
     }
 
-    const voiceRecordMessage = (win, record, index) => ({
-      ...record,
-      id: String(record?.id || `${win?.id || 'chat-history'}-voice-${index}`),
-      isSent: false,
-      voiceRead: true,
-      content: String(record?.content || '[语音]')
-    })
+    const voiceRecordMessage = (win, record, index) => {
+      const transcript = String(record?.voiceTranscript || '').trim()
+      return {
+        ...record,
+        id: String(record?.id || `${win?.id || 'chat-history'}-voice-${index}`),
+        isSent: false,
+        voiceRead: true,
+        content: String(record?.content || '[语音]'),
+        voiceTranscript: transcript,
+        voiceTranscriptStatus: transcript
+          ? 'success'
+          : String(record?.voiceTranscriptStatus || 'idle').trim() || 'idle'
+      }
+    }
 
     return {
       ...props.state,
-      // 合并转发浮窗中的语音仅支持播放，不显示“转文字”面板（转写只在主聊天页和导出 HTML 提供）
+      // 合并转发浮窗只提供播放和已有转写，不在浮窗内发起新的转写任务。
       messageState: { ...props.state, transcribeVoice: undefined },
       recordTextSegments,
       openRecordUrl,

--- a/frontend/components/chat/ChatOverlays.vue
+++ b/frontend/components/chat/ChatOverlays.vue
@@ -957,14 +957,19 @@
         定位引用消息
       </button>
       <button
-        v-if="contextMenu.message?.renderType === 'voice' && !privacyMode && voiceTranscriptionAvailable && typeof transcribeVoice === 'function'"
+        v-if="contextMenu.message?.renderType === 'voice'
+          && !privacyMode
+          && nativeVoiceTranscriptionAvailable
+          && typeof transcribeVoice === 'function'
+          && !(contextMenu.message?.voiceTranscriptStatus === 'success'
+            && contextMenu.message?.voiceTranscriptModel === 'wechat-native')"
         class="chat-context-menu__item block w-full text-left px-3 py-2"
         type="button"
         :disabled="contextMenu.message?.voiceTranscriptStatus === 'loading'"
         :class="contextMenu.message?.voiceTranscriptStatus === 'loading' ? 'opacity-50 cursor-not-allowed' : ''"
         @click="onTranscribeVoiceClick"
       >
-        {{ ['success', 'error'].includes(contextMenu.message?.voiceTranscriptStatus) ? '重新转文字' : '转文字' }}
+        {{ contextMenu.message?.voiceTranscriptStatus === 'error' ? '重试微信转文字' : '微信转文字' }}
       </button>
       <button
         class="chat-context-menu__item block w-full text-left px-3 py-2"
@@ -1087,9 +1092,8 @@ export default defineComponent({
       if (!message || typeof transcribe !== 'function') return
       const status = String(message?.voiceTranscriptStatus || '')
       if (status === 'loading') return
-      const hasResult = status === 'success' || status === 'error'
       if (typeof props.state?.closeContextMenu === 'function') props.state.closeContextMenu()
-      void transcribe(message, { force: hasResult })
+      void transcribe(message)
     }
 
     watch(

--- a/frontend/components/chat/MessageContent.vue
+++ b/frontend/components/chat/MessageContent.vue
@@ -164,7 +164,11 @@
                       class="hidden"
                     ></audio>
                     <div
-                      v-if="!privacyMode && typeof transcribeVoice === 'function'"
+                      v-if="!privacyMode && (
+                        typeof transcribeVoice === 'function'
+                        || message.voiceTranscriptStatus === 'success'
+                        || !!message.voiceTranscript
+                      )"
                       class="wechat-voice-transcript"
                       :class="[
                         message.isSent ? 'wechat-voice-transcript--sent' : 'wechat-voice-transcript--received',
@@ -172,37 +176,50 @@
                       ]"
                     >
                       <button
-                        v-if="(!message.voiceTranscriptStatus || message.voiceTranscriptStatus === 'idle') && voiceTranscriptionAvailable"
+                        v-if="typeof transcribeVoice === 'function' && !message.voiceTranscript && (!message.voiceTranscriptStatus || message.voiceTranscriptStatus === 'idle') && nativeVoiceTranscriptionAvailable"
                         type="button"
                         class="wechat-voice-transcript__action"
-                        title="将语音识别为中文"
+                        title="使用微信原生语音转文字"
                         @click.stop="transcribeVoice(message)"
                       >
                         <i class="fa-solid fa-language" aria-hidden="true"></i>
-                        <span>转文字</span>
+                        <span>微信转文字</span>
                       </button>
                       <span
-                        v-else-if="(!message.voiceTranscriptStatus || message.voiceTranscriptStatus === 'idle') && (!voiceTranscriptionStatusKnown || voiceTranscriptionStatusLoading)"
+                        v-else-if="!message.voiceTranscript && (!message.voiceTranscriptStatus || message.voiceTranscriptStatus === 'idle') && (!nativeVoiceTranscriptionStatusKnown || nativeVoiceTranscriptionStatusLoading)"
                         class="wechat-voice-transcript__status"
                         role="status"
-                      >正在检查本地模型…</span>
+                      >正在检查微信转写…</span>
                       <span
-                        v-else-if="!message.voiceTranscriptStatus || message.voiceTranscriptStatus === 'idle'"
+                        v-else-if="!message.voiceTranscript && (!message.voiceTranscriptStatus || message.voiceTranscriptStatus === 'idle')"
                         class="wechat-voice-transcript__error"
-                      >{{ voiceTranscriptionUnavailableReason }}</span>
+                      >{{ nativeVoiceTranscriptionUnavailableReason }}</span>
                       <span v-else-if="message.voiceTranscriptStatus === 'loading'" class="wechat-voice-transcript__status" role="status">
                         <i class="fa-solid fa-spinner fa-spin" aria-hidden="true"></i>
                         正在转文字…
                       </span>
-                      <p v-else-if="message.voiceTranscriptStatus === 'success'" class="wechat-voice-transcript__text">{{ message.voiceTranscript || '未识别到文字' }}</p>
+                      <template v-else-if="message.voiceTranscriptStatus === 'success' || !!message.voiceTranscript">
+                        <span
+                          class="wechat-voice-transcript__source"
+                          :class="`wechat-voice-transcript__source--${voiceTranscriptSourceKey(message)}`"
+                          :data-transcript-source="voiceTranscriptSourceKey(message)"
+                          :title="voiceTranscriptSourceTitle(message)"
+                        >{{ voiceTranscriptSourceLabel(message) }}</span>
+                        <p class="wechat-voice-transcript__text">{{ message.voiceTranscript || '未识别到文字' }}</p>
+                      </template>
                       <template v-else>
                         <span class="wechat-voice-transcript__error">{{ message.voiceTranscriptError || '语音识别失败' }}</span>
                         <button
+                          v-if="typeof transcribeVoice === 'function' && nativeVoiceTranscriptionAvailable && !nativeVoiceTranscriptionStatusLoading"
                           type="button"
                           class="wechat-voice-transcript__retry"
                           title="重新识别"
-                          @click.stop="transcribeVoice(message, { force: true })"
+                          @click.stop="transcribeVoice(message)"
                         >重试</button>
+                        <span
+                          v-else-if="!nativeVoiceTranscriptionAvailable"
+                          class="wechat-voice-transcript__error"
+                        >{{ nativeVoiceTranscriptionUnavailableReason }}</span>
                       </template>
                     </div>
                   </div>
@@ -593,6 +610,26 @@ export default defineComponent({
       props.state?.toggleImageGroupExpanded?.(groupKey)
     }
 
+    const voiceTranscriptSourceKey = (message) => {
+      const model = String(message?.voiceTranscriptModel || '').trim().toLowerCase()
+      if (model === 'wechat-native') return 'wechat'
+      return model ? 'project' : 'unknown'
+    }
+
+    const voiceTranscriptSourceLabel = (message) => ({
+      wechat: '微信原生转写',
+      project: '本项目转写',
+      unknown: '转写来源未标记'
+    })[voiceTranscriptSourceKey(message)]
+
+    const voiceTranscriptSourceTitle = (message) => {
+      const source = voiceTranscriptSourceKey(message)
+      if (source === 'wechat') return '文字由微信客户端原生语音转文字能力生成'
+      const model = String(message?.voiceTranscriptModel || '').trim()
+      if (source === 'project') return `文字由本项目本地 Whisper 转写（模型：${model}）`
+      return '该转写记录没有来源标记'
+    }
+
     const parseEmojiSegments = (text) => {
       const fn = props.state?.parseTextWithEmoji
       if (typeof fn === 'function') return fn(String(text || ''))
@@ -687,6 +724,9 @@ export default defineComponent({
       onMessageEmojiRenderError,
       imageGroupLazySource,
       toggleImageGroupWithTransition,
+      voiceTranscriptSourceKey,
+      voiceTranscriptSourceLabel,
+      voiceTranscriptSourceTitle,
       wechatPcLogoUrl
     }
   }

--- a/frontend/composables/chat/useChatMessages.js
+++ b/frontend/composables/chat/useChatMessages.js
@@ -17,6 +17,34 @@ import { createMessageNormalizer, dedupeMessagesById } from '~/lib/chat/message-
 const DEFAULT_CHAT_SOURCE = 'auto'
 const IMAGE_GROUP_LAYOUT_DURATION_MS = 250
 const IMAGE_GROUP_LAYOUT_EASING = 'cubic-bezier(0.2, 0, 0, 1)'
+const NATIVE_VOICE_DISPATCH_TOKEN = Symbol('nativeVoiceDispatchToken')
+
+const nativeVoiceErrorDetail = (error) => error?.data?.detail || error?.detail || {}
+
+export const mergeWechatNativeVoiceTranscript = (message, payload) => {
+  const model = String(payload?.model ?? payload?.voiceTranscriptModel ?? '').trim().toLowerCase()
+  const text = String(payload?.text ?? payload?.voiceTranscript ?? '').trim()
+  if (model !== 'wechat-native' || !text) return message
+
+  const language = String(payload?.language ?? payload?.voiceTranscriptLanguage ?? '').trim()
+  if (
+    String(message?.voiceTranscript || '').trim() === text
+    && String(message?.voiceTranscriptStatus || '').trim() === 'success'
+    && String(message?.voiceTranscriptModel || '').trim().toLowerCase() === 'wechat-native'
+    && String(message?.voiceTranscriptLanguage || '').trim() === language
+    && !String(message?.voiceTranscriptError || '').trim()
+  ) return message
+
+  return {
+    ...message,
+    voiceTranscript: text,
+    voiceTranscriptStatus: 'success',
+    voiceTranscriptError: '',
+    voiceTranscriptLanguage: language,
+    voiceTranscriptModel: 'wechat-native',
+    voiceTranscriptNativeRequestId: ''
+  }
+}
 
 export const useChatMessages = ({
   api,
@@ -43,6 +71,8 @@ export const useChatMessages = ({
   let messageLoadTargetUsername = ''
   let realtimeRefreshController = null
   let realtimeRefreshTargetUsername = ''
+  let nativeVoiceRevision = 0
+  const nativeVoiceTranscriptPolls = new Map()
 
   const isAbortError = (error, controller = null) => {
     return !!(
@@ -141,6 +171,75 @@ export const useChatMessages = ({
       return voiceTranscriptionStatus.value
     })()
     return await voiceTranscriptionStatusPromise
+  }
+
+  const nativeVoiceTranscriptionStatus = ref(null)
+  const nativeVoiceTranscriptionStatusLoading = ref(false)
+  let nativeVoiceTranscriptionStatusPromise = null
+  let nativeVoiceTranscriptionStatusSequence = 0
+  let nativeVoiceTranscriptionStatusUpdatedAt = 0
+  const nativeVoiceTranscriptionStatusTtlMs = 5000
+  const nativeVoiceTranscriptionStatusKnown = computed(() => !!nativeVoiceTranscriptionStatus.value)
+  const nativeVoiceTranscriptionAvailable = computed(() => nativeVoiceTranscriptionStatus.value?.available === true)
+  const nativeVoiceTranscriptionUnavailableReason = computed(() => {
+    const reason = String(nativeVoiceTranscriptionStatus.value?.reason || '').trim()
+    return ({
+      runtime_trigger_e2e_not_validated: '当前微信版本的原生转写桥接尚未启用。',
+      unsupported_platform: '微信原生语音转文字目前仅支持 Windows。',
+      unsupported_architecture: '微信原生语音转文字需要 64 位 Windows。',
+      weixin_main_ui_not_found: '请先登录并打开微信。',
+      weixin_main_ui_ambiguous: '检测到多个微信主窗口，无法安全选择账号。',
+      weixin_version_unsupported: '当前微信版本暂不支持微信原生语音转文字。请使用微信 4.1.12.26，并完全退出、重新启动微信后再试。',
+      active_account_mismatch: '当前项目账号与已登录微信账号不一致。',
+      active_account_unverified: '无法确认当前项目账号与已登录微信账号一致。',
+      bridge_manager_unavailable: '微信原生语音转文字服务尚未就绪。',
+      inspection_failed: '无法检查微信原生语音转文字状态。请重启本应用和微信后再试。',
+      bridge_restart_required: '桥接状态已失效。请完全退出微信，重启本应用（开发模式下同时重启后端）后，再重新打开并登录微信。'
+    })[reason] || reason || '微信原生语音转文字当前不可用。'
+  })
+
+  const refreshNativeVoiceTranscriptionStatus = async ({ force = false } = {}) => {
+    const account = String(selectedAccount.value || '').trim()
+    if (!account) {
+      nativeVoiceTranscriptionStatus.value = null
+      return null
+    }
+    if (
+      !force
+      && nativeVoiceTranscriptionStatus.value
+      && (Date.now() - nativeVoiceTranscriptionStatusUpdatedAt) < nativeVoiceTranscriptionStatusTtlMs
+    ) return nativeVoiceTranscriptionStatus.value
+    if (nativeVoiceTranscriptionStatusPromise?.account === account) {
+      return await nativeVoiceTranscriptionStatusPromise.promise
+    }
+    const sequence = ++nativeVoiceTranscriptionStatusSequence
+    nativeVoiceTranscriptionStatusLoading.value = true
+    const promise = (async () => {
+      let result
+      try {
+        result = await api.getNativeVoiceTranscriptionStatus({ account })
+      } catch (error) {
+        result = {
+          available: false,
+          reason: String(error?.message || '无法读取微信原生语音转文字状态').trim()
+        }
+      } finally {
+        if (sequence === nativeVoiceTranscriptionStatusSequence) {
+          nativeVoiceTranscriptionStatusLoading.value = false
+          nativeVoiceTranscriptionStatusPromise = null
+        }
+      }
+      if (
+        sequence === nativeVoiceTranscriptionStatusSequence
+        && String(selectedAccount.value || '').trim() === account
+      ) {
+        nativeVoiceTranscriptionStatus.value = result
+        nativeVoiceTranscriptionStatusUpdatedAt = Date.now()
+      }
+      return result
+    })()
+    nativeVoiceTranscriptionStatusPromise = { account, promise }
+    return await promise
   }
 
   const highlightServerIdStr = ref('')
@@ -1120,12 +1219,144 @@ export const useChatMessages = ({
     await playVoiceById(message?.id)
   }
 
+  const stopNativeVoiceTranscriptPolling = () => {
+    nativeVoiceRevision += 1
+    for (const entry of nativeVoiceTranscriptPolls.values()) {
+      try { entry.controller?.abort?.() } catch {}
+    }
+    nativeVoiceTranscriptPolls.clear()
+    for (const list of Object.values(allMessages.value || {})) {
+      if (!Array.isArray(list)) continue
+      for (const message of list) {
+        if (
+          String(message?.voiceTranscriptStatus || '').trim().toLowerCase() === 'loading'
+          && (
+            String(message?.voiceTranscriptNativeRequestId || '').trim()
+            || message?.[NATIVE_VOICE_DISPATCH_TOKEN]
+          )
+        ) {
+          message.voiceTranscriptStatus = 'idle'
+          message.voiceTranscriptError = ''
+          delete message[NATIVE_VOICE_DISPATCH_TOKEN]
+        }
+      }
+    }
+  }
+
+  const waitForNativeVoiceTranscriptPoll = (delayMs, signal) => new Promise((resolve) => {
+    if (signal?.aborted || delayMs <= 0) {
+      resolve()
+      return
+    }
+    const finish = () => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }
+    const timer = setTimeout(finish, delayMs)
+    const onAbort = () => {
+      clearTimeout(timer)
+      finish()
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+
+  // 按 requestId + 精确消息 identity 读取 bridge 回调缓存；packed_info_data 仅作为后端兼容回退。
+  const pollNativeVoiceTranscript = async (
+    message,
+    { requestId = '', maxAttempts = 85, intervalMs = 1200 } = {}
+  ) => {
+    const accountAtStart = String(selectedAccount.value || '').trim()
+    const usernameAtStart = String(selectedContact.value?.username || '').trim()
+    const serverId = String(message?.serverIdStr || message?.serverId || '').trim()
+    const localId = String(message?.localIdStr || message?.localId || '').trim()
+    const nativeRequestId = String(requestId || '').trim()
+    const messageId = String(message?.id || '').trim()
+    if (
+      !accountAtStart
+      || !usernameAtStart
+      || !serverId
+      || serverId === '0'
+      || typeof api?.getNativeVoiceTranscript !== 'function'
+    ) return { status: 'pending', serverId, text: '', language: '', model: '' }
+
+    const pollKey = `${accountAtStart}:${usernameAtStart}:${serverId}:${localId}:${nativeRequestId}`
+    const active = nativeVoiceTranscriptPolls.get(pollKey)
+    if (active?.promise) return await active.promise
+
+    const attempts = Math.max(1, Math.min(120, Math.trunc(Number(maxAttempts) || 1)))
+    const delayMs = Math.max(0, Math.min(10000, Math.trunc(Number(intervalMs) || 0)))
+    const controller = typeof AbortController === 'function' ? new AbortController() : null
+    const entry = { controller, promise: null }
+    entry.promise = (async () => {
+      let result = { status: 'pending', serverId, text: '', language: '', model: '' }
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (
+          controller?.signal?.aborted
+          || String(selectedAccount.value || '').trim() !== accountAtStart
+          || String(selectedContact.value?.username || '').trim() !== usernameAtStart
+        ) return { ...result, status: 'cancelled' }
+
+        try {
+          result = await api.getNativeVoiceTranscript({
+            account: accountAtStart,
+            server_id: serverId,
+            username: usernameAtStart,
+            ...(localId && localId !== '0' ? { local_id: localId } : {}),
+            ...(nativeRequestId ? { request_id: nativeRequestId } : {}),
+            ...(controller ? { signal: controller.signal } : {})
+          })
+        } catch (error) {
+          if (isAbortError(error, controller)) return { ...result, status: 'cancelled' }
+          throw error
+        }
+
+        const list = allMessages.value[usernameAtStart]
+        const index = Array.isArray(list)
+          ? list.findIndex((item) => (
+              (messageId && String(item?.id || '') === messageId)
+              || String(item?.serverIdStr || item?.serverId || '').trim() === serverId
+            ))
+          : -1
+        if (index < 0) return { ...result, status: 'stale' }
+
+        const resultStatus = String(result?.status || '').trim().toLowerCase()
+        if (['error', 'expired', 'released'].includes(resultStatus)) {
+          const resultError = new Error(String(
+            result?.message || result?.error?.message || '微信原生语音转文字未能返回结果。'
+          ).trim())
+          resultError.code = String(result?.code || result?.error?.code || `native_transcript_${resultStatus}`).trim()
+          throw resultError
+        }
+
+        const updated = mergeWechatNativeVoiceTranscript(list[index], result)
+        if (updated !== list[index]) {
+          const next = list.slice()
+          next[index] = updated
+          allMessages.value = { ...allMessages.value, [usernameAtStart]: next }
+          return { ...result, status: 'success', model: 'wechat-native' }
+        }
+        if (resultStatus === 'success') return result
+        if (attempt + 1 < attempts) {
+          await waitForNativeVoiceTranscriptPoll(delayMs, controller?.signal)
+        }
+      }
+      return result
+    })().finally(() => {
+      if (nativeVoiceTranscriptPolls.get(pollKey) === entry) nativeVoiceTranscriptPolls.delete(pollKey)
+    })
+    nativeVoiceTranscriptPolls.set(pollKey, entry)
+    return await entry.promise
+  }
+
   // 批量读取当前会话语音消息的转写缓存并合并进消息列表（仅恢复展示，不触发识别）。
   // serverIdStr 为精确字符串，禁止转 Number（19 位 svr_id 超出 JS Number 安全范围）。
   const restoreVoiceTranscripts = async (username) => {
+    const transcriptRevision = nativeVoiceRevision
+    const accountAtStart = String(selectedAccount.value || '').trim()
     const key = String(username || '').trim()
     if (!key || privacyMode?.value) return
     void refreshVoiceTranscriptionStatus()
+    void refreshNativeVoiceTranscriptionStatus()
     const list = allMessages.value[key]
     if (!Array.isArray(list) || !list.length) return
 
@@ -1136,13 +1367,134 @@ export const useChatMessages = ({
       return !status || status === 'idle'
     })
     if (!pending.length) return
+
+    if (typeof api?.lookupNativeVoiceTranscriptionCache === 'function') {
+      try {
+        const nativeResponse = await api.lookupNativeVoiceTranscriptionCache({
+          account: accountAtStart,
+          username: key,
+          items: pending.map((message) => ({
+            server_id: String(message?.serverIdStr || message?.serverId || '').trim(),
+            local_id: String(message?.localIdStr || message?.localId || '').trim()
+          })).filter((item) => item.server_id && item.local_id && item.local_id !== '0')
+        })
+        if (
+          transcriptRevision !== nativeVoiceRevision
+          || String(selectedAccount.value || '').trim() !== accountAtStart
+        ) return
+        const nativeItems = Array.isArray(nativeResponse?.items) ? nativeResponse.items : []
+        if (nativeItems.length) {
+          const hits = new Map(nativeItems.map((item) => [
+            `${String(item?.serverId || '').trim()}:${String(item?.localId || '').trim()}`,
+            item
+          ]))
+          const current = allMessages.value[key]
+          if (!Array.isArray(current) || !current.length) return
+          let changed = false
+          const resumedPolls = []
+          const next = current.map((message) => {
+            const identity = `${String(message?.serverIdStr || message?.serverId || '').trim()}:${String(message?.localIdStr || message?.localId || '').trim()}`
+            const hit = hits.get(identity)
+            const hitStatus = String(hit?.status || '').trim().toLowerCase()
+            let updated = mergeWechatNativeVoiceTranscript(message, hit)
+            if (updated === message && hitStatus === 'pending') {
+              const requestId = String(hit?.requestId || '').trim()
+              if (requestId) {
+                updated = {
+                  ...message,
+                  voiceTranscriptStatus: 'loading',
+                  voiceTranscriptError: '',
+                  voiceTranscriptNativeRequestId: requestId
+                }
+                resumedPolls.push({
+                  message: updated,
+                  requestId,
+                  intervalMs: Math.max(1200, Number(hit?.pollAfterMs) || 0)
+                })
+              }
+            } else if (updated === message && hitStatus === 'error') {
+              updated = {
+                ...message,
+                voiceTranscriptStatus: 'error',
+                voiceTranscriptError: String(hit?.message || '微信原生语音转文字未能返回结果。').trim(),
+                voiceTranscriptNativeRequestId: String(hit?.requestId || '').trim()
+              }
+            }
+            if (updated !== message) changed = true
+            return updated
+          })
+          if (changed) allMessages.value = { ...allMessages.value, [key]: next }
+          for (const resumed of resumedPolls) {
+            void pollNativeVoiceTranscript(resumed.message, {
+              requestId: resumed.requestId,
+              intervalMs: resumed.intervalMs
+            }).then(async (result) => {
+              const status = String(result?.status || '').trim().toLowerCase()
+              if (['success', 'cancelled', 'stale'].includes(status)) return
+              const pendingError = new Error('微信原生语音转文字尚未返回结果，请稍后重试。')
+              pendingError.code = 'native_transcript_pending'
+              throw pendingError
+            }).catch(async (error) => {
+              if (
+                transcriptRevision !== nativeVoiceRevision
+                || String(selectedAccount.value || '').trim() !== accountAtStart
+                || String(selectedContact.value?.username || '').trim() !== key
+              ) return
+              await refreshNativeVoiceTranscriptionStatus({ force: true })
+              if (
+                transcriptRevision !== nativeVoiceRevision
+                || String(selectedAccount.value || '').trim() !== accountAtStart
+                || String(selectedContact.value?.username || '').trim() !== key
+              ) return
+              const messages = allMessages.value[key]
+              const index = Array.isArray(messages)
+                ? messages.findIndex((message) => (
+                    String(message?.id || '') === String(resumed.message?.id || '')
+                    || String(message?.serverIdStr || message?.serverId || '').trim()
+                      === String(resumed.message?.serverIdStr || resumed.message?.serverId || '').trim()
+                  ))
+                : -1
+              if (index < 0) return
+              if (
+                String(messages[index]?.voiceTranscriptNativeRequestId || '').trim()
+                !== resumed.requestId
+              ) return
+              const detail = nativeVoiceErrorDetail(error)
+              const updated = {
+                ...messages[index],
+                voiceTranscriptStatus: 'error',
+                voiceTranscriptError: String(
+                  detail?.message || error?.message || '微信原生语音转文字未能返回结果。'
+                ).trim(),
+                voiceTranscriptNativeRequestId: ''
+              }
+              const replacement = messages.slice()
+              replacement[index] = updated
+              allMessages.value = { ...allMessages.value, [key]: replacement }
+            })
+          }
+        }
+      } catch {}
+    }
+
     if (typeof api?.lookupChatVoiceTranscriptionCache !== 'function') return
+    const projectPending = (allMessages.value[key] || []).filter((message) => {
+      if (String(message?.renderType || '') !== 'voice') return false
+      if (!String(message?.serverIdStr || '').trim()) return false
+      const status = String(message?.voiceTranscriptStatus || 'idle')
+      return !status || status === 'idle'
+    })
+    if (!projectPending.length) return
 
     try {
       const resp = await api.lookupChatVoiceTranscriptionCache({
-        account: selectedAccount.value,
-        server_ids: pending.map((m) => String(m.serverIdStr).trim())
+        account: accountAtStart,
+        server_ids: projectPending.map((m) => String(m.serverIdStr).trim())
       })
+      if (
+        transcriptRevision !== nativeVoiceRevision
+        || String(selectedAccount.value || '').trim() !== accountAtStart
+      ) return
       const items = resp?.items
       if (!items || typeof items !== 'object') return
 
@@ -1163,38 +1515,148 @@ export const useChatMessages = ({
     } catch {}
   }
 
-  const transcribeVoice = async (message, { force = false } = {}) => {
+  const transcribeVoice = async (message) => {
+    const transcriptRevision = nativeVoiceRevision
+    const accountAtStart = String(selectedAccount.value || '').trim()
+    const usernameAtStart = String(selectedContact.value?.username || '').trim()
     // 语音消息的 svr_id 是 19 位大整数，超出 JS Number 安全范围（2^53），
     // 必须使用精确字符串 serverIdStr，否则后端会查不到语音数据。
-    const serverId = String(message?.serverIdStr || message?.serverId || '').trim()
-    if (!message || !serverId || serverId === '0' || message.voiceTranscriptStatus === 'loading') return
+    const serverIdStr = String(message?.serverIdStr ?? '').trim()
+    const serverId = serverIdStr || String(message?.serverId ?? '').trim()
+    const localIdStr = String(message?.localIdStr ?? '').trim()
+    const localId = localIdStr || String(message?.localId ?? '').trim()
+    const usableServerId = serverId && serverId !== '0' ? serverId : ''
+    const usableLocalId = localId && localId !== '0' ? localId : ''
+    if (
+      !message
+      || !accountAtStart
+      || !usernameAtStart
+      || (!usableServerId && !usableLocalId)
+      || message.voiceTranscriptStatus === 'loading'
+    ) return
 
     // 模板渲染的是 renderMessages 的浅拷贝（非响应式），直接改拷贝不会驱动 UI 更新，
     // 且 computed 重算时拷贝会被替换导致状态丢失。必须修改 allMessages 中的原对象。
-    const key = String(selectedContact.value?.username || '').trim()
+    const key = usernameAtStart
     const list = key ? allMessages.value[key] : null
     const target =
       (Array.isArray(list) ? list.find((item) => item?.id === message.id) : null) || message
 
-    const capability = await refreshVoiceTranscriptionStatus({ force: true })
-    if (!capability?.available) return
-
+    const nativeDispatchToken = Symbol('nativeVoiceDispatch')
+    Object.defineProperty(target, NATIVE_VOICE_DISPATCH_TOKEN, {
+      configurable: true,
+      enumerable: false,
+      value: nativeDispatchToken,
+      writable: true
+    })
     target.voiceTranscriptStatus = 'loading'
     target.voiceTranscriptError = ''
-    try {
-      const result = await api.transcribeChatVoice({
-        account: selectedAccount.value,
-        server_id: serverId,
-        force
-      })
-      target.voiceTranscript = String(result?.text || '').trim()
-      target.voiceTranscriptLanguage = String(result?.language || '').trim()
-      target.voiceTranscriptModel = String(result?.model || '').trim()
-      target.voiceTranscriptStatus = 'success'
-    } catch (error) {
-      const detail = error?.data?.detail || error?.detail
-      target.voiceTranscriptError = String(detail?.message || error?.message || '语音识别失败').trim()
+    target.voiceTranscriptNativeRequestId = ''
+
+    const requestIsCurrent = () => !(
+      target[NATIVE_VOICE_DISPATCH_TOKEN] !== nativeDispatchToken
+      || transcriptRevision !== nativeVoiceRevision
+      || String(selectedAccount.value || '').trim() !== accountAtStart
+      || String(selectedContact.value?.username || '').trim() !== usernameAtStart
+    )
+
+    const setVoiceError = (error, fallback = '语音识别失败') => {
+      if (!requestIsCurrent()) return
+      const detail = nativeVoiceErrorDetail(error)
+      target.voiceTranscriptError = String(detail?.message || error?.message || fallback).trim()
       target.voiceTranscriptStatus = 'error'
+      target.voiceTranscriptNativeRequestId = ''
+    }
+
+    if (typeof api?.triggerNativeVoiceTranscription !== 'function') {
+      setVoiceError(null, '当前版本未提供微信原生语音转文字接口。')
+      delete target[NATIVE_VOICE_DISPATCH_TOKEN]
+      return
+    }
+
+    try {
+      const nativeResult = await api.triggerNativeVoiceTranscription({
+        account: accountAtStart,
+        username: usernameAtStart,
+        ...(usableServerId ? { server_id: usableServerId } : {}),
+        ...(usableLocalId ? { local_id: usableLocalId } : {})
+      })
+      if (!requestIsCurrent()) return
+
+      const resolvedServerId = String(nativeResult?.serverId ?? '').trim()
+      const resolvedLocalId = String(nativeResult?.localId ?? '').trim()
+      if (resolvedServerId && resolvedServerId !== '0') target.serverIdStr = resolvedServerId
+      if (resolvedLocalId && resolvedLocalId !== '0') target.localIdStr = resolvedLocalId
+
+      const nativeStatus = String(nativeResult?.status || '').trim().toLowerCase()
+      if (nativeStatus === 'success') {
+        const updated = mergeWechatNativeVoiceTranscript(target, {
+          ...nativeResult,
+          model: 'wechat-native'
+        })
+        if (updated === target) {
+          const invalidResponse = new Error('微信原生语音转写返回了无效结果。')
+          invalidResponse.code = 'native_transport_invalid_response'
+          throw invalidResponse
+        }
+        Object.assign(target, updated)
+        target.voiceTranscriptNativeRequestId = ''
+        return
+      }
+
+      if (nativeStatus === 'accepted' || nativeStatus === 'pending') {
+        const nativeRequestId = String(nativeResult?.requestId || '').trim()
+        if (!nativeRequestId) {
+          const invalidResponse = new Error('微信原生语音转写未返回可轮询的 requestId。')
+          invalidResponse.code = 'native_transport_invalid_response'
+          throw invalidResponse
+        }
+        target.voiceTranscriptNativeRequestId = nativeRequestId
+        const pollResult = await pollNativeVoiceTranscript(target, {
+          requestId: nativeRequestId,
+          intervalMs: Math.max(1200, Number(nativeResult?.pollAfterMs) || 0)
+        })
+        if (!requestIsCurrent()) return
+        if (String(pollResult?.status || '').trim().toLowerCase() === 'success') {
+          const updated = mergeWechatNativeVoiceTranscript(target, {
+            ...pollResult,
+            model: 'wechat-native'
+          })
+          if (updated === target) {
+            const invalidResponse = new Error('微信原生语音转写轮询返回了无效结果。')
+            invalidResponse.code = 'native_transport_invalid_response'
+            setVoiceError(invalidResponse)
+            return
+          }
+          Object.assign(target, updated)
+          target.voiceTranscriptNativeRequestId = ''
+          return
+        }
+        if (['cancelled', 'stale'].includes(String(pollResult?.status || '').trim().toLowerCase())) return
+        const pendingError = new Error('微信原生语音转写尚未返回结果，请稍后重试。')
+        pendingError.code = 'native_transcript_pending'
+        await refreshNativeVoiceTranscriptionStatus({ force: true })
+        if (!requestIsCurrent()) return
+        setVoiceError(pendingError)
+        return
+      }
+
+      const invalidResponse = new Error('微信原生语音转写返回了未知状态。')
+      invalidResponse.code = 'native_transport_invalid_response'
+      throw invalidResponse
+    } catch (error) {
+      if (!requestIsCurrent()) return
+      await refreshNativeVoiceTranscriptionStatus({ force: true })
+      if (!requestIsCurrent()) return
+      setVoiceError(error, '微信原生语音转写触发失败')
+    } finally {
+      if (target[NATIVE_VOICE_DISPATCH_TOKEN] === nativeDispatchToken) {
+        delete target[NATIVE_VOICE_DISPATCH_TOKEN]
+        if (String(target.voiceTranscriptStatus || '').trim().toLowerCase() === 'loading') {
+          target.voiceTranscriptStatus = 'idle'
+          target.voiceTranscriptError = ''
+        }
+      }
     }
   }
 
@@ -1810,17 +2272,47 @@ export const useChatMessages = ({
       loadLargeImagePreferences()
       const latest = hydrateQuoteImageUrls(dedupeMessagesById(rawMessages.map(normalizeMessage)), existing)
 
-      const seenIds = new Set(existing.map((message) => String(message?.id || '')))
+      const latestById = new Map(
+        latest
+          .map((message) => [String(message?.id || ''), message])
+          .filter(([id]) => !!id)
+      )
+      const latestByServerId = new Map(
+        latest
+          .map((message) => [String(message?.serverIdStr || message?.serverId || '').trim(), message])
+          .filter(([serverId]) => !!serverId && serverId !== '0')
+      )
+      let existingChanged = false
+      const updatedExisting = existing.map((message) => {
+        const incoming = latestById.get(String(message?.id || ''))
+          || latestByServerId.get(String(message?.serverIdStr || message?.serverId || '').trim())
+        if (!incoming) return message
+        const updated = mergeWechatNativeVoiceTranscript(message, incoming)
+        if (updated !== message) existingChanged = true
+        return updated
+      })
+
+      const seenIds = new Set(updatedExisting.map((message) => String(message?.id || '')))
+      const seenServerIds = new Set(
+        updatedExisting
+          .map((message) => String(message?.serverIdStr || message?.serverId || '').trim())
+          .filter((serverId) => !!serverId && serverId !== '0')
+      )
       const newOnes = []
       for (const message of latest) {
         const id = String(message?.id || '')
-        if (!id || seenIds.has(id)) continue
+        const serverId = String(message?.serverIdStr || message?.serverId || '').trim()
+        if (!id || seenIds.has(id) || (serverId && serverId !== '0' && seenServerIds.has(serverId))) continue
         seenIds.add(id)
+        if (serverId && serverId !== '0') seenServerIds.add(serverId)
         newOnes.push(message)
       }
-      if (!newOnes.length) return
+      if (!newOnes.length && !existingChanged) return
 
-      allMessages.value = { ...allMessages.value, [username]: hydrateQuoteImageUrls([...existing, ...newOnes]) }
+      allMessages.value = {
+        ...allMessages.value,
+        [username]: hydrateQuoteImageUrls([...updatedExisting, ...newOnes])
+      }
 
       await nextTick()
       const nextContainer = messageContainerRef.value
@@ -1874,6 +2366,7 @@ export const useChatMessages = ({
   const resetMessageState = () => {
     abortMessageLoad()
     abortRealtimeRefresh()
+    stopNativeVoiceTranscriptPolling()
     clearVoicePlaybackState()
     allMessages.value = {}
     messagesMeta.value = {}
@@ -2479,9 +2972,18 @@ export const useChatMessages = ({
     clearContactProfileHoverHideTimer()
   }
 
+  const onNativeVoiceWindowFocus = () => {
+    void refreshNativeVoiceTranscriptionStatus({ force: true })
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('focus', onNativeVoiceWindowFocus)
+  }
+
   watch(
     () => selectedContact.value?.username,
     (username) => {
+      stopNativeVoiceTranscriptPolling()
       const nextUsername = String(username || '').trim()
       if (messageLoadTargetUsername && messageLoadTargetUsername !== nextUsername) {
         abortMessageLoad()
@@ -2505,6 +3007,13 @@ export const useChatMessages = ({
   watch(
     () => selectedAccount.value,
     () => {
+      stopNativeVoiceTranscriptPolling()
+      nativeVoiceTranscriptionStatusSequence += 1
+      nativeVoiceTranscriptionStatusPromise = null
+      nativeVoiceTranscriptionStatusLoading.value = false
+      nativeVoiceTranscriptionStatus.value = null
+      nativeVoiceTranscriptionStatusUpdatedAt = 0
+      void refreshNativeVoiceTranscriptionStatus()
       clearExpandedImageGroups()
       loadLargeImagePreferences()
       clearContactProfileHoverHideTimer()
@@ -2516,8 +3025,12 @@ export const useChatMessages = ({
   )
 
   onUnmounted(() => {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('focus', onNativeVoiceWindowFocus)
+    }
     abortMessageLoad()
     abortRealtimeRefresh()
+    stopNativeVoiceTranscriptPolling()
     if (highlightTimer) clearTimeout(highlightTimer)
     highlightTimer = null
     cancelImageGroupTransition()
@@ -2569,6 +3082,12 @@ export const useChatMessages = ({
     voiceTranscriptionAvailable,
     voiceTranscriptionUnavailableReason,
     refreshVoiceTranscriptionStatus,
+    nativeVoiceTranscriptionStatus,
+    nativeVoiceTranscriptionStatusLoading,
+    nativeVoiceTranscriptionStatusKnown,
+    nativeVoiceTranscriptionAvailable,
+    nativeVoiceTranscriptionUnavailableReason,
+    refreshNativeVoiceTranscriptionStatus,
     highlightServerIdStr,
     highlightMessageId,
     expandedImageGroupKeys,
@@ -2629,6 +3148,9 @@ export const useChatMessages = ({
     setVoiceRef,
     playVoice,
     transcribeVoice,
+    pollNativeVoiceTranscript,
+    restoreVoiceTranscripts,
+    stopNativeVoiceTranscriptPolling,
     playQuoteVoice,
     getQuoteVoiceId,
     getVoiceDurationInSeconds,

--- a/frontend/composables/useApi.js
+++ b/frontend/composables/useApi.js
@@ -25,6 +25,19 @@ export const useApi = () => {
     }
     return fallback
   }
+
+  const responseError = (response, message) => {
+    const error = new Error(message)
+    const detail = response?._data?.detail
+    error.status = Number(response?.status || 0)
+    error.statusCode = error.status
+    error.data = response?._data
+    error.detail = detail
+    if (detail && typeof detail === 'object' && detail.code) {
+      error.code = String(detail.code).trim()
+    }
+    return error
+  }
   
   // 基础请求函数
   const request = async (url, options = {}) => {
@@ -37,7 +50,7 @@ export const useApi = () => {
             const fallback = response.status === 400
               ? '请求参数错误'
               : `请求失败 (${response.status})`
-            throw new Error(responseDetailMessage(response, fallback))
+            throw responseError(response, responseDetailMessage(response, fallback))
           } else if (response.status >= 500) {
             const backendDetail = responseDetailMessage(response)
             const message = backendDetail || '服务器错误，请稍后重试'
@@ -50,7 +63,7 @@ export const useApi = () => {
               source: 'useApi',
               apiBase: baseURL,
             })
-            throw new Error(message)
+            throw responseError(response, message)
           }
         }
       })
@@ -420,6 +433,61 @@ export const useApi = () => {
         // 避免精度丢失导致后端查不到语音数据（后端 pydantic 会将精确字符串解析为 int）。
         server_id: String(data.server_id ?? '').trim(),
         force: !!data.force
+      }
+    })
+  }
+
+  const getNativeVoiceTranscript = async (data = {}) => {
+    const query = new URLSearchParams()
+    if (data.account) query.set('account', String(data.account).trim())
+    query.set('server_id', String(data.server_id ?? '').trim())
+    if (data.username) query.set('username', String(data.username).trim())
+    const localId = String(data.local_id ?? '').trim()
+    const requestId = String(data.request_id ?? '').trim()
+    if (localId && localId !== '0') query.set('local_id', localId)
+    if (requestId) query.set('request_id', requestId)
+    return await request(
+      `/chat/media/voice/transcription/native?${query.toString()}`,
+      data.signal ? { signal: data.signal } : {}
+    )
+  }
+
+  const triggerNativeVoiceTranscription = async (data = {}) => {
+    const body = {
+      account: String(data.account ?? '').trim(),
+      username: String(data.username ?? '').trim()
+    }
+    const serverId = String(data.server_id ?? '').trim()
+    const localId = String(data.local_id ?? '').trim()
+    if (serverId && serverId !== '0') body.server_id = serverId
+    if (localId && localId !== '0') body.local_id = localId
+    return await request('/chat/media/voice/transcription/native/trigger', {
+      method: 'POST',
+      body
+    })
+  }
+
+  const getNativeVoiceTranscriptionStatus = async (data = {}) => {
+    const query = new URLSearchParams()
+    if (data.account) query.set('account', String(data.account).trim())
+    return await request(
+      `/chat/media/voice/transcription/native/status${query.toString() ? `?${query.toString()}` : ''}`
+    )
+  }
+
+  const lookupNativeVoiceTranscriptionCache = async (data = {}) => {
+    const items = Array.isArray(data.items)
+      ? data.items.map((item) => ({
+          server_id: String(item?.server_id ?? '').trim(),
+          local_id: String(item?.local_id ?? '').trim()
+        })).filter((item) => item.server_id && item.local_id)
+      : []
+    return await request('/chat/media/voice/transcription/native/cache_lookup', {
+      method: 'POST',
+      body: {
+        account: String(data.account ?? '').trim(),
+        username: String(data.username ?? '').trim(),
+        items
       }
     })
   }
@@ -865,6 +933,10 @@ export const useApi = () => {
     getVoiceTranscriptionStatus,
     setVoiceTranscriptionDevice,
     transcribeChatVoice,
+    getNativeVoiceTranscript,
+    triggerNativeVoiceTranscription,
+    getNativeVoiceTranscriptionStatus,
+    lookupNativeVoiceTranscriptionCache,
     lookupChatVoiceTranscriptionCache,
     createChatExport,
     getChatExport,

--- a/frontend/tests/native-voice-transcript-polling.test.js
+++ b/frontend/tests/native-voice-transcript-polling.test.js
@@ -1,0 +1,762 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  mergeWechatNativeVoiceTranscript,
+  useChatMessages
+} from '~/composables/chat/useChatMessages'
+import { useApi } from '~/composables/useApi'
+
+vi.mock('~/lib/server-error-logging', () => ({ reportServerError: vi.fn() }))
+vi.mock('~/stores/chatAccounts', () => ({
+  useChatAccountsStore: () => ({ applySourceResponse: vi.fn() })
+}))
+
+
+const mountChatMessagesState = (api, { realtime = false } = {}) => {
+  const selectedAccount = ref('account-a')
+  const selectedContact = ref({ username: 'wxid_friend' })
+  let state
+  const wrapper = mount(defineComponent({
+    setup() {
+      state = useChatMessages({
+        api,
+        apiBase: 'http://127.0.0.1:10392/api',
+        selectedAccount,
+        selectedContact,
+        realtimeEnabled: ref(realtime),
+        privacyMode: ref(false),
+        searchContext: ref({ active: false })
+      })
+      return () => h('div')
+    }
+  }))
+  return { state, wrapper, selectedAccount, selectedContact }
+}
+
+const existingVoice = () => ({
+  id: 'voice-1',
+  serverIdStr: '9007199254740993',
+  localIdStr: '4294967295',
+  renderType: 'voice',
+  voiceTranscript: '',
+  voiceTranscriptStatus: 'idle',
+  voiceTranscriptError: '',
+  voiceTranscriptLanguage: '',
+  voiceTranscriptModel: ''
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+const nativeError = (code, message = code) => Object.assign(new Error(message), {
+  code,
+  data: { detail: { code, message } }
+})
+
+const deferred = () => {
+  let resolve
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('微信原生转写定向轮询', () => {
+  it('pending 后命中时更新 allMessages 中已有语音对象', async () => {
+    const api = {
+      getNativeVoiceTranscript: vi.fn()
+        .mockResolvedValueOnce({
+          status: 'pending',
+          serverId: '9007199254740993',
+          text: '',
+          language: '',
+          model: ''
+        })
+        .mockResolvedValueOnce({
+          status: 'success',
+          serverId: '9007199254740993',
+          text: '微信刚生成的文字',
+          language: '',
+          model: 'wechat-native'
+        })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    const result = await state.pollNativeVoiceTranscript(message, {
+      requestId: 'request-1',
+      maxAttempts: 2,
+      intervalMs: 0
+    })
+
+    expect(result).toMatchObject({ status: 'success', model: 'wechat-native' })
+    expect(api.getNativeVoiceTranscript).toHaveBeenCalledTimes(2)
+    expect(api.getNativeVoiceTranscript.mock.calls[0][0]).toMatchObject({
+      account: 'account-a',
+      server_id: '9007199254740993',
+      username: 'wxid_friend',
+      local_id: '4294967295',
+      request_id: 'request-1'
+    })
+    expect(state.allMessages.value.wxid_friend).toHaveLength(1)
+    expect(state.allMessages.value.wxid_friend[0]).toMatchObject({
+      id: 'voice-1',
+      voiceTranscript: '微信刚生成的文字',
+      voiceTranscriptStatus: 'success',
+      voiceTranscriptError: '',
+      voiceTranscriptModel: 'wechat-native'
+    })
+    wrapper.unmount()
+  })
+
+  it('轮询预算允许微信回调在第 32 次查询才完成', async () => {
+    const pending = {
+      status: 'pending',
+      serverId: '9007199254740993',
+      localId: '4294967295',
+      requestId: 'request-slow',
+      text: '',
+      language: '',
+      model: ''
+    }
+    const getNativeVoiceTranscript = vi.fn()
+    for (let index = 0; index < 31; index += 1) {
+      getNativeVoiceTranscript.mockResolvedValueOnce(pending)
+    }
+    getNativeVoiceTranscript.mockResolvedValueOnce({
+      status: 'success',
+      serverId: '9007199254740993',
+      localId: '4294967295',
+      requestId: 'request-slow',
+      text: '较晚返回的微信文字',
+      language: '',
+      model: 'wechat-native'
+    })
+    const api = { getNativeVoiceTranscript }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    const result = await state.pollNativeVoiceTranscript(message, {
+      requestId: 'request-slow',
+      maxAttempts: 32,
+      intervalMs: 0
+    })
+
+    expect(api.getNativeVoiceTranscript).toHaveBeenCalledTimes(32)
+    expect(result).toMatchObject({ status: 'success', text: '较晚返回的微信文字' })
+    wrapper.unmount()
+  })
+
+  it('realtime 刷新按同一 server_id 更新已有语音而不是只追加新 ID', async () => {
+    const api = {
+      listChatMessages: vi.fn().mockResolvedValue({
+        messages: [{
+          id: 'voice-from-realtime-source',
+          serverId: '9007199254740993',
+          serverIdStr: '9007199254740993',
+          renderType: 'voice',
+          voiceTranscript: 'realtime 更新的原生文字',
+          voiceTranscriptStatus: 'success',
+          voiceTranscriptError: '',
+          voiceTranscriptLanguage: '',
+          voiceTranscriptModel: 'wechat-native'
+        }]
+      })
+    }
+    const { state, wrapper } = mountChatMessagesState(api, { realtime: true })
+    state.allMessages.value = { wxid_friend: [existingVoice()] }
+
+    await state.refreshRealtimeIncremental()
+
+    expect(state.allMessages.value.wxid_friend).toHaveLength(1)
+    expect(state.allMessages.value.wxid_friend[0]).toMatchObject({
+      id: 'voice-1',
+      voiceTranscript: 'realtime 更新的原生文字',
+      voiceTranscriptStatus: 'success',
+      voiceTranscriptModel: 'wechat-native'
+    })
+    wrapper.unmount()
+  })
+
+  it('页面重载后从项目 native cache 恢复 callback-only 结果', async () => {
+    const api = {
+      lookupNativeVoiceTranscriptionCache: vi.fn().mockResolvedValue({
+        status: 'success',
+        items: [{
+          serverId: '9007199254740993',
+          localId: '4294967295',
+          text: '刷新后恢复的微信回调文字',
+          language: '',
+          model: 'wechat-native'
+        }]
+      }),
+      lookupChatVoiceTranscriptionCache: vi.fn().mockResolvedValue({ status: 'success', items: {} }),
+      getVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: false }),
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: true })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    state.allMessages.value = { wxid_friend: [existingVoice()] }
+
+    await state.restoreVoiceTranscripts('wxid_friend')
+
+    expect(api.lookupNativeVoiceTranscriptionCache).toHaveBeenCalledWith({
+      account: 'account-a',
+      username: 'wxid_friend',
+      items: [{
+        server_id: '9007199254740993',
+        local_id: '4294967295'
+      }]
+    })
+    expect(api.lookupChatVoiceTranscriptionCache).not.toHaveBeenCalled()
+    expect(state.allMessages.value.wxid_friend[0]).toMatchObject({
+      voiceTranscript: '刷新后恢复的微信回调文字',
+      voiceTranscriptStatus: 'success',
+      voiceTranscriptModel: 'wechat-native'
+    })
+    wrapper.unmount()
+  })
+
+  it('切换会话中止轮询后解除 loading，并可在返回时从 native cache 恢复', async () => {
+    const api = {
+      lookupNativeVoiceTranscriptionCache: vi.fn().mockResolvedValue({
+        status: 'success',
+        items: [{
+          serverId: '9007199254740993',
+          localId: '4294967295',
+          text: '离开会话期间完成的微信文字',
+          language: '',
+          model: 'wechat-native'
+        }]
+      }),
+      lookupChatVoiceTranscriptionCache: vi.fn(),
+      getVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: false }),
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: true })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = {
+      ...existingVoice(),
+      voiceTranscriptStatus: 'loading',
+      voiceTranscriptNativeRequestId: 'request-in-flight'
+    }
+    state.allMessages.value = { wxid_friend: [message] }
+
+    state.stopNativeVoiceTranscriptPolling()
+    expect(message.voiceTranscriptStatus).toBe('idle')
+    expect(message.voiceTranscriptNativeRequestId).toBe('request-in-flight')
+
+    await state.restoreVoiceTranscripts('wxid_friend')
+    expect(state.allMessages.value.wxid_friend[0]).toMatchObject({
+      voiceTranscript: '离开会话期间完成的微信文字',
+      voiceTranscriptStatus: 'success',
+      voiceTranscriptModel: 'wechat-native',
+      voiceTranscriptNativeRequestId: ''
+    })
+    expect(api.lookupChatVoiceTranscriptionCache).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('返回会话时恢复 pending requestId 并续轮询到 success，不读取旧 Whisper cache', async () => {
+    const api = {
+      lookupNativeVoiceTranscriptionCache: vi.fn().mockResolvedValue({
+        status: 'success',
+        items: [{
+          serverId: '9007199254740993',
+          localId: '4294967295',
+          status: 'pending',
+          requestId: 'request-resumed',
+          pollAfterMs: 1200
+        }]
+      }),
+      getNativeVoiceTranscript: vi.fn().mockResolvedValue({
+        status: 'success',
+        serverId: '9007199254740993',
+        localId: '4294967295',
+        text: '返回会话后继续收到的微信文字',
+        model: 'wechat-native'
+      }),
+      lookupChatVoiceTranscriptionCache: vi.fn().mockResolvedValue({
+        status: 'success',
+        items: { '9007199254740993': { text: '不应覆盖的旧 Whisper 文字' } }
+      }),
+      getVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: false }),
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: true })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    state.allMessages.value = { wxid_friend: [existingVoice()] }
+
+    await state.restoreVoiceTranscripts('wxid_friend')
+    await vi.waitFor(() => {
+      expect(state.allMessages.value.wxid_friend[0]).toMatchObject({
+        voiceTranscript: '返回会话后继续收到的微信文字',
+        voiceTranscriptStatus: 'success',
+        voiceTranscriptModel: 'wechat-native',
+        voiceTranscriptNativeRequestId: ''
+      })
+    })
+
+    expect(api.getNativeVoiceTranscript).toHaveBeenCalledWith(expect.objectContaining({
+      account: 'account-a',
+      username: 'wxid_friend',
+      server_id: '9007199254740993',
+      local_id: '4294967295',
+      request_id: 'request-resumed'
+    }))
+    expect(api.lookupChatVoiceTranscriptionCache).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('返回会话时恢复 native error，且不会被旧 Whisper cache 覆盖', async () => {
+    const api = {
+      lookupNativeVoiceTranscriptionCache: vi.fn().mockResolvedValue({
+        status: 'success',
+        items: [{
+          serverId: '9007199254740993',
+          localId: '4294967295',
+          status: 'error',
+          requestId: 'request-error',
+          code: 'native_trigger_timeout',
+          message: '微信原生语音转文字等待超时。'
+        }]
+      }),
+      lookupChatVoiceTranscriptionCache: vi.fn().mockResolvedValue({
+        status: 'success',
+        items: { '9007199254740993': { text: '不应覆盖的旧 Whisper 文字' } }
+      }),
+      getVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: false }),
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({ available: true })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    state.allMessages.value = { wxid_friend: [existingVoice()] }
+
+    await state.restoreVoiceTranscripts('wxid_friend')
+
+    expect(state.allMessages.value.wxid_friend[0]).toMatchObject({
+      voiceTranscript: '',
+      voiceTranscriptStatus: 'error',
+      voiceTranscriptError: '微信原生语音转文字等待超时。',
+      voiceTranscriptNativeRequestId: 'request-error'
+    })
+    expect(api.lookupChatVoiceTranscriptionCache).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('pending 或非微信来源不会覆盖已有本项目文字', () => {
+    const project = {
+      voiceTranscript: '本项目文字',
+      voiceTranscriptStatus: 'success',
+      voiceTranscriptModel: 'small'
+    }
+    expect(mergeWechatNativeVoiceTranscript(project, {
+      status: 'pending',
+      text: '',
+      model: ''
+    })).toBe(project)
+    expect(mergeWechatNativeVoiceTranscript(project, {
+      status: 'success',
+      text: '另一个项目结果',
+      model: 'medium'
+    })).toBe(project)
+  })
+})
+
+describe('微信原生转写 native-first 编排', () => {
+  it.each([
+    ['会话', ({ selectedContact }) => { selectedContact.value = { username: 'wxid_other' } }],
+    ['账号', ({ selectedAccount }) => { selectedAccount.value = 'account-b' }]
+  ])('trigger 返回前切换%s会解除 pre-trigger loading', async (_label, switchContext) => {
+    const pendingTrigger = deferred()
+    const api = {
+      triggerNativeVoiceTranscription: vi.fn(() => pendingTrigger.promise),
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({
+        available: false,
+        reason: 'bridge_restart_required'
+      })
+    }
+    const mounted = mountChatMessagesState(api)
+    const { state, wrapper } = mounted
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    const request = state.transcribeVoice(message)
+    expect(message.voiceTranscriptStatus).toBe('loading')
+
+    switchContext(mounted)
+    await nextTick()
+    expect(message.voiceTranscriptStatus).toBe('idle')
+    expect(message.voiceTranscriptError).toBe('')
+
+    pendingTrigger.resolve({
+      status: 'accepted',
+      serverId: '9007199254740993',
+      localId: '4294967295',
+      requestId: 'request-after-navigation'
+    })
+    await request
+
+    expect(message.voiceTranscriptStatus).toBe('idle')
+    expect(message.voiceTranscriptNativeRequestId || '').toBe('')
+    wrapper.unmount()
+  })
+
+  it('useApi 以精确字符串 POST，并以完整 identity 和 requestId 查询原生结果', async () => {
+    const fetch = vi.fn(async (_url, options = {}) => options.body || { available: true })
+    vi.stubGlobal('useApiBase', () => 'http://127.0.0.1:10392/api')
+    vi.stubGlobal('$fetch', fetch)
+    const api = useApi()
+
+    await api.triggerNativeVoiceTranscription({
+      account: 'account-a',
+      username: 'wxid_friend',
+      server_id: '9007199254740993',
+      local_id: '4294967295'
+    })
+    await api.getNativeVoiceTranscript({
+      account: 'account-a',
+      username: 'wxid_friend',
+      server_id: '9007199254740993',
+      local_id: '4294967295',
+      request_id: 'request-1'
+    })
+    await api.lookupNativeVoiceTranscriptionCache({
+      account: 'account-a',
+      username: 'wxid_friend',
+      items: [{
+        server_id: '9007199254740993',
+        local_id: '4294967295'
+      }]
+    })
+    await api.getNativeVoiceTranscriptionStatus({ account: 'account-a' })
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/chat/media/voice/transcription/native/trigger', expect.objectContaining({
+      method: 'POST',
+      body: {
+        account: 'account-a',
+        username: 'wxid_friend',
+        server_id: '9007199254740993',
+        local_id: '4294967295'
+      }
+    }))
+    expect(fetch).toHaveBeenNthCalledWith(
+      4,
+      '/chat/media/voice/transcription/native/status?account=account-a',
+      expect.any(Object)
+    )
+    expect(fetch.mock.calls[1][0]).toContain('account=account-a')
+    expect(fetch.mock.calls[1][0]).toContain('username=wxid_friend')
+    expect(fetch.mock.calls[1][0]).toContain('server_id=9007199254740993')
+    expect(fetch.mock.calls[1][0]).toContain('local_id=4294967295')
+    expect(fetch.mock.calls[1][0]).toContain('request_id=request-1')
+    expect(fetch.mock.calls[2]).toEqual([
+      '/chat/media/voice/transcription/native/cache_lookup',
+      expect.objectContaining({
+        method: 'POST',
+        body: {
+          account: 'account-a',
+          username: 'wxid_friend',
+          items: [{
+            server_id: '9007199254740993',
+            local_id: '4294967295'
+          }]
+        }
+      })
+    ])
+    expect(fetch.mock.calls[0][1].body.server_id).toBe('9007199254740993')
+    expect(typeof fetch.mock.calls[0][1].body.server_id).toBe('string')
+  })
+
+  it('useApi 保留后端原生错误 code 供严格回退判定', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetch = vi.fn(async (_url, options = {}) => {
+      await options.onResponseError({
+        response: {
+          status: 503,
+          _data: {
+            detail: {
+              code: 'native_weixin_not_running',
+              message: 'Weixin 未运行'
+            }
+          }
+        }
+      })
+    })
+    vi.stubGlobal('useApiBase', () => 'http://127.0.0.1:10392/api')
+    vi.stubGlobal('$fetch', fetch)
+    const api = useApi()
+
+    await expect(api.triggerNativeVoiceTranscription({
+      account: 'account-a',
+      username: 'wxid_friend',
+      server_id: '9007199254740993'
+    })).rejects.toMatchObject({
+      code: 'native_weixin_not_running',
+      status: 503,
+      detail: expect.objectContaining({ code: 'native_weixin_not_running' })
+    })
+  })
+
+  it('原生 fast path 成功时立即写入 wechat-native 且不加载 Whisper', async () => {
+    const api = {
+      triggerNativeVoiceTranscription: vi.fn().mockResolvedValue({
+        status: 'success',
+        serverId: '9007199254740993',
+        localId: '4294967295',
+        text: '微信已有文字',
+        language: '',
+        model: 'wechat-native'
+      }),
+      getVoiceTranscriptionStatus: vi.fn(),
+      transcribeChatVoice: vi.fn()
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    await state.transcribeVoice(message)
+
+    expect(api.triggerNativeVoiceTranscription).toHaveBeenCalledWith({
+      account: 'account-a',
+      username: 'wxid_friend',
+      server_id: '9007199254740993',
+      local_id: '4294967295'
+    })
+    expect(api.getVoiceTranscriptionStatus).not.toHaveBeenCalled()
+    expect(api.transcribeChatVoice).not.toHaveBeenCalled()
+    expect(message).toMatchObject({
+      voiceTranscript: '微信已有文字',
+      voiceTranscriptStatus: 'success',
+      voiceTranscriptModel: 'wechat-native'
+    })
+    wrapper.unmount()
+  })
+
+  it('accepted 后使用既有精确 server_id 轮询并合并微信结果', async () => {
+    const api = {
+      triggerNativeVoiceTranscription: vi.fn().mockResolvedValue({
+        status: 'accepted',
+        serverId: '9007199254740993',
+        localId: '4294967295',
+        requestId: 'request-1'
+      }),
+      getNativeVoiceTranscript: vi.fn().mockResolvedValue({
+        status: 'success',
+        serverId: '9007199254740993',
+        text: '微信轮询文字',
+        language: '',
+        model: 'wechat-native'
+      }),
+      getVoiceTranscriptionStatus: vi.fn(),
+      transcribeChatVoice: vi.fn()
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    await state.transcribeVoice(message)
+
+    expect(api.getNativeVoiceTranscript).toHaveBeenCalledTimes(1)
+    expect(api.getNativeVoiceTranscript).toHaveBeenCalledWith(expect.objectContaining({
+      account: 'account-a',
+      server_id: '9007199254740993',
+      username: 'wxid_friend',
+      local_id: '4294967295',
+      request_id: 'request-1'
+    }))
+    expect(api.transcribeChatVoice).not.toHaveBeenCalled()
+    expect(state.allMessages.value.wxid_friend[0]).toMatchObject({
+      voiceTranscript: '微信轮询文字',
+      voiceTranscriptStatus: 'success',
+      voiceTranscriptModel: 'wechat-native'
+    })
+    wrapper.unmount()
+  })
+
+  it('accepted/pending 缺少 requestId 时拒绝降级为无代际绑定轮询', async () => {
+    const api = {
+      triggerNativeVoiceTranscription: vi.fn().mockResolvedValue({
+        status: 'accepted',
+        serverId: '9007199254740993',
+        localId: '4294967295',
+        requestId: ''
+      }),
+      getNativeVoiceTranscript: vi.fn(),
+      transcribeChatVoice: vi.fn()
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    await state.transcribeVoice(message)
+
+    expect(api.getNativeVoiceTranscript).not.toHaveBeenCalled()
+    expect(api.transcribeChatVoice).not.toHaveBeenCalled()
+    expect(message.voiceTranscriptStatus).toBe('error')
+    expect(message.voiceTranscriptError).toContain('requestId')
+    wrapper.unmount()
+  })
+
+  it('账号切换后丢弃旧账号的延迟 native status 响应', async () => {
+    let resolveAccountA
+    let resolveAccountB
+    const api = {
+      getNativeVoiceTranscriptionStatus: vi.fn(({ account }) => new Promise((resolve) => {
+        if (account === 'account-a') resolveAccountA = resolve
+        else resolveAccountB = resolve
+      }))
+    }
+    const { state, wrapper, selectedAccount } = mountChatMessagesState(api)
+
+    const accountARequest = state.refreshNativeVoiceTranscriptionStatus({ force: true })
+    selectedAccount.value = 'account-b'
+    await nextTick()
+    const accountBRequest = state.refreshNativeVoiceTranscriptionStatus({ force: true })
+    resolveAccountB({ available: false, reason: 'account-b-not-ready' })
+    await accountBRequest
+    resolveAccountA({ available: true, reason: '' })
+    await accountARequest
+
+    expect(state.nativeVoiceTranscriptionStatus.value).toEqual({
+      available: false,
+      reason: 'account-b-not-ready'
+    })
+    wrapper.unmount()
+  })
+
+  it('窗口重新获得焦点时刷新此前不可用的微信原生状态', async () => {
+    const api = {
+      getNativeVoiceTranscriptionStatus: vi.fn()
+        .mockResolvedValueOnce({ available: false, reason: 'weixin_main_ui_not_found' })
+        .mockResolvedValueOnce({ available: true, reason: '' })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    await state.refreshNativeVoiceTranscriptionStatus({ force: true })
+    expect(state.nativeVoiceTranscriptionAvailable.value).toBe(false)
+
+    window.dispatchEvent(new Event('focus'))
+    await vi.waitFor(() => expect(api.getNativeVoiceTranscriptionStatus).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(state.nativeVoiceTranscriptionAvailable.value).toBe(true))
+
+    wrapper.unmount()
+  })
+
+  it('微信版本不匹配时明确提示受支持版本和重启步骤', async () => {
+    const api = {
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({
+        available: false,
+        reason: 'weixin_version_unsupported'
+      })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+
+    await state.refreshNativeVoiceTranscriptionStatus({ force: true })
+
+    expect(state.nativeVoiceTranscriptionAvailable.value).toBe(false)
+    expect(state.nativeVoiceTranscriptionUnavailableReason.value).toBe(
+      '当前微信版本暂不支持微信原生语音转文字。请使用微信 4.1.12.26，并完全退出、重新启动微信后再试。'
+    )
+    wrapper.unmount()
+  })
+
+  it('状态检查失败时显示中文恢复提示而不是内部 reason code', async () => {
+    const api = {
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({
+        available: false,
+        reason: 'inspection_failed'
+      })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+
+    await state.refreshNativeVoiceTranscriptionStatus({ force: true })
+
+    expect(state.nativeVoiceTranscriptionUnavailableReason.value).toBe(
+      '无法检查微信原生语音转文字状态。请重启本应用和微信后再试。'
+    )
+    wrapper.unmount()
+  })
+
+  it.each([
+    'native_transport_unavailable',
+    'native_weixin_not_running',
+    'native_weixin_version_unsupported'
+  ])('原生可用性错误 %s 也不静默回退 Whisper', async (code) => {
+    const error = nativeError(code, '原生能力不可用')
+    const api = {
+      triggerNativeVoiceTranscription: vi.fn().mockRejectedValue(error),
+      getVoiceTranscriptionStatus: vi.fn(),
+      transcribeChatVoice: vi.fn().mockResolvedValue({
+        text: 'Whisper 回退文字',
+        language: 'zh',
+        model: 'small'
+      })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    await state.transcribeVoice(message)
+
+    expect(api.getVoiceTranscriptionStatus).not.toHaveBeenCalled()
+    expect(api.transcribeChatVoice).not.toHaveBeenCalled()
+    expect(message.voiceTranscriptStatus).toBe('error')
+    expect(message.voiceTranscriptError).toBe('原生能力不可用')
+    wrapper.unmount()
+  })
+
+  it.each([
+    'voice_message_not_found',
+    'voice_message_ambiguous',
+    'voice_message_id_mismatch',
+    'voice_message_not_voice',
+    'native_trigger_rejected',
+    'native_trigger_timeout',
+    'native_transport_failed',
+    'native_message_lookup_unavailable'
+  ])('错误 %s 不静默回退 Whisper', async (code) => {
+    const error = nativeError(code, `原生失败 ${code}`)
+    const api = {
+      triggerNativeVoiceTranscription: vi.fn().mockRejectedValue(error),
+      getVoiceTranscriptionStatus: vi.fn(),
+      transcribeChatVoice: vi.fn()
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    await state.transcribeVoice(message)
+
+    expect(api.getVoiceTranscriptionStatus).not.toHaveBeenCalled()
+    expect(api.transcribeChatVoice).not.toHaveBeenCalled()
+    expect(message.voiceTranscriptStatus).toBe('error')
+    expect(message.voiceTranscriptError).toBe(`原生失败 ${code}`)
+    wrapper.unmount()
+  })
+
+  it('native callback 状态不确定后强制刷新 status 并立即禁用桥接', async () => {
+    const error = nativeError('native_transport_failed', '微信原生回调状态不确定')
+    const api = {
+      triggerNativeVoiceTranscription: vi.fn().mockRejectedValue(error),
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({
+        available: false,
+        reason: 'bridge_restart_required'
+      }),
+      transcribeChatVoice: vi.fn()
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+    const message = existingVoice()
+    state.allMessages.value = { wxid_friend: [message] }
+
+    await state.transcribeVoice(message)
+
+    expect(api.getNativeVoiceTranscriptionStatus).toHaveBeenCalledWith({ account: 'account-a' })
+    expect(state.nativeVoiceTranscriptionAvailable.value).toBe(false)
+    expect(state.nativeVoiceTranscriptionUnavailableReason.value).toContain('完全退出微信')
+    expect(state.nativeVoiceTranscriptionUnavailableReason.value).toContain('重启本应用')
+    expect(api.transcribeChatVoice).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})

--- a/frontend/tests/voice-transcription-message.test.js
+++ b/frontend/tests/voice-transcription-message.test.js
@@ -3,6 +3,7 @@ import { nextTick } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
 import MessageContent from '~/components/chat/MessageContent.vue'
+import ChatHistoryFloatingWindows from '~/components/chat/ChatHistoryFloatingWindows.vue'
 import MessageItem from '~/components/chat/MessageItem.vue'
 
 const makeMessage = (overrides = {}) => ({
@@ -23,6 +24,10 @@ const makeMessage = (overrides = {}) => ({
 
 const makeState = () => ({
   privacyMode: false,
+  nativeVoiceTranscriptionStatusKnown: true,
+  nativeVoiceTranscriptionStatusLoading: false,
+  nativeVoiceTranscriptionAvailable: true,
+  nativeVoiceTranscriptionUnavailableReason: '',
   voiceTranscriptionStatusKnown: true,
   voiceTranscriptionStatusLoading: false,
   voiceTranscriptionAvailable: true,
@@ -71,11 +76,14 @@ describe('语音消息转写状态', () => {
     await wrapper.setProps({
       message: makeMessage({
         voiceTranscriptStatus: 'success',
-        voiceTranscript: '缓存恢复的简体文字'
+        voiceTranscript: '缓存恢复的简体文字',
+        voiceTranscriptModel: 'tiny'
       })
     })
 
     expect(wrapper.text()).toContain('缓存恢复的简体文字')
+    expect(wrapper.text()).toContain('本项目转写')
+    expect(wrapper.get('[data-transcript-source="project"]').attributes('title')).toContain('tiny')
     expect(wrapper.text()).not.toContain('转文字')
   })
 
@@ -93,9 +101,10 @@ describe('语音消息转写状态', () => {
     expect(wrapper.text()).toContain('正在转文字')
 
     await wrapper.setProps({
-      message: makeMessage({ voiceTranscriptStatus: 'success', voiceTranscript: '识别成功的文字' })
+      message: makeMessage({ voiceTranscriptStatus: 'success', voiceTranscript: '识别成功的文字', voiceTranscriptModel: 'medium' })
     })
     expect(wrapper.text()).toContain('识别成功的文字')
+    expect(wrapper.text()).toContain('本项目转写')
 
     const failedMessage = makeMessage({
       voiceTranscriptStatus: 'error',
@@ -107,14 +116,14 @@ describe('语音消息转写状态', () => {
 
     await wrapper.get('.wechat-voice-transcript__retry').trigger('click')
     await nextTick()
-    expect(state.transcribeVoice).toHaveBeenLastCalledWith(failedMessage, { force: true })
+    expect(state.transcribeVoice).toHaveBeenLastCalledWith(failedMessage)
   })
 
-  it('模型缺失且禁止下载时不提供转写按钮并显示原因', () => {
+  it('微信原生桥接不可用时不提供主转写按钮并显示原因', () => {
     const state = {
       ...makeState(),
-      voiceTranscriptionAvailable: false,
-      voiceTranscriptionUnavailableReason: 'Whisper 模型尚未下载到本机缓存。 当前已禁止自动下载。'
+      nativeVoiceTranscriptionAvailable: false,
+      nativeVoiceTranscriptionUnavailableReason: '当前微信版本暂不支持微信原生语音转文字。请使用微信 4.1.12.26，并完全退出、重新启动微信后再试。'
     }
     const wrapper = mount(MessageContent, {
       ...mountOptions,
@@ -122,6 +131,63 @@ describe('语音消息转写状态', () => {
     })
 
     expect(wrapper.find('.wechat-voice-transcript__action').exists()).toBe(false)
-    expect(wrapper.text()).toContain('当前已禁止自动下载')
+    expect(wrapper.text()).toContain('请使用微信 4.1.12.26')
+  })
+
+  it('桥接要求重启时隐藏错误态重试按钮并显示权威状态', () => {
+    const state = {
+      ...makeState(),
+      nativeVoiceTranscriptionAvailable: false,
+      nativeVoiceTranscriptionStatusLoading: false,
+      nativeVoiceTranscriptionUnavailableReason: '桥接状态已失效。请完全退出微信，重启本应用（开发模式下同时重启后端）后，再重新打开并登录微信。'
+    }
+    const wrapper = mount(MessageContent, {
+      ...mountOptions,
+      props: {
+        state,
+        message: makeMessage({
+          voiceTranscriptStatus: 'error',
+          voiceTranscriptError: '微信原生回调状态不确定。'
+        })
+      }
+    })
+
+    expect(wrapper.find('.wechat-voice-transcript__retry').exists()).toBe(false)
+    expect(wrapper.text()).toContain('完全退出微信')
+    expect(wrapper.text()).toContain('重启本应用')
+  })
+
+  it('合并转发浮窗在不提供新转写操作时仍展示微信原生文字', () => {
+    const state = {
+      ...makeState(),
+      floatingWindows: [{
+        id: 'history-1',
+        kind: 'chatHistory',
+        title: '聊天记录',
+        x: 10,
+        y: 10,
+        zIndex: 10,
+        width: 420,
+        height: 500,
+        records: [makeMessage({
+          voiceTranscriptStatus: '',
+          voiceTranscript: '微信已经转写的合成文字',
+          voiceTranscriptModel: 'wechat-native'
+        })]
+      }],
+      focusFloatingWindow: vi.fn(),
+      startFloatingWindowDrag: vi.fn(),
+      closeFloatingWindow: vi.fn()
+    }
+    const wrapper = mount(ChatHistoryFloatingWindows, {
+      ...mountOptions,
+      props: { state }
+    })
+
+    expect(wrapper.text()).toContain('微信已经转写的合成文字')
+    expect(wrapper.text()).toContain('微信原生转写')
+    expect(wrapper.get('[data-transcript-source="wechat"]').attributes('title')).toContain('微信客户端原生')
+    expect(wrapper.find('.wechat-voice-transcript__action').exists()).toBe(false)
+    expect(wrapper.find('.wechat-voice-transcript__retry').exists()).toBe(false)
   })
 })

--- a/src/wechat_decrypt_tool/chat_helpers.py
+++ b/src/wechat_decrypt_tool/chat_helpers.py
@@ -589,6 +589,131 @@ def _extract_md5_from_packed_info(packed_info: Any) -> str:
     return ""
 
 
+def _extract_voice_transcript_from_packed_info(packed_info: Any) -> str:
+    """Extract a completed WeChat-native voice transcript.
+
+    Voice messages store the result in ``packed_info_data`` as a protobuf-like
+    payload.  The transcript is top-level field 5, nested field 2, and nested
+    field 1 must be status 2 (completed).  Parsing only that exact path avoids
+    mistaking unrelated UTF-8 strings in packed metadata for a transcript.
+    """
+
+    if packed_info is None:
+        return ""
+
+    if isinstance(packed_info, memoryview):
+        data = packed_info.tobytes()
+    elif isinstance(packed_info, (bytes, bytearray)):
+        data = bytes(packed_info)
+    elif isinstance(packed_info, str):
+        value = packed_info.strip()
+        if value.lower().startswith("0x"):
+            value = value[2:]
+        if value and _PACKED_INFO_HEX_RE.fullmatch(value) and len(value) % 2 == 0:
+            try:
+                data = bytes.fromhex(value)
+            except ValueError:
+                return ""
+        else:
+            data = value.encode("utf-8", errors="ignore")
+    else:
+        if isinstance(packed_info, (int, float, bool)):
+            return ""
+        try:
+            data = bytes(packed_info)
+        except Exception:
+            return ""
+
+    # Message metadata is tiny in practice.  Bound parsing of untrusted blobs.
+    if not data or len(data) > 1024 * 1024:
+        return ""
+
+    def read_varint(raw: bytes, offset: int) -> tuple[Optional[int], int]:
+        value = 0
+        shift = 0
+        pos = offset
+        for _ in range(10):
+            if pos >= len(raw):
+                return None, offset
+            byte = raw[pos]
+            pos += 1
+            value |= (byte & 0x7F) << shift
+            if (byte & 0x80) == 0:
+                return value, pos
+            shift += 7
+        return None, offset
+
+    def parse_fields(raw: bytes) -> Optional[list[tuple[int, int, Any]]]:
+        fields: list[tuple[int, int, Any]] = []
+        pos = 0
+        while pos < len(raw):
+            tag, next_pos = read_varint(raw, pos)
+            if tag is None or next_pos <= pos:
+                return None
+            pos = next_pos
+            field_no = int(tag) >> 3
+            wire_type = int(tag) & 0x07
+            if field_no <= 0:
+                return None
+
+            if wire_type == 0:
+                value, next_pos = read_varint(raw, pos)
+                if value is None or next_pos <= pos:
+                    return None
+                fields.append((field_no, wire_type, value))
+                pos = next_pos
+            elif wire_type == 1:
+                if pos + 8 > len(raw):
+                    return None
+                fields.append((field_no, wire_type, raw[pos : pos + 8]))
+                pos += 8
+            elif wire_type == 2:
+                size, next_pos = read_varint(raw, pos)
+                if size is None or next_pos <= pos:
+                    return None
+                pos = next_pos
+                end = pos + int(size)
+                if end > len(raw):
+                    return None
+                fields.append((field_no, wire_type, raw[pos:end]))
+                pos = end
+            elif wire_type == 5:
+                if pos + 4 > len(raw):
+                    return None
+                fields.append((field_no, wire_type, raw[pos : pos + 4]))
+                pos += 4
+            else:
+                return None
+        return fields
+
+    top_fields = parse_fields(data)
+    if top_fields is None:
+        return ""
+
+    for field_no, wire_type, nested_blob in top_fields:
+        if field_no != 5 or wire_type != 2 or not isinstance(nested_blob, bytes):
+            continue
+        nested_fields = parse_fields(nested_blob)
+        if nested_fields is None:
+            continue
+        status: Optional[int] = None
+        text_blob: Optional[bytes] = None
+        for nested_no, nested_wire, nested_value in nested_fields:
+            if nested_no == 1 and nested_wire == 0:
+                status = int(nested_value)
+            elif nested_no == 2 and nested_wire == 2 and isinstance(nested_value, bytes):
+                text_blob = nested_value
+        if status != 2 or not text_blob:
+            continue
+        try:
+            transcript = text_blob.decode("utf-8", errors="strict").strip()
+        except UnicodeDecodeError:
+            continue
+        if transcript:
+            return transcript
+    return ""
+
+
 def _resource_lookup_chat_id(resource_conn: sqlite3.Connection, username: str) -> Optional[int]:
     if not username:
         return None

--- a/src/wechat_decrypt_tool/native_core_client.py
+++ b/src/wechat_decrypt_tool/native_core_client.py
@@ -57,6 +57,10 @@ _NATIVE_CORE_DISTRIBUTION_TICKET_PATTERN = re.compile(
 )
 _NATIVE_CORE_BUILD_LIFETIME_SECONDS = 45 * 24 * 60 * 60
 _MAX_ENCRYPTED_EXPORT_PLAINTEXT_SIZE = 256 * 1024 * 1024 * 1024
+_NATIVE_ASR_MAX_ACCOUNT_SIZE = 255
+_NATIVE_ASR_MAX_ACCOUNT_DIRECTORY_SIZE = 32 * 1024
+_NATIVE_ASR_MAX_CONVERSATION_SIZE = 255
+_NATIVE_ASR_MAX_TEXT_SIZE = 64 * 1024
 _ENV_NATIVE_CORE_BROKER = "WECHAT_TOOL_NATIVE_CORE_BROKER"
 _ENV_NATIVE_CORE_TRUST_KEY = "WECHAT_TOOL_NATIVE_CORE_TRUST_KEY_PATH"
 _LEGACY_WCDB_ENVIRONMENT = (
@@ -101,6 +105,39 @@ class NativeCoreFeature(IntFlag):
     DATABASE_READ = 1 << 0
     EXPORT = 1 << 1
     MEDIA_DECRYPT = 1 << 2
+    NATIVE_ASR = 1 << 4
+
+
+class NativeCoreAsrReason(IntEnum):
+    READY = 0
+    UNSUPPORTED_PLATFORM = 1
+    UNSUPPORTED_ARCHITECTURE = 2
+    RUNTIME_UNAVAILABLE = 3
+    WECHAT_NOT_RUNNING = 4
+    WECHAT_NOT_LOGGED_IN = 5
+    ACCOUNT_UNVERIFIED = 6
+    ACCOUNT_MISMATCH = 7
+    WECHAT_VERSION_MISMATCH = 8
+    WEIXIN_SHA256_MISMATCH = 9
+    BRIDGE_RESTART_REQUIRED = 10
+    BUSY = 11
+    MESSAGE_NOT_FOUND = 12
+    MESSAGE_AMBIGUOUS = 13
+    NOT_VOICE = 14
+    PROVIDER_UNAVAILABLE = 15
+    DISPATCH_FAILED = 16
+    CALLBACK_FAILED = 17
+    TIMEOUT = 18
+    CANCELLED = 19
+    INTERNAL = 20
+
+
+class NativeCoreAsrRequestState(IntEnum):
+    PENDING = 1
+    RUNNING = 2
+    SUCCEEDED = 3
+    FAILED = 4
+    CANCELLED = 5
 
 
 _NATIVE_CORE_OFFLINE_BOOTSTRAP_FEATURES = (
@@ -239,6 +276,74 @@ class _WceOwnedBuffer(ctypes.Structure):
     ]
 
 
+class _WceNativeAsrStatusOptions(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32),
+        ("account_utf8", ctypes.c_char_p),
+        ("account_directory_utf8", ctypes.c_char_p),
+    ]
+
+
+class _WceNativeAsrStatus(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("reason", ctypes.c_uint32),
+        ("platform_supported", ctypes.c_uint32),
+        ("ready", ctypes.c_uint32),
+        ("wechat_process_id", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32),
+        ("expected_wechat_version", ctypes.c_char * 32),
+        ("actual_wechat_version", ctypes.c_char * 32),
+        ("expected_weixin_sha256", ctypes.c_uint8 * 32),
+        ("actual_weixin_sha256", ctypes.c_uint8 * 32),
+    ]
+
+
+class _WceNativeAsrBeginOptions(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32),
+        ("account_utf8", ctypes.c_char_p),
+        ("account_directory_utf8", ctypes.c_char_p),
+        ("conversation_utf8", ctypes.c_char_p),
+        ("server_id", ctypes.c_uint64),
+        ("local_id", ctypes.c_uint32),
+        ("reserved2", ctypes.c_uint32),
+        ("operation_nonce", ctypes.c_uint64),
+    ]
+
+
+class _WceNativeAsrPollOptions(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32),
+        ("request_handle", ctypes.c_uint64),
+        ("operation_nonce", ctypes.c_uint64),
+    ]
+
+
+class _WceNativeAsrPollResult(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("state", ctypes.c_uint32),
+        ("reason", ctypes.c_uint32),
+        ("terminal_status", ctypes.c_int32),
+        ("server_id", ctypes.c_uint64),
+        ("local_id", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32),
+    ]
+
+
+class _WceNativeAsrCloseOptions(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32),
+        ("request_handle", ctypes.c_uint64),
+        ("operation_nonce", ctypes.c_uint64),
+    ]
+
+
 class _WceExportBeginOptions(ctypes.Structure):
     _fields_ = [
         ("struct_size", ctypes.c_uint32),
@@ -364,6 +469,28 @@ class NativeCoreRuntimeStatus:
     build_id: bytes = field(repr=False)
     device_id: bytes = field(repr=False)
     startup_nonce: bytes = field(repr=False)
+
+
+@dataclass(frozen=True)
+class NativeCoreAsrStatus:
+    reason: NativeCoreAsrReason
+    platform_supported: bool
+    ready: bool
+    wechat_process_id: int
+    expected_wechat_version: str
+    actual_wechat_version: str
+    expected_weixin_sha256: bytes = field(repr=False)
+    actual_weixin_sha256: bytes = field(repr=False)
+
+
+@dataclass(frozen=True)
+class NativeCoreAsrPollResult:
+    state: NativeCoreAsrRequestState
+    reason: NativeCoreAsrReason
+    terminal_status: NativeCoreStatus
+    server_id: int
+    local_id: int
+    text: str
 
 
 @dataclass(frozen=True)
@@ -1049,7 +1176,8 @@ def _load_native_core_build_manifest(
         build_expires_at_unix = build_expires_at_unix_value
         if int(time.time()) >= build_expires_at_unix:
             raise NativeCorePolicyError(
-                "This wechatdb native build has reached its fixed expiration time."
+                "This wechatdb native build has reached its fixed expiration time.",
+                status=int(NativeCoreStatus.BUILD_MISMATCH),
             )
     else:
         if build_issued_at_unix_value is None and build_expires_at_unix_value is None:
@@ -1503,6 +1631,77 @@ def _operation_nonce() -> int:
     return nonce
 
 
+def _encode_native_asr_utf8(value: str, *, field_name: str, maximum_size: int) -> bytes:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{field_name} must be valid UTF-8") from exc
+    if not encoded or len(encoded) > maximum_size or b"\0" in encoded:
+        raise ValueError(
+            f"{field_name} must be 1 to {maximum_size} UTF-8 bytes without NUL bytes"
+        )
+    return encoded
+
+
+def _encode_native_asr_account_directory(
+    value: str | os.PathLike[str],
+) -> bytes:
+    try:
+        path_value = os.fspath(value)
+    except TypeError as exc:
+        raise ValueError("account_directory must be a path string") from exc
+    if not isinstance(path_value, str):
+        raise ValueError("account_directory must be a path string")
+    if not Path(path_value).is_absolute():
+        raise ValueError("account_directory must be an absolute path")
+    return _encode_native_asr_utf8(
+        path_value,
+        field_name="account_directory",
+        maximum_size=_NATIVE_ASR_MAX_ACCOUNT_DIRECTORY_SIZE,
+    )
+
+
+def _decode_native_asr_fixed_utf8(
+    value: _WceNativeAsrStatus,
+    field_name: str,
+) -> str:
+    field = getattr(type(value), field_name)
+    raw = ctypes.string_at(ctypes.addressof(value) + field.offset, 32)
+    terminator = raw.find(b"\0")
+    if terminator < 0 or any(raw[terminator + 1 :]):
+        raise NativeCoreProtocolError(
+            f"wechatdb native ASR returned an invalid {field_name}."
+        )
+    try:
+        return raw[:terminator].decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise NativeCoreProtocolError(
+            f"wechatdb native ASR returned a non-UTF-8 {field_name}."
+        ) from exc
+
+
+def _decode_native_asr_owned_text(output: _WceOwnedBuffer) -> str:
+    expected_size = ctypes.sizeof(_WceOwnedBuffer)
+    output_size = int(output.size)
+    if (
+        int(output.struct_size) != expected_size
+        or int(output.flags) != 0
+        or output_size > _NATIVE_ASR_MAX_TEXT_SIZE
+        or (output_size == 0 and bool(output.data))
+        or (output_size != 0 and not bool(output.data))
+    ):
+        raise NativeCoreProtocolError("wechatdb native ASR returned an invalid owned buffer.")
+    payload = ctypes.string_at(output.data, output_size) if output_size else b""
+    if b"\0" in payload:
+        raise NativeCoreProtocolError("wechatdb native ASR returned text containing a NUL byte.")
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise NativeCoreProtocolError("wechatdb native ASR returned non-UTF-8 text.") from exc
+
+
 class NativeCoreClient:
     def __init__(
         self,
@@ -1556,6 +1755,7 @@ class NativeCoreClient:
         self._export_handles: set[int] = set()
         self._encrypted_export_handles: set[int] = set()
         self._decrypted_export_handles: set[int] = set()
+        self._native_asr_handles: set[int] = set()
         try:
             runtime_status = self.get_status()
             _verify_native_core_component_build_ids(
@@ -1590,6 +1790,10 @@ class NativeCoreClient:
     @property
     def build_manifest(self) -> NativeCoreBuildManifest:
         return self._build_manifest
+
+    @property
+    def supports_native_asr(self) -> bool:
+        return self._supports_native_asr
 
     def _configure_abi(self) -> None:
         lib = self._library
@@ -1644,6 +1848,26 @@ class NativeCoreClient:
                 + ", ".join(missing_decrypt_symbols)
             )
         self._supports_export_decryption = bool(available_decrypt_symbols)
+        native_asr_symbols = (
+            "wce_native_asr_get_status",
+            "wce_native_asr_begin",
+            "wce_native_asr_poll",
+            "wce_native_asr_close",
+        )
+        available_native_asr_symbols = tuple(
+            name for name in native_asr_symbols if hasattr(lib, name)
+        )
+        if available_native_asr_symbols and len(available_native_asr_symbols) != len(
+            native_asr_symbols
+        ):
+            missing_native_asr_symbols = (
+                name for name in native_asr_symbols if name not in available_native_asr_symbols
+            )
+            raise NativeCoreProtocolError(
+                "wechatdb native client has an incomplete native ASR ABI: "
+                + ", ".join(missing_native_asr_symbols)
+            )
+        self._supports_native_asr = bool(available_native_asr_symbols)
         self._supports_export_verification = hasattr(lib, "wce_export_verify_seal")
         if (
             self._build_manifest.root_public_key_compiled
@@ -1771,6 +1995,31 @@ class NativeCoreClient:
                 ctypes.c_uint64,
             ]
             lib.wce_export_decrypt_abort.restype = ctypes.c_int32
+        if self._supports_native_asr:
+            lib.wce_native_asr_get_status.argtypes = [
+                ctypes.c_void_p,
+                ctypes.POINTER(_WceNativeAsrStatusOptions),
+                ctypes.POINTER(_WceNativeAsrStatus),
+            ]
+            lib.wce_native_asr_get_status.restype = ctypes.c_int32
+            lib.wce_native_asr_begin.argtypes = [
+                ctypes.c_void_p,
+                ctypes.POINTER(_WceNativeAsrBeginOptions),
+                ctypes.POINTER(ctypes.c_uint64),
+            ]
+            lib.wce_native_asr_begin.restype = ctypes.c_int32
+            lib.wce_native_asr_poll.argtypes = [
+                ctypes.c_void_p,
+                ctypes.POINTER(_WceNativeAsrPollOptions),
+                ctypes.POINTER(_WceNativeAsrPollResult),
+                ctypes.POINTER(_WceOwnedBuffer),
+            ]
+            lib.wce_native_asr_poll.restype = ctypes.c_int32
+            lib.wce_native_asr_close.argtypes = [
+                ctypes.c_void_p,
+                ctypes.POINTER(_WceNativeAsrCloseOptions),
+            ]
+            lib.wce_native_asr_close.restype = ctypes.c_int32
         if self._supports_export_verification:
             lib.wce_export_verify_seal.argtypes = [
                 ctypes.POINTER(_WceExportVerifyOptions),
@@ -1818,6 +2067,17 @@ class NativeCoreClient:
                 return
             handle = self._handle
             if handle.value:
+                for request_handle in tuple(self._native_asr_handles):
+                    try:
+                        options = _WceNativeAsrCloseOptions(
+                            struct_size=ctypes.sizeof(_WceNativeAsrCloseOptions),
+                            reserved=0,
+                            request_handle=request_handle,
+                            operation_nonce=_operation_nonce(),
+                        )
+                        self._library.wce_native_asr_close(handle, ctypes.byref(options))
+                    except Exception:
+                        pass
                 for export_handle in tuple(self._decrypted_export_handles):
                     try:
                         self._library.wce_export_decrypt_abort(
@@ -1868,6 +2128,7 @@ class NativeCoreClient:
             self._export_handles.clear()
             self._encrypted_export_handles.clear()
             self._decrypted_export_handles.clear()
+            self._native_asr_handles.clear()
             self._closed = True
             self._handle = ctypes.c_void_p()
             if handle.value:
@@ -2000,6 +2261,257 @@ class NativeCoreClient:
                 )
             )
             self._raise_for_status(rc, "authorize operation")
+
+    def _require_native_asr(self) -> None:
+        if not self._supports_native_asr:
+            raise NativeCoreProtocolError(
+                "wechatdb native client does not implement the native ASR ABI."
+            )
+
+    def get_native_asr_status(
+        self,
+        account: str,
+        account_directory: str | os.PathLike[str],
+    ) -> NativeCoreAsrStatus:
+        self._require_native_asr()
+        encoded_account = _encode_native_asr_utf8(
+            account,
+            field_name="account",
+            maximum_size=_NATIVE_ASR_MAX_ACCOUNT_SIZE,
+        )
+        encoded_account_directory = _encode_native_asr_account_directory(
+            account_directory
+        )
+        options = _WceNativeAsrStatusOptions(
+            struct_size=ctypes.sizeof(_WceNativeAsrStatusOptions),
+            reserved=0,
+            account_utf8=encoded_account,
+            account_directory_utf8=encoded_account_directory,
+        )
+        status = _WceNativeAsrStatus(
+            struct_size=ctypes.sizeof(_WceNativeAsrStatus)
+        )
+        with self._lock:
+            rc = int(
+                self._library.wce_native_asr_get_status(
+                    self._open_handle(), ctypes.byref(options), ctypes.byref(status)
+                )
+            )
+            self._raise_for_status(rc, "get native ASR status")
+
+        if (
+            int(status.struct_size) != ctypes.sizeof(_WceNativeAsrStatus)
+            or int(status.reserved) != 0
+            or int(status.platform_supported) not in {0, 1}
+            or int(status.ready) not in {0, 1}
+        ):
+            raise NativeCoreProtocolError(
+                "wechatdb native ASR returned invalid status metadata."
+            )
+        try:
+            reason = NativeCoreAsrReason(int(status.reason))
+        except ValueError as exc:
+            raise NativeCoreProtocolError(
+                "wechatdb native ASR returned an unknown status reason."
+            ) from exc
+        platform_supported = bool(status.platform_supported)
+        ready = bool(status.ready)
+        process_id = int(status.wechat_process_id)
+        if (ready and (reason is not NativeCoreAsrReason.READY or not platform_supported or not process_id)) or (
+            not ready and reason is NativeCoreAsrReason.READY
+        ):
+            raise NativeCoreProtocolError(
+                "wechatdb native ASR returned an inconsistent readiness status."
+            )
+        return NativeCoreAsrStatus(
+            reason=reason,
+            platform_supported=platform_supported,
+            ready=ready,
+            wechat_process_id=process_id,
+            expected_wechat_version=_decode_native_asr_fixed_utf8(
+                status, "expected_wechat_version"
+            ),
+            actual_wechat_version=_decode_native_asr_fixed_utf8(
+                status, "actual_wechat_version"
+            ),
+            expected_weixin_sha256=bytes(status.expected_weixin_sha256),
+            actual_weixin_sha256=bytes(status.actual_weixin_sha256),
+        )
+
+    def begin_native_asr(
+        self,
+        account: str,
+        account_directory: str | os.PathLike[str],
+        conversation: str,
+        server_id: int,
+        local_id: int = 0,
+    ) -> int:
+        self._require_native_asr()
+        encoded_account = _encode_native_asr_utf8(
+            account,
+            field_name="account",
+            maximum_size=_NATIVE_ASR_MAX_ACCOUNT_SIZE,
+        )
+        encoded_account_directory = _encode_native_asr_account_directory(
+            account_directory
+        )
+        encoded_conversation = _encode_native_asr_utf8(
+            conversation,
+            field_name="conversation",
+            maximum_size=_NATIVE_ASR_MAX_CONVERSATION_SIZE,
+        )
+        server_id_value = int(server_id)
+        local_id_value = int(local_id)
+        if not 1 <= server_id_value <= 0xFFFF_FFFF_FFFF_FFFF:
+            raise ValueError("server_id must be between 1 and 18446744073709551615")
+        if not 0 <= local_id_value <= 0xFFFF_FFFF:
+            raise ValueError("local_id must be between 0 and 4294967295")
+        options = _WceNativeAsrBeginOptions(
+            struct_size=ctypes.sizeof(_WceNativeAsrBeginOptions),
+            reserved=0,
+            account_utf8=encoded_account,
+            account_directory_utf8=encoded_account_directory,
+            conversation_utf8=encoded_conversation,
+            server_id=server_id_value,
+            local_id=local_id_value,
+            reserved2=0,
+            operation_nonce=_operation_nonce(),
+        )
+        output = ctypes.c_uint64()
+        with self._lock:
+            rc = int(
+                self._library.wce_native_asr_begin(
+                    self._open_handle(), ctypes.byref(options), ctypes.byref(output)
+                )
+            )
+            self._raise_for_status(rc, "begin native ASR")
+            if not output.value:
+                raise NativeCoreProtocolError(
+                    "wechatdb native ASR returned an empty request handle."
+                )
+            request_handle = int(output.value)
+            self._native_asr_handles.add(request_handle)
+        return request_handle
+
+    def poll_native_asr(self, request_handle: int) -> NativeCoreAsrPollResult:
+        self._require_native_asr()
+        handle_value = int(request_handle)
+        if not 1 <= handle_value <= 0xFFFF_FFFF_FFFF_FFFF:
+            raise ValueError("request_handle must be between 1 and 18446744073709551615")
+        options = _WceNativeAsrPollOptions(
+            struct_size=ctypes.sizeof(_WceNativeAsrPollOptions),
+            reserved=0,
+            request_handle=handle_value,
+            operation_nonce=_operation_nonce(),
+        )
+        result = _WceNativeAsrPollResult(
+            struct_size=ctypes.sizeof(_WceNativeAsrPollResult)
+        )
+        output = _WceOwnedBuffer(struct_size=ctypes.sizeof(_WceOwnedBuffer))
+        with self._lock:
+            if handle_value not in self._native_asr_handles:
+                raise NativeCoreUnavailableError(
+                    "wechatdb native ASR request handle is closed."
+                )
+            try:
+                rc = int(
+                    self._library.wce_native_asr_poll(
+                        self._open_handle(),
+                        ctypes.byref(options),
+                        ctypes.byref(result),
+                        ctypes.byref(output),
+                    )
+                )
+                self._raise_for_status(rc, "poll native ASR")
+                text = _decode_native_asr_owned_text(output)
+            finally:
+                self._library.wce_buffer_release(ctypes.byref(output))
+
+        if (
+            int(result.struct_size) != ctypes.sizeof(_WceNativeAsrPollResult)
+            or int(result.reserved) != 0
+            or int(result.server_id) == 0
+        ):
+            raise NativeCoreProtocolError(
+                "wechatdb native ASR returned invalid poll metadata."
+            )
+        try:
+            state = NativeCoreAsrRequestState(int(result.state))
+            reason = NativeCoreAsrReason(int(result.reason))
+            terminal_status = NativeCoreStatus(int(result.terminal_status))
+        except ValueError as exc:
+            raise NativeCoreProtocolError(
+                "wechatdb native ASR returned an unknown poll state."
+            ) from exc
+        terminal = state in {
+            NativeCoreAsrRequestState.SUCCEEDED,
+            NativeCoreAsrRequestState.FAILED,
+            NativeCoreAsrRequestState.CANCELLED,
+        }
+        if (
+            (
+                state is NativeCoreAsrRequestState.SUCCEEDED
+                and (
+                    not text
+                    or reason is not NativeCoreAsrReason.READY
+                    or terminal_status is not NativeCoreStatus.OK
+                )
+            )
+            or (state is not NativeCoreAsrRequestState.SUCCEEDED and bool(text))
+            or (
+                not terminal
+                and (
+                    reason is not NativeCoreAsrReason.READY
+                    or terminal_status is not NativeCoreStatus.OK
+                )
+            )
+        ):
+            raise NativeCoreProtocolError(
+                "wechatdb native ASR returned an inconsistent poll result."
+            )
+        return NativeCoreAsrPollResult(
+            state=state,
+            reason=reason,
+            terminal_status=terminal_status,
+            server_id=int(result.server_id),
+            local_id=int(result.local_id),
+            text=text,
+        )
+
+    def close_native_asr(self, request_handle: int) -> None:
+        self._require_native_asr()
+        handle_value = int(request_handle)
+        if not 1 <= handle_value <= 0xFFFF_FFFF_FFFF_FFFF:
+            raise ValueError("request_handle must be between 1 and 18446744073709551615")
+        options = _WceNativeAsrCloseOptions(
+            struct_size=ctypes.sizeof(_WceNativeAsrCloseOptions),
+            reserved=0,
+            request_handle=handle_value,
+            operation_nonce=_operation_nonce(),
+        )
+        with self._lock:
+            if handle_value not in self._native_asr_handles:
+                return
+            rc = int(
+                self._library.wce_native_asr_close(
+                    self._open_handle(), ctypes.byref(options)
+                )
+            )
+            if rc in {
+                int(NativeCoreStatus.OK),
+                int(NativeCoreStatus.NOT_FOUND),
+                int(NativeCoreStatus.LICENSE_REQUIRED),
+                int(NativeCoreStatus.LEASE_INVALID),
+                int(NativeCoreStatus.LEASE_EXPIRED),
+                int(NativeCoreStatus.FEATURE_DENIED),
+                int(NativeCoreStatus.BUILD_MISMATCH),
+                int(NativeCoreStatus.DEVICE_MISMATCH),
+                int(NativeCoreStatus.TAMPER_DETECTED),
+                int(NativeCoreStatus.LIMIT),
+            }:
+                self._native_asr_handles.discard(handle_value)
+                return
+            self._raise_for_status(rc, "close native ASR")
 
     def open_database(
         self,

--- a/src/wechat_decrypt_tool/native_core_lease.py
+++ b/src/wechat_decrypt_tool/native_core_lease.py
@@ -24,6 +24,7 @@ from .native_core_client import (
     NativeCorePolicyError,
     NativeCoreProtocolError,
     NativeCoreRuntimeStatus,
+    NativeCoreStatus,
     NativeCoreUnavailableError,
     _is_development_native_core_build_manifest,
     _is_production_native_core_build_manifest,
@@ -413,7 +414,8 @@ def validate_native_core_authorization_policy(
     ) or _is_source_public_native_core_build_manifest(manifest):
         if int(time.time()) >= manifest.build_expires_at_unix:
             raise NativeCorePolicyError(
-                "This native core build has reached its fixed expiration time."
+                "This native core build has reached its fixed expiration time.",
+                status=int(NativeCoreStatus.BUILD_MISMATCH),
             )
         _production_license_configuration()
         return "production"
@@ -592,7 +594,8 @@ def _validate_unchanged_device_status(
         or before.startup_nonce != after.startup_nonce
     ):
         raise NativeCorePolicyError(
-            "Native core broker identity changed during license challenge."
+            "Native core broker identity changed during license challenge.",
+            status=int(NativeCoreStatus.TAMPER_DETECTED),
         )
 
 
@@ -632,7 +635,8 @@ def _validated_device_proof(
         or startup_nonce != status.startup_nonce
     ):
         raise NativeCorePolicyError(
-            "Native core device proof does not match the challenged broker state."
+            "Native core device proof does not match the challenged broker state.",
+            status=int(NativeCoreStatus.TAMPER_DETECTED),
         )
     return public_key, signature
 
@@ -1032,7 +1036,8 @@ def _refresh_native_core_lease_internal(
                         ):
                             credential_store.delete()
                             raise NativeCorePolicyError(
-                                "Cached native core lease exceeds the fixed build expiration."
+                                "Cached native core lease exceeds the fixed build expiration.",
+                                status=int(NativeCoreStatus.BUILD_MISMATCH),
                             )
                         configure_product_telemetry(
                             license_url=license_url,
@@ -1110,13 +1115,40 @@ def _refresh_native_core_lease_internal(
             raise
         refreshed_status = client.get_status()
         if not (int(refreshed_status.feature_bits) & int(feature)):
-            raise NativeCorePolicyError("Installed native core lease does not grant the requested feature.")
+            raise NativeCorePolicyError(
+                "Installed native core lease does not grant the requested feature.",
+                status=int(NativeCoreStatus.FEATURE_DENIED),
+            )
         if (
             manifest.build_expires_at_unix > 0
             and refreshed_status.lease_expires_unix > manifest.build_expires_at_unix
         ):
             raise NativeCorePolicyError(
-                "Installed native core lease exceeds the fixed build expiration."
+                "Installed native core lease exceeds the fixed build expiration.",
+                status=int(NativeCoreStatus.BUILD_MISMATCH),
+            )
+        post_install_now = int(time.time())
+        if not _status_grants_feature(
+            refreshed_status,
+            feature,
+            manifest=manifest,
+            now=post_install_now,
+            minimum_validity_seconds=minimum_validity_seconds,
+        ):
+            required_until = post_install_now + max(0, int(minimum_validity_seconds))
+            build_near_expiration = (
+                manifest.build_expires_at_unix > 0
+                and manifest.build_expires_at_unix <= required_until
+            )
+            raise NativeCorePolicyError(
+                "The native core build expires too soon for this operation."
+                if build_near_expiration
+                else "The installed native core lease expires too soon for this operation.",
+                status=int(
+                    NativeCoreStatus.BUILD_MISMATCH
+                    if build_near_expiration
+                    else NativeCoreStatus.LEASE_EXPIRED
+                ),
             )
         if (
             grant is not None

--- a/src/wechat_decrypt_tool/native_core_voice_asr.py
+++ b/src/wechat_decrypt_tool/native_core_voice_asr.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .account_identity import resolve_account_self_username
+from .native_core_broker import NativeCoreManagedOperation, managed_native_core_operation
+from .native_core_client import (
+    NativeCoreAsrReason,
+    NativeCoreAsrRequestState,
+    NativeCoreClient,
+    NativeCoreError,
+    NativeCoreFeature,
+    NativeCorePolicyError,
+    NativeCoreProtocolError,
+    NativeCoreStatus,
+    NativeCoreUnavailableError,
+    get_native_core_client,
+)
+from .native_core_lease import refresh_native_core_lease
+from .native_voice_transcription import (
+    NativeVoiceTriggerCommand,
+    NativeVoiceTriggerError,
+    NativeVoiceTriggerReceipt,
+    mark_native_voice_transcript_error,
+    mark_native_voice_transcript_pending,
+    mark_native_voice_transcript_success,
+)
+
+
+_POLL_INTERVAL_SECONDS = 1.0
+_POLL_TIMEOUT_SECONDS = 100.0
+_LEASE_MINIMUM_VALIDITY_SECONDS = 180
+_EXPECTED_WECHAT_VERSION = "4.1.12.26"
+_CLOSE_RETRY_DELAYS_SECONDS = (0.05, 0.15)
+
+
+_STATUS_REASON_KEYS: dict[NativeCoreAsrReason, str] = {
+    NativeCoreAsrReason.READY: "",
+    NativeCoreAsrReason.UNSUPPORTED_PLATFORM: "unsupported_platform",
+    NativeCoreAsrReason.UNSUPPORTED_ARCHITECTURE: "unsupported_architecture",
+    NativeCoreAsrReason.RUNTIME_UNAVAILABLE: "bridge_manager_unavailable",
+    NativeCoreAsrReason.WECHAT_NOT_RUNNING: "weixin_main_ui_not_found",
+    NativeCoreAsrReason.WECHAT_NOT_LOGGED_IN: "weixin_main_ui_not_found",
+    NativeCoreAsrReason.ACCOUNT_UNVERIFIED: "active_account_unverified",
+    NativeCoreAsrReason.ACCOUNT_MISMATCH: "active_account_mismatch",
+    NativeCoreAsrReason.WECHAT_VERSION_MISMATCH: "weixin_version_unsupported",
+    NativeCoreAsrReason.WEIXIN_SHA256_MISMATCH: "weixin_version_unsupported",
+    NativeCoreAsrReason.BRIDGE_RESTART_REQUIRED: "bridge_restart_required",
+    NativeCoreAsrReason.BUSY: "bridge_manager_unavailable",
+}
+
+
+_ERROR_DETAILS: dict[NativeCoreAsrReason, tuple[str, str]] = {
+    NativeCoreAsrReason.UNSUPPORTED_PLATFORM: (
+        "native_transport_unavailable",
+        "微信原生语音转文字目前仅支持 64 位 Windows。",
+    ),
+    NativeCoreAsrReason.UNSUPPORTED_ARCHITECTURE: (
+        "native_transport_unavailable",
+        "微信原生语音转文字需要 64 位 Windows。",
+    ),
+    NativeCoreAsrReason.RUNTIME_UNAVAILABLE: (
+        "native_transport_unavailable",
+        "微信原生语音转文字服务尚未就绪。",
+    ),
+    NativeCoreAsrReason.WECHAT_NOT_RUNNING: (
+        "native_weixin_not_running",
+        "请先登录并打开微信，再使用微信原生语音转文字。",
+    ),
+    NativeCoreAsrReason.WECHAT_NOT_LOGGED_IN: (
+        "native_weixin_not_running",
+        "请先登录并进入微信，再使用微信原生语音转文字。",
+    ),
+    NativeCoreAsrReason.ACCOUNT_UNVERIFIED: (
+        "native_trigger_rejected",
+        "无法确认当前项目账号与已登录微信账号一致。",
+    ),
+    NativeCoreAsrReason.ACCOUNT_MISMATCH: (
+        "native_trigger_rejected",
+        "当前项目账号与已登录微信账号不一致。",
+    ),
+    NativeCoreAsrReason.WECHAT_VERSION_MISMATCH: (
+        "native_weixin_version_unsupported",
+        "当前微信版本不受支持。请使用微信 4.1.12.26，并完全退出、重新启动微信后再试。",
+    ),
+    NativeCoreAsrReason.WEIXIN_SHA256_MISMATCH: (
+        "native_weixin_version_unsupported",
+        "当前微信版本不受支持。请使用微信 4.1.12.26，并完全退出、重新启动微信后再试。",
+    ),
+    NativeCoreAsrReason.BRIDGE_RESTART_REQUIRED: (
+        "native_trigger_rejected",
+        "微信原生语音转文字桥接状态已失效。请完全退出微信，重启本应用（开发模式下同时重启后端）后，再重新打开并登录微信。",
+    ),
+    NativeCoreAsrReason.BUSY: (
+        "native_transport_busy",
+        "已有微信原生语音转文字任务正在处理，请稍后再试。",
+    ),
+    NativeCoreAsrReason.MESSAGE_NOT_FOUND: (
+        "voice_message_not_found",
+        "微信未找到指定的语音消息。",
+    ),
+    NativeCoreAsrReason.MESSAGE_AMBIGUOUS: (
+        "voice_message_ambiguous",
+        "微信内部匹配到多条语音消息，已停止转写。",
+    ),
+    NativeCoreAsrReason.NOT_VOICE: (
+        "native_trigger_rejected",
+        "指定消息不是可转写的微信语音。",
+    ),
+    NativeCoreAsrReason.PROVIDER_UNAVAILABLE: (
+        "native_trigger_rejected",
+        "微信原生语音转文字服务当前不可用。",
+    ),
+    NativeCoreAsrReason.DISPATCH_FAILED: (
+        "native_trigger_rejected",
+        "微信未能提交原生语音转文字任务。",
+    ),
+    NativeCoreAsrReason.CALLBACK_FAILED: (
+        "native_transcript_failed",
+        "微信原生语音转文字未能返回结果。",
+    ),
+    NativeCoreAsrReason.TIMEOUT: (
+        "native_trigger_timeout",
+        "等待微信原生语音转文字结果超时。",
+    ),
+    NativeCoreAsrReason.CANCELLED: (
+        "native_transcript_failed",
+        "微信原生语音转文字任务已取消。",
+    ),
+    NativeCoreAsrReason.INTERNAL: (
+        "native_transport_failed",
+        "微信原生语音转文字内部调用失败。",
+    ),
+}
+
+
+def _reason_error(reason: NativeCoreAsrReason) -> NativeVoiceTriggerError:
+    code, message = _ERROR_DETAILS.get(
+        reason,
+        ("native_transport_failed", "微信原生语音转文字调用失败。"),
+    )
+    return NativeVoiceTriggerError(code, message)
+
+
+_NATIVE_ASR_AUTHORIZATION_STATUSES = {
+    NativeCoreStatus.LICENSE_REQUIRED,
+    NativeCoreStatus.LEASE_INVALID,
+    NativeCoreStatus.LEASE_EXPIRED,
+    NativeCoreStatus.FEATURE_DENIED,
+}
+_NATIVE_ASR_INTEGRITY_STATUSES = {
+    NativeCoreStatus.BUILD_MISMATCH,
+    NativeCoreStatus.DEVICE_MISMATCH,
+    NativeCoreStatus.TAMPER_DETECTED,
+}
+
+
+def _native_core_status_error(
+    status: int | NativeCoreStatus | None,
+    *,
+    include_generic: bool,
+) -> NativeVoiceTriggerError | None:
+    try:
+        known = NativeCoreStatus(status) if status is not None else None
+    except (TypeError, ValueError):
+        known = None
+    if known is None:
+        return None
+    if known is NativeCoreStatus.BUSY:
+        return NativeVoiceTriggerError(
+            "native_transport_busy",
+            "已有微信原生语音转文字任务正在处理，请稍后再试。",
+        )
+    if known is NativeCoreStatus.TIMEOUT:
+        return NativeVoiceTriggerError(
+            "native_trigger_timeout",
+            "等待微信原生语音转文字结果超时。",
+        )
+    if known in _NATIVE_ASR_AUTHORIZATION_STATUSES:
+        return NativeVoiceTriggerError(
+            "native_asr_not_authorized",
+            "当前授权未包含微信原生语音转文字功能，或授权已过期。",
+        )
+    if known in _NATIVE_ASR_INTEGRITY_STATUSES:
+        return NativeVoiceTriggerError(
+            "native_transport_unavailable",
+            "受保护的微信原生语音转文字组件与当前构建或设备不匹配。",
+        )
+    if known in {NativeCoreStatus.PROTOCOL, NativeCoreStatus.INVALID_ARGUMENT}:
+        return NativeVoiceTriggerError(
+            "native_transport_invalid_response",
+            "受保护的微信原生语音转文字组件返回了无效响应。",
+        )
+    if not include_generic:
+        return None
+    if known in {
+        NativeCoreStatus.UNAVAILABLE,
+        NativeCoreStatus.IO,
+        NativeCoreStatus.UNSUPPORTED,
+    }:
+        return NativeVoiceTriggerError(
+            "native_transport_unavailable",
+            "当前构建中的受保护微信原生语音转文字组件不可用。",
+        )
+    return NativeVoiceTriggerError(
+        "native_transport_failed",
+        "受保护的微信原生语音转文字调用失败。",
+    )
+
+
+def _native_core_error(exc: BaseException) -> NativeVoiceTriggerError:
+    if isinstance(exc, NativeCoreError):
+        mapped = _native_core_status_error(exc.status, include_generic=True)
+        if mapped is not None:
+            return mapped
+    if isinstance(exc, NativeCorePolicyError):
+        return NativeVoiceTriggerError(
+            "native_asr_not_authorized",
+            "当前授权未包含微信原生语音转文字功能，或授权已过期。",
+        )
+    if isinstance(exc, (NativeCoreUnavailableError, NativeCoreProtocolError)):
+        return NativeVoiceTriggerError(
+            "native_transport_unavailable",
+            "当前构建中的受保护微信原生语音转文字组件不可用。",
+        )
+    return NativeVoiceTriggerError(
+        "native_transport_failed",
+        "微信原生语音转文字调用失败。",
+    )
+
+
+def native_core_voice_asr_status(account_dir: Optional[Path] = None) -> dict[str, object]:
+    """Passively inspect readiness through the licensed native-core broker."""
+
+    result: dict[str, object] = {
+        "available": False,
+        "reason": "",
+        "version": _EXPECTED_WECHAT_VERSION,
+        "pid": None,
+    }
+    if os.name != "nt" or not sys.platform.startswith("win"):
+        result["reason"] = "unsupported_platform"
+        return result
+    if account_dir is None:
+        result["reason"] = "active_account_unverified"
+        return result
+    if _TRANSPORT.restart_required:
+        result["reason"] = "bridge_restart_required"
+        return result
+    operation: NativeCoreManagedOperation | None = None
+    try:
+        operation = managed_native_core_operation()
+        client = get_native_core_client()
+        if not client.supports_native_asr:
+            result["reason"] = "bridge_manager_unavailable"
+            return result
+        account_path = Path(account_dir)
+        status = client.get_native_asr_status(
+            resolve_account_self_username(account_path),
+            account_path,
+        )
+        reason = _STATUS_REASON_KEYS.get(status.reason, "bridge_manager_unavailable")
+        result.update(
+            {
+                "available": bool(status.ready and status.reason is NativeCoreAsrReason.READY),
+                "reason": reason,
+                "version": status.expected_wechat_version or _EXPECTED_WECHAT_VERSION,
+                "pid": status.wechat_process_id or None,
+            }
+        )
+        return result
+    except NativeCorePolicyError:
+        result["reason"] = "bridge_manager_unavailable"
+        return result
+    except (NativeCoreError, OSError, ValueError):
+        result["reason"] = "inspection_failed"
+        return result
+    finally:
+        if operation is not None:
+            operation.close()
+
+
+@dataclass
+class _ActiveRequest:
+    command: NativeVoiceTriggerCommand
+    request_id: str
+    request_handle: int
+    client: NativeCoreClient
+    operation: NativeCoreManagedOperation
+    cleanup_failed: bool = False
+
+
+class NativeCoreVoiceAsrTransport:
+    """One-at-a-time native-core ASR transport with a bounded poll worker."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._active: _ActiveRequest | None = None
+
+    @property
+    def restart_required(self) -> bool:
+        with self._lock:
+            return bool(self._active is not None and self._active.cleanup_failed)
+
+    @staticmethod
+    def _key(command: NativeVoiceTriggerCommand) -> tuple[str, str, int, int]:
+        return (
+            os.path.normcase(os.path.abspath(os.fspath(command.account_dir))),
+            command.conversation,
+            int(command.server_id),
+            int(command.local_id),
+        )
+
+    @staticmethod
+    def _close_native_handle(client: NativeCoreClient, request_handle: int) -> bool:
+        for attempt in range(len(_CLOSE_RETRY_DELAYS_SECONDS) + 1):
+            try:
+                client.close_native_asr(request_handle)
+                return True
+            except Exception:
+                if attempt < len(_CLOSE_RETRY_DELAYS_SECONDS):
+                    time.sleep(_CLOSE_RETRY_DELAYS_SECONDS[attempt])
+        return False
+
+    def _finish_active(self, active: _ActiveRequest) -> bool:
+        if not self._close_native_handle(active.client, active.request_handle):
+            with self._lock:
+                active.cleanup_failed = True
+                if self._active is None:
+                    self._active = active
+            return False
+        with self._lock:
+            if self._active is active:
+                self._active = None
+        active.operation.close()
+        return True
+
+    @staticmethod
+    def _cleanup_failure_error() -> NativeVoiceTriggerError:
+        return NativeVoiceTriggerError(
+            "native_trigger_rejected",
+            "微信原生语音转文字桥接清理失败。请完全退出微信，重启本应用（开发模式下同时重启后端）后，再重新打开并登录微信。",
+        )
+
+    def trigger(self, command: NativeVoiceTriggerCommand) -> NativeVoiceTriggerReceipt:
+        with self._lock:
+            if self._active is not None:
+                if self._active.cleanup_failed:
+                    raise self._cleanup_failure_error()
+                if self._key(self._active.command) == self._key(command):
+                    return NativeVoiceTriggerReceipt(
+                        status="pending", request_id=self._active.request_id
+                    )
+                raise _reason_error(NativeCoreAsrReason.BUSY)
+
+            operation: NativeCoreManagedOperation | None = None
+            request_handle = 0
+            client: NativeCoreClient | None = None
+            request_id = ""
+            active: _ActiveRequest | None = None
+            try:
+                operation = managed_native_core_operation()
+                client = get_native_core_client()
+                if not client.supports_native_asr:
+                    raise NativeVoiceTriggerError(
+                        "native_transport_unavailable",
+                        "当前受保护的 native-core 运行时不包含微信原生语音转文字功能。",
+                    )
+                status = client.get_native_asr_status(
+                    command.account, command.account_dir
+                )
+                if not status.ready or status.reason is not NativeCoreAsrReason.READY:
+                    raise _reason_error(status.reason)
+                refresh_native_core_lease(
+                    client,
+                    NativeCoreFeature.NATIVE_ASR,
+                    minimum_validity_seconds=_LEASE_MINIMUM_VALIDITY_SECONDS,
+                )
+                request_handle = client.begin_native_asr(
+                    command.account,
+                    command.account_dir,
+                    command.conversation,
+                    command.server_id,
+                    command.local_id,
+                )
+                request_id = "native-core:" + secrets.token_urlsafe(24)
+                active = _ActiveRequest(
+                    command=command,
+                    request_id=request_id,
+                    request_handle=request_handle,
+                    client=client,
+                    operation=operation,
+                )
+                request_handle = 0
+                cached = mark_native_voice_transcript_pending(
+                    account_dir=command.account_dir,
+                    conversation=command.conversation,
+                    server_id=command.server_id,
+                    local_id=command.local_id,
+                    request_id=request_id,
+                )
+                if cached.status != "pending" or cached.request_id != request_id:
+                    if not self._finish_active(active):
+                        operation = None
+                        active = None
+                        raise self._cleanup_failure_error()
+                    operation = None
+                    active = None
+                    if cached.request_id and cached.status in {"pending", "success"}:
+                        return NativeVoiceTriggerReceipt(
+                            status="pending", request_id=cached.request_id
+                        )
+                    raise NativeVoiceTriggerError(
+                        "native_transport_invalid_response",
+                        "微信原生语音转文字缓存代际发生冲突。",
+                    )
+                self._active = active
+                operation = None
+                worker = threading.Thread(
+                    target=self._poll_worker,
+                    args=(active,),
+                    name="wechat-native-asr-poll",
+                    daemon=True,
+                )
+                worker.start()
+                return NativeVoiceTriggerReceipt(
+                    status="accepted", request_id=request_id
+                )
+            except NativeVoiceTriggerError as exc:
+                if active is not None:
+                    if not self._finish_active(active):
+                        operation = None
+                        raise self._cleanup_failure_error() from exc
+                    operation = None
+                elif client is not None and request_handle:
+                    if not self._close_native_handle(client, request_handle):
+                        retained = _ActiveRequest(
+                            command=command,
+                            request_id=request_id or "native-core:cleanup-failed",
+                            request_handle=request_handle,
+                            client=client,
+                            operation=operation,
+                            cleanup_failed=True,
+                        )
+                        self._active = retained
+                        operation = None
+                        raise self._cleanup_failure_error() from exc
+                raise
+            except Exception as exc:
+                if active is not None:
+                    if not self._finish_active(active):
+                        operation = None
+                        raise self._cleanup_failure_error() from exc
+                    operation = None
+                elif client is not None and request_handle:
+                    if not self._close_native_handle(client, request_handle):
+                        retained = _ActiveRequest(
+                            command=command,
+                            request_id=request_id or "native-core:cleanup-failed",
+                            request_handle=request_handle,
+                            client=client,
+                            operation=operation,
+                            cleanup_failed=True,
+                        )
+                        self._active = retained
+                        operation = None
+                        raise self._cleanup_failure_error() from exc
+                raise _native_core_error(exc) from exc
+            finally:
+                if operation is not None:
+                    operation.close()
+
+    def _store_error(
+        self,
+        active: _ActiveRequest,
+        error: NativeVoiceTriggerError,
+    ) -> None:
+        mark_native_voice_transcript_error(
+            account_dir=active.command.account_dir,
+            conversation=active.command.conversation,
+            server_id=active.command.server_id,
+            local_id=active.command.local_id,
+            request_id=active.request_id,
+            error_code=error.code,
+            error_message=error.user_message,
+        )
+
+    def _poll_worker(self, active: _ActiveRequest) -> None:
+        deadline = time.monotonic() + _POLL_TIMEOUT_SECONDS
+        try:
+            while True:
+                poll = active.client.poll_native_asr(active.request_handle)
+                if (
+                    poll.server_id != active.command.server_id
+                    or poll.local_id != active.command.local_id
+                ):
+                    raise NativeVoiceTriggerError(
+                        "native_transport_invalid_response",
+                        "微信原生语音转文字返回的消息身份不匹配。",
+                    )
+                if poll.state is NativeCoreAsrRequestState.SUCCEEDED:
+                    mark_native_voice_transcript_success(
+                        account_dir=active.command.account_dir,
+                        conversation=active.command.conversation,
+                        server_id=active.command.server_id,
+                        local_id=active.command.local_id,
+                        request_id=active.request_id,
+                        text=poll.text,
+                    )
+                    return
+                if poll.state in {
+                    NativeCoreAsrRequestState.FAILED,
+                    NativeCoreAsrRequestState.CANCELLED,
+                }:
+                    error = _native_core_status_error(
+                        poll.terminal_status,
+                        include_generic=False,
+                    ) or _reason_error(poll.reason)
+                    self._store_error(active, error)
+                    return
+                if time.monotonic() >= deadline:
+                    self._store_error(active, _reason_error(NativeCoreAsrReason.TIMEOUT))
+                    return
+                time.sleep(_POLL_INTERVAL_SECONDS)
+        except NativeVoiceTriggerError as exc:
+            self._store_error(active, exc)
+        except Exception as exc:
+            self._store_error(active, _native_core_error(exc))
+        finally:
+            self._finish_active(active)
+
+
+_TRANSPORT = NativeCoreVoiceAsrTransport()
+
+
+def build_native_core_voice_asr_transport() -> NativeCoreVoiceAsrTransport:
+    return _TRANSPORT
+
+
+__all__ = [
+    "NativeCoreVoiceAsrTransport",
+    "build_native_core_voice_asr_transport",
+    "native_core_voice_asr_status",
+]

--- a/src/wechat_decrypt_tool/native_voice_transcription.py
+++ b/src/wechat_decrypt_tool/native_voice_transcription.py
@@ -1,0 +1,915 @@
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import re
+import sqlite3
+import threading
+import time
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional, Protocol
+
+from .account_identity import resolve_account_self_username
+from .account_source_policy import account_prefers_decrypted_snapshot
+from .chat_helpers import _extract_voice_transcript_from_packed_info
+from .voice_transcription import _numbered_db_shards
+
+
+_MAX_WECHAT_SERVER_ID = (1 << 64) - 1
+_MAX_WECHAT_LOCAL_ID = (1 << 32) - 1
+_POSITIVE_DECIMAL_ID = re.compile(r"^[1-9][0-9]*$")
+_TRIGGER_RECEIPT_STATUSES = frozenset({"accepted", "pending"})
+_NATIVE_TRANSCRIPT_CACHE_LOCK = threading.RLock()
+_NATIVE_TRANSCRIPT_PENDING_TTL_SECONDS = 120.0
+_NATIVE_TRANSCRIPT_ERROR_TTL_SECONDS = 300.0
+_MAX_NATIVE_TRANSCRIPT_BYTES = 64 * 1024
+_MAX_NATIVE_REQUEST_ID_BYTES = 256
+_MAX_NATIVE_ERROR_CODE_BYTES = 128
+_MAX_NATIVE_ERROR_MESSAGE_BYTES = 2048
+
+
+class NativeVoiceTriggerError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = str(code or "native_trigger_failed")
+        self.user_message = str(message or "微信原生语音转写触发失败。")
+
+
+@dataclass(frozen=True)
+class NativeVoiceTriggerCommand:
+    account_dir: Path
+    account: str
+    conversation: str
+    server_id: int
+    local_id: int = 0
+
+
+@dataclass(frozen=True)
+class NativeVoiceTriggerReceipt:
+    status: Literal["accepted", "pending"]
+    request_id: str = ""
+
+
+@dataclass(frozen=True)
+class NativeVoiceTranscriptCacheEntry:
+    account_dir: Path
+    conversation: str
+    server_id: int
+    local_id: int
+    status: Literal["pending", "success", "error"]
+    request_id: str
+    text: str
+    error_code: str
+    error_message: str
+    updated_at: float
+    expires_at: Optional[float]
+
+
+class NativeVoiceTriggerTransport(Protocol):
+    def trigger(self, command: NativeVoiceTriggerCommand) -> NativeVoiceTriggerReceipt:
+        """Dispatch one bounded request; transcript polling belongs to the caller."""
+
+
+class UnavailableNativeVoiceTriggerTransport:
+    """Fail closed until the version-locked Win32 bridge is wired in."""
+
+    def trigger(self, _command: NativeVoiceTriggerCommand) -> NativeVoiceTriggerReceipt:
+        raise NativeVoiceTriggerError(
+            "native_transport_unavailable",
+            "微信原生语音转写桥接尚未接入当前构建。",
+        )
+
+
+_UNAVAILABLE_TRANSPORT = UnavailableNativeVoiceTriggerTransport()
+
+
+def get_native_voice_trigger_transport() -> NativeVoiceTriggerTransport:
+    try:
+        from .native_core_voice_asr import build_native_core_voice_asr_transport
+
+        transport = build_native_core_voice_asr_transport()
+        if transport is not None:
+            return transport
+    except Exception:
+        # Artifact discovery is intentionally fail-closed; trigger-time errors
+        # are surfaced by the real transport as NativeVoiceTriggerError.
+        pass
+    return _UNAVAILABLE_TRANSPORT
+
+
+def parse_native_voice_message_id(value: Optional[str], field_name: str) -> int:
+    """Parse an exact decimal string without accepting JSON numbers or coercion."""
+
+    if value is None:
+        return 0
+    if not isinstance(value, str) or not _POSITIVE_DECIMAL_ID.fullmatch(value):
+        raise NativeVoiceTriggerError(
+            "invalid_message_id",
+            f"{field_name} 必须是正整数十进制字符串。",
+        )
+    parsed = int(value)
+    maximum = _MAX_WECHAT_LOCAL_ID if field_name == "local_id" else _MAX_WECHAT_SERVER_ID
+    if parsed > maximum:
+        raise NativeVoiceTriggerError(
+            "invalid_message_id",
+            f"{field_name} 超出微信消息 ID 范围。",
+        )
+    return parsed
+
+
+def normalize_native_voice_conversation(value: str) -> str:
+    if not isinstance(value, str):
+        raise NativeVoiceTriggerError("invalid_conversation", "username 必须是字符串。")
+    conversation = value.strip()
+    if not conversation:
+        raise NativeVoiceTriggerError("invalid_conversation", "缺少 username。")
+    if "\x00" in conversation or len(conversation.encode("utf-8")) > 1024:
+        raise NativeVoiceTriggerError("invalid_conversation", "username 格式无效。")
+    return conversation
+
+
+def _native_voice_cache_path(account_dir: Path) -> Path:
+    return Path(account_dir) / "_cache" / "native_voice_transcripts.sqlite3"
+
+
+def _native_voice_cache_account_key(account_dir: Path) -> str:
+    try:
+        path = str(Path(account_dir).resolve(strict=False))
+    except OSError:
+        path = str(Path(account_dir).absolute())
+    return os.path.normcase(path)
+
+
+def _normalize_native_cache_id(value: int, *, field_name: str, allow_zero: bool) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer")
+    minimum = 0 if allow_zero else 1
+    maximum = _MAX_WECHAT_LOCAL_ID if field_name == "local_id" else _MAX_WECHAT_SERVER_ID
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{field_name} is outside the WeChat message ID range")
+    return value
+
+
+def _normalize_native_cache_string(
+    value: str,
+    *,
+    field_name: str,
+    maximum_bytes: int,
+    required: bool,
+) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    normalized = unicodedata.normalize("NFC", value).strip()
+    if "\x00" in normalized:
+        raise ValueError(f"{field_name} contains a NUL character")
+    if required and not normalized:
+        raise ValueError(f"{field_name} must not be empty")
+    if len(normalized.encode("utf-8")) > maximum_bytes:
+        raise ValueError(f"{field_name} is too large")
+    return normalized
+
+
+def _normalize_native_request_id(value: str) -> str:
+    normalized = _normalize_native_cache_string(
+        value,
+        field_name="request_id",
+        maximum_bytes=_MAX_NATIVE_REQUEST_ID_BYTES,
+        required=True,
+    )
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in normalized):
+        raise ValueError("request_id contains a control character")
+    return normalized
+
+
+def _normalize_native_transcript_text(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("text must be a string")
+    return _normalize_native_cache_string(
+        value.replace("\r\n", "\n").replace("\r", "\n"),
+        field_name="text",
+        maximum_bytes=_MAX_NATIVE_TRANSCRIPT_BYTES,
+        required=True,
+    )
+
+
+def _native_voice_cache_expiry(updated_at: float, ttl_seconds: Optional[float]) -> Optional[float]:
+    if ttl_seconds is None:
+        return None
+    ttl = float(ttl_seconds)
+    if not math.isfinite(ttl) or ttl <= 0:
+        raise ValueError("ttl_seconds must be a positive finite number")
+    return updated_at + ttl
+
+
+def _open_native_voice_cache(account_dir: Path, *, create: bool) -> Optional[sqlite3.Connection]:
+    cache_path = _native_voice_cache_path(account_dir)
+    if not create and not cache_path.is_file():
+        return None
+    if create:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(cache_path), timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 5000")
+    if create:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS native_voice_transcript (
+                account_key TEXT NOT NULL,
+                conversation TEXT NOT NULL,
+                server_id TEXT NOT NULL,
+                local_id INTEGER NOT NULL,
+                status TEXT NOT NULL CHECK (status IN ('pending', 'success', 'error')),
+                request_id TEXT NOT NULL,
+                text TEXT NOT NULL,
+                error_code TEXT NOT NULL,
+                error_message TEXT NOT NULL,
+                updated_at REAL NOT NULL,
+                expires_at REAL,
+                PRIMARY KEY (account_key, conversation, server_id, local_id)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS native_voice_transcript_server_idx "
+            "ON native_voice_transcript (account_key, server_id, updated_at DESC)"
+        )
+        conn.commit()
+    return conn
+
+
+def _native_voice_cache_entry_from_row(
+    account_dir: Path,
+    row: sqlite3.Row,
+) -> NativeVoiceTranscriptCacheEntry:
+    expires_at = row["expires_at"]
+    return NativeVoiceTranscriptCacheEntry(
+        account_dir=Path(account_dir),
+        conversation=str(row["conversation"]),
+        server_id=int(row["server_id"]),
+        local_id=int(row["local_id"]),
+        status=str(row["status"]),  # type: ignore[arg-type]
+        request_id=str(row["request_id"]),
+        text=str(row["text"]),
+        error_code=str(row["error_code"]),
+        error_message=str(row["error_message"]),
+        updated_at=float(row["updated_at"]),
+        expires_at=float(expires_at) if expires_at is not None else None,
+    )
+
+
+def _write_native_voice_transcript_cache(
+    *,
+    account_dir: Path,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+    status: Literal["pending", "success", "error"],
+    request_id: str,
+    text: str = "",
+    error_code: str = "",
+    error_message: str = "",
+    ttl_seconds: Optional[float],
+) -> NativeVoiceTranscriptCacheEntry:
+    account_path = Path(account_dir)
+    account_key = _native_voice_cache_account_key(account_path)
+    resolved_conversation = normalize_native_voice_conversation(conversation)
+    resolved_server_id = _normalize_native_cache_id(
+        server_id,
+        field_name="server_id",
+        allow_zero=False,
+    )
+    resolved_local_id = _normalize_native_cache_id(
+        local_id,
+        field_name="local_id",
+        allow_zero=True,
+    )
+    resolved_request_id = _normalize_native_request_id(request_id)
+    resolved_text = _normalize_native_transcript_text(text) if status == "success" else ""
+    resolved_error_code = (
+        _normalize_native_cache_string(
+            error_code,
+            field_name="error_code",
+            maximum_bytes=_MAX_NATIVE_ERROR_CODE_BYTES,
+            required=True,
+        )
+        if status == "error"
+        else ""
+    )
+    resolved_error_message = (
+        _normalize_native_cache_string(
+            error_message,
+            field_name="error_message",
+            maximum_bytes=_MAX_NATIVE_ERROR_MESSAGE_BYTES,
+            required=False,
+        )
+        if status == "error"
+        else ""
+    )
+    updated_at = time.time()
+    expires_at = _native_voice_cache_expiry(updated_at, ttl_seconds)
+    key_params = (
+        account_key,
+        resolved_conversation,
+        str(resolved_server_id),
+        resolved_local_id,
+    )
+
+    with _NATIVE_TRANSCRIPT_CACHE_LOCK:
+        conn = _open_native_voice_cache(account_path, create=True)
+        assert conn is not None
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT * FROM native_voice_transcript "
+                "WHERE account_key = ? AND conversation = ? AND server_id = ? AND local_id = ?",
+                key_params,
+            ).fetchone()
+            current = _native_voice_cache_entry_from_row(account_path, row) if row else None
+            current_is_live = bool(
+                current is not None
+                and (current.expires_at is None or current.expires_at > updated_at)
+            )
+
+            # A synchronous callback may win the race against the caller writing
+            # pending. Never downgrade a completed result, and never let a stale
+            # callback overwrite a different in-flight request for the same row.
+            preserve_current = bool(
+                current_is_live
+                and (
+                    current.status == "success"
+                    or (
+                        status == "pending"
+                        and current.status in {"pending", "error"}
+                        and current.request_id == resolved_request_id
+                    )
+                    or (
+                        status != "pending"
+                        and current.request_id != resolved_request_id
+                    )
+                )
+            )
+            if preserve_current:
+                conn.commit()
+                assert current is not None
+                return current
+
+            conn.execute(
+                """
+                INSERT INTO native_voice_transcript (
+                    account_key, conversation, server_id, local_id, status,
+                    request_id, text, error_code, error_message, updated_at, expires_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (account_key, conversation, server_id, local_id) DO UPDATE SET
+                    status = excluded.status,
+                    request_id = excluded.request_id,
+                    text = excluded.text,
+                    error_code = excluded.error_code,
+                    error_message = excluded.error_message,
+                    updated_at = excluded.updated_at,
+                    expires_at = excluded.expires_at
+                """,
+                (
+                    *key_params,
+                    status,
+                    resolved_request_id,
+                    resolved_text,
+                    resolved_error_code,
+                    resolved_error_message,
+                    updated_at,
+                    expires_at,
+                ),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+    return NativeVoiceTranscriptCacheEntry(
+        account_dir=account_path,
+        conversation=resolved_conversation,
+        server_id=resolved_server_id,
+        local_id=resolved_local_id,
+        status=status,
+        request_id=resolved_request_id,
+        text=resolved_text,
+        error_code=resolved_error_code,
+        error_message=resolved_error_message,
+        updated_at=updated_at,
+        expires_at=expires_at,
+    )
+
+
+def mark_native_voice_transcript_pending(
+    *,
+    account_dir: Path,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+    request_id: str,
+    ttl_seconds: float = _NATIVE_TRANSCRIPT_PENDING_TTL_SECONDS,
+) -> NativeVoiceTranscriptCacheEntry:
+    return _write_native_voice_transcript_cache(
+        account_dir=account_dir,
+        conversation=conversation,
+        server_id=server_id,
+        local_id=local_id,
+        status="pending",
+        request_id=request_id,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def mark_native_voice_transcript_success(
+    *,
+    account_dir: Path,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+    request_id: str,
+    text: str,
+    ttl_seconds: Optional[float] = None,
+) -> NativeVoiceTranscriptCacheEntry:
+    return _write_native_voice_transcript_cache(
+        account_dir=account_dir,
+        conversation=conversation,
+        server_id=server_id,
+        local_id=local_id,
+        status="success",
+        request_id=request_id,
+        text=text,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def mark_native_voice_transcript_error(
+    *,
+    account_dir: Path,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+    request_id: str,
+    error_code: str,
+    error_message: str = "",
+    ttl_seconds: float = _NATIVE_TRANSCRIPT_ERROR_TTL_SECONDS,
+) -> NativeVoiceTranscriptCacheEntry:
+    return _write_native_voice_transcript_cache(
+        account_dir=account_dir,
+        conversation=conversation,
+        server_id=server_id,
+        local_id=local_id,
+        status="error",
+        request_id=request_id,
+        error_code=error_code,
+        error_message=error_message,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def lookup_native_voice_transcript_cache(
+    account_dir: Path,
+    server_id: int,
+    *,
+    conversation: str = "",
+    local_id: int = 0,
+    request_id: str = "",
+    now: Optional[float] = None,
+    include_expired: bool = False,
+    strict: bool = False,
+) -> Optional[NativeVoiceTranscriptCacheEntry]:
+    account_path = Path(account_dir)
+    account_key = _native_voice_cache_account_key(account_path)
+    resolved_server_id = _normalize_native_cache_id(
+        server_id,
+        field_name="server_id",
+        allow_zero=False,
+    )
+    resolved_local_id = _normalize_native_cache_id(
+        local_id,
+        field_name="local_id",
+        allow_zero=True,
+    )
+    resolved_conversation = (
+        normalize_native_voice_conversation(conversation) if conversation else ""
+    )
+    resolved_request_id = (
+        _normalize_native_request_id(request_id)
+        if request_id
+        else ""
+    )
+    current_time = time.time() if now is None else float(now)
+    if not math.isfinite(current_time):
+        raise ValueError("now must be finite")
+
+    sql = (
+        "SELECT * FROM native_voice_transcript "
+        "WHERE account_key = ? AND server_id = ?"
+    )
+    params: list[object] = [account_key, str(resolved_server_id)]
+    if not include_expired:
+        sql += " AND (expires_at IS NULL OR expires_at > ?)"
+        params.append(current_time)
+    if resolved_conversation:
+        sql += " AND conversation = ?"
+        params.append(resolved_conversation)
+    if resolved_local_id > 0:
+        sql += " AND local_id = ?"
+        params.append(resolved_local_id)
+    if resolved_request_id:
+        sql += " AND request_id = ?"
+        params.append(resolved_request_id)
+    sql += " ORDER BY updated_at DESC LIMIT 1"
+
+    with _NATIVE_TRANSCRIPT_CACHE_LOCK:
+        try:
+            conn = _open_native_voice_cache(account_path, create=False)
+        except (OSError, sqlite3.Error) as exc:
+            if strict:
+                raise NativeVoiceTriggerError(
+                    "native_result_store_unavailable",
+                    "微信原生语音转写结果缓存暂时不可用。",
+                ) from exc
+            return None
+        if conn is None:
+            return None
+        try:
+            row = conn.execute(sql, tuple(params)).fetchone()
+            return _native_voice_cache_entry_from_row(account_path, row) if row else None
+        except (TypeError, ValueError, sqlite3.Error) as exc:
+            if strict:
+                raise NativeVoiceTriggerError(
+                    "native_result_store_unavailable",
+                    "微信原生语音转写结果缓存暂时不可用。",
+                ) from exc
+            return None
+        finally:
+            conn.close()
+
+
+def lookup_cached_native_voice_transcript(
+    account_dir: Path,
+    server_id: int,
+    *,
+    conversation: str = "",
+    local_id: int = 0,
+    request_id: str = "",
+    strict: bool = False,
+) -> str:
+    entry = lookup_native_voice_transcript_cache(
+        account_dir,
+        server_id,
+        conversation=conversation,
+        local_id=local_id,
+        request_id=request_id,
+        strict=strict,
+    )
+    return entry.text if entry is not None and entry.status == "success" else ""
+
+
+def _message_db_paths(root: Path, conversation: str) -> list[Path]:
+    normal = _numbered_db_shards(root, "message")
+    business = _numbered_db_shards(root, "biz_message")
+    return (business + normal) if conversation.startswith("gh_") else (normal + business)
+
+
+@dataclass
+class _VoiceTargetQueryResult:
+    rows: set[tuple[int, int]]
+    transcripts: dict[tuple[int, int], str]
+    successful_queries: int
+    failures: list[str]
+
+
+def _target_where_sql(*, server_id: int, local_id: int, parameterized: bool) -> tuple[str, tuple[int, ...]]:
+    clauses: list[str] = []
+    values: list[int] = []
+    for column, value in (("server_id", server_id), ("local_id", local_id)):
+        if int(value) <= 0:
+            continue
+        clauses.append(f"{column} = {'?' if parameterized else int(value)}")
+        values.append(int(value))
+    return " OR ".join(clauses), tuple(values)
+
+
+def _query_local_voice_targets(
+    account_dir: Path,
+    *,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+) -> _VoiceTargetQueryResult:
+    table_name = f"Msg_{hashlib.md5(conversation.encode('utf-8')).hexdigest()}"
+    quoted_table = '"' + table_name.replace('"', '""') + '"'
+    targets: set[tuple[int, int]] = set()
+    transcripts: dict[tuple[int, int], str] = {}
+    successful_queries = 0
+    failures: list[str] = []
+    where_sql, params = _target_where_sql(
+        server_id=server_id,
+        local_id=local_id,
+        parameterized=True,
+    )
+    for db_path in _message_db_paths(Path(account_dir), conversation):
+        conn: Optional[sqlite3.Connection] = None
+        try:
+            conn = sqlite3.connect(str(db_path))
+            table_row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND lower(name)=lower(?) LIMIT 1",
+                (table_name,),
+            ).fetchone()
+            if not table_row:
+                successful_queries += 1
+                continue
+            try:
+                rows = conn.execute(
+                    f"SELECT local_id, server_id, packed_info_data FROM {quoted_table} "
+                    f"WHERE local_type = 34 AND ({where_sql}) LIMIT 4",
+                    params,
+                )
+            except sqlite3.OperationalError:
+                rows = conn.execute(
+                    f"SELECT local_id, server_id, NULL AS packed_info_data FROM {quoted_table} "
+                    f"WHERE local_type = 34 AND ({where_sql}) LIMIT 4",
+                    params,
+                )
+            for row_local_id, row_server_id, packed_info in rows:
+                target = (int(row_local_id or 0), int(row_server_id or 0))
+                targets.add(target)
+                text = _extract_voice_transcript_from_packed_info(packed_info)
+                if text:
+                    transcripts[target] = text
+            successful_queries += 1
+        except Exception as exc:
+            failures.append(f"local:{db_path.name}:{type(exc).__name__}")
+            continue
+        finally:
+            if conn is not None:
+                conn.close()
+    return _VoiceTargetQueryResult(targets, transcripts, successful_queries, failures)
+
+
+def _query_realtime_voice_targets(
+    account_dir: Path,
+    *,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+) -> _VoiceTargetQueryResult:
+    targets: set[tuple[int, int]] = set()
+    transcripts: dict[tuple[int, int], str] = {}
+    successful_queries = 0
+    failures: list[str] = []
+    try:
+        from .wcdb_realtime import WCDB_REALTIME, exec_query as wcdb_exec_query
+
+        realtime = WCDB_REALTIME.ensure_connected(Path(account_dir))
+        message_dir = Path(realtime.db_storage_dir) / "message"
+        table_name = f"Msg_{hashlib.md5(conversation.encode('utf-8')).hexdigest()}"
+        quoted_table = '"' + table_name.replace('"', '""') + '"'
+        where_sql, _params = _target_where_sql(
+            server_id=server_id,
+            local_id=local_id,
+            parameterized=False,
+        )
+        for db_path in _message_db_paths(message_dir, conversation):
+            try:
+                with realtime.lock:
+                    table_rows = wcdb_exec_query(
+                        realtime.handle,
+                        kind="message",
+                        path=str(db_path),
+                        sql=(
+                            "SELECT name FROM sqlite_master WHERE type='table' AND lower(name)=lower("
+                            f"'{table_name}') LIMIT 1"
+                        ),
+                    )
+                if not table_rows:
+                    successful_queries += 1
+                    continue
+                try:
+                    with realtime.lock:
+                        rows = wcdb_exec_query(
+                            realtime.handle,
+                            kind="message",
+                            path=str(db_path),
+                            sql=(
+                                f"SELECT local_id, server_id, packed_info_data FROM {quoted_table} "
+                                f"WHERE local_type = 34 AND ({where_sql}) LIMIT 4"
+                            ),
+                        )
+                except Exception:
+                    with realtime.lock:
+                        rows = wcdb_exec_query(
+                            realtime.handle,
+                            kind="message",
+                            path=str(db_path),
+                            sql=(
+                                f"SELECT local_id, server_id, NULL AS packed_info_data FROM {quoted_table} "
+                                f"WHERE local_type = 34 AND ({where_sql}) LIMIT 4"
+                            ),
+                        )
+                successful_queries += 1
+            except Exception as exc:
+                failures.append(f"realtime:{db_path.name}:{type(exc).__name__}")
+                continue
+            for row in rows or []:
+                if not isinstance(row, dict):
+                    continue
+                values = {str(key).lower(): value for key, value in row.items()}
+                try:
+                    target = (
+                        int(values.get("local_id") or 0),
+                        int(values.get("server_id") or 0),
+                    )
+                    targets.add(target)
+                    text = _extract_voice_transcript_from_packed_info(
+                        values.get("packed_info_data")
+                    )
+                    if text:
+                        transcripts[target] = text
+                except Exception:
+                    continue
+    except Exception as exc:
+        failures.append(f"realtime:connect:{type(exc).__name__}")
+    return _VoiceTargetQueryResult(targets, transcripts, successful_queries, failures)
+
+
+def resolve_native_voice_target(
+    account_dir: Path,
+    *,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+) -> tuple[int, int, str]:
+    """Validate one voice row inside the selected account and conversation."""
+
+    local_result = _query_local_voice_targets(
+        account_dir,
+        conversation=conversation,
+        server_id=server_id,
+        local_id=local_id,
+    )
+    if account_prefers_decrypted_snapshot(Path(account_dir)):
+        # Imported snapshots are intentionally isolated from the currently
+        # logged-in local WeChat account.  Never fill a snapshot lookup from
+        # the process-wide realtime WCDB connection.
+        realtime_result = _VoiceTargetQueryResult(set(), {}, 0, [])
+    else:
+        realtime_result = _query_realtime_voice_targets(
+            account_dir,
+            conversation=conversation,
+            server_id=server_id,
+            local_id=local_id,
+        )
+    combined_rows = local_result.rows | realtime_result.rows
+    successful_queries = local_result.successful_queries + realtime_result.successful_queries
+    if successful_queries <= 0:
+        raise NativeVoiceTriggerError(
+            "native_message_lookup_unavailable",
+            "当前无法读取指定账号的微信消息数据，未触发原生转写。",
+        )
+
+    requested_rows = {
+        row for row in combined_rows
+        if (server_id > 0 and row[1] == server_id)
+        or (local_id > 0 and row[0] == local_id)
+    }
+    positive_targets = {
+        row for row in requested_rows if row[0] > 0 and row[1] > 0
+    }
+    if server_id > 0 and local_id > 0:
+        exact = (local_id, server_id)
+        # local_id is scoped to a message shard and can legitimately be reused
+        # by the same conversation in another message_*.db.  Once the exact
+        # pair exists, only a conflicting mapping for the globally stable
+        # server_id invalidates it; a row that merely reuses local_id does not.
+        conflicting_server_rows = {
+            row for row in requested_rows
+            if row[1] == server_id and row != exact
+        }
+        if exact not in combined_rows or conflicting_server_rows:
+            raise NativeVoiceTriggerError(
+                "voice_message_id_mismatch",
+                "server_id 与 local_id 未映射到指定会话中的同一条语音消息。",
+            )
+        target = exact
+    elif len(positive_targets) > 1:
+        raise NativeVoiceTriggerError(
+            "voice_message_ambiguous",
+            "同一会话中找到了多条冲突的语音消息，请改用 server_id。",
+        )
+    elif len(positive_targets) == 1:
+        target = next(iter(positive_targets))
+    elif local_id > 0 and any(
+        row_local_id == local_id and row_server_id <= 0
+        for row_local_id, row_server_id in requested_rows
+    ):
+        raise NativeVoiceTriggerError(
+            "voice_message_unsynced",
+            "该语音消息尚无 server_id，暂不能触发微信原生转写。",
+        )
+    else:
+        raise NativeVoiceTriggerError(
+            "voice_message_not_found",
+            "在指定账号和会话中未找到该语音消息。",
+        )
+
+    text = str(
+        lookup_cached_native_voice_transcript(
+            account_dir,
+            target[1],
+            conversation=conversation,
+            local_id=target[0],
+        )
+        or realtime_result.transcripts.get(target)
+        or local_result.transcripts.get(target)
+        or ""
+    ).strip()
+    return target[0], target[1], text
+
+
+def trigger_native_voice_transcription(
+    *,
+    account_dir: Path,
+    conversation: str,
+    server_id: Optional[str] = None,
+    local_id: Optional[str] = None,
+    transport: Optional[NativeVoiceTriggerTransport] = None,
+) -> dict[str, object]:
+    """Resolve, fast-path, and dispatch once; never poll or sleep in the POST path."""
+
+    resolved_conversation = normalize_native_voice_conversation(conversation)
+    parsed_server_id = parse_native_voice_message_id(server_id, "server_id")
+    parsed_local_id = parse_native_voice_message_id(local_id, "local_id")
+    if parsed_server_id <= 0 and parsed_local_id <= 0:
+        raise NativeVoiceTriggerError(
+            "missing_message_id",
+            "server_id 和 local_id 至少需要提供一个。",
+        )
+    parsed_local_id, parsed_server_id, existing_text = resolve_native_voice_target(
+        Path(account_dir),
+        conversation=resolved_conversation,
+        server_id=parsed_server_id,
+        local_id=parsed_local_id,
+    )
+
+    account_path = Path(account_dir)
+    response_base: dict[str, object] = {
+        "serverId": str(parsed_server_id),
+        "localId": str(parsed_local_id) if parsed_local_id > 0 else "",
+        "account": account_path.name,
+        "conversation": resolved_conversation,
+        "language": "",
+    }
+    if existing_text:
+        return {
+            "status": "success",
+            **response_base,
+            "text": existing_text,
+            "model": "wechat-native",
+            "requestId": "",
+            "pollAfterMs": 0,
+        }
+
+    command = NativeVoiceTriggerCommand(
+        account_dir=account_path,
+        account=resolve_account_self_username(account_path),
+        conversation=resolved_conversation,
+        server_id=parsed_server_id,
+        local_id=parsed_local_id,
+    )
+    try:
+        receipt = (transport or get_native_voice_trigger_transport()).trigger(command)
+    except NativeVoiceTriggerError:
+        raise
+    except Exception as exc:
+        raise NativeVoiceTriggerError(
+            "native_transport_failed",
+            "微信原生语音转写桥接调用失败。",
+        ) from exc
+    receipt_status = str(getattr(receipt, "status", "") or "").strip().lower()
+    if receipt_status not in _TRIGGER_RECEIPT_STATUSES:
+        raise NativeVoiceTriggerError(
+            "native_transport_invalid_response",
+            "微信原生语音转写桥接返回了无效状态。",
+        )
+    try:
+        receipt_request_id = _normalize_native_request_id(
+            str(getattr(receipt, "request_id", "") or "")
+        )
+    except (TypeError, ValueError) as exc:
+        raise NativeVoiceTriggerError(
+            "native_transport_invalid_response",
+            "微信原生语音转写桥接未返回有效的 requestId。",
+        ) from exc
+    return {
+        "status": receipt_status,
+        **response_base,
+        "text": "",
+        "model": "",
+        "requestId": receipt_request_id,
+        "pollAfterMs": 1200,
+    }

--- a/src/wechat_decrypt_tool/routers/chat.py
+++ b/src/wechat_decrypt_tool/routers/chat.py
@@ -37,6 +37,7 @@ from ..chat_helpers import (
     _extract_chatroom_top_message_metadata,
     _extract_image_group_info,
     _extract_md5_from_packed_info,
+    _extract_voice_transcript_from_packed_info,
     _extract_sender_from_group_xml,
     _extract_xml_attr,
     _extract_xml_tag_or_attr,
@@ -3122,6 +3123,11 @@ def _append_full_messages_from_rows(
         create_time = int(r["create_time"] or 0)
         sort_seq = int(r["sort_seq"] or 0) if r["sort_seq"] is not None else 0
         local_type = int(r["local_type"] or 0)
+        native_voice_transcript = (
+            _extract_voice_transcript_from_packed_info(_row_get_value(r, "packed_info_data"))
+            if local_type == 34
+            else ""
+        )
         sender_username = _decode_sqlite_text(r["sender_username"]).strip()
 
         is_sent = False
@@ -3607,6 +3613,11 @@ def _append_full_messages_from_rows(
                 "videoUrl": video_url,
                 "videoThumbUrl": video_thumb_url,
                 "voiceLength": voice_length,
+                "voiceTranscript": native_voice_transcript,
+                "voiceTranscriptStatus": "success" if native_voice_transcript else "idle",
+                "voiceTranscriptError": "",
+                "voiceTranscriptLanguage": "",
+                "voiceTranscriptModel": "wechat-native" if native_voice_transcript else "",
                 "voipType": voip_type,
                 "quoteUsername": str(quote_username).strip(),
                 "quoteServerId": str(quote_server_id).strip(),
@@ -5077,6 +5088,11 @@ def _collect_chat_messages(
                 create_time = int(r["create_time"] or 0)
                 sort_seq = int(r["sort_seq"] or 0) if r["sort_seq"] is not None else 0
                 local_type = int(r["local_type"] or 0)
+                native_voice_transcript = (
+                    _extract_voice_transcript_from_packed_info(_row_get_value(r, "packed_info_data"))
+                    if local_type == 34
+                    else ""
+                )
                 sender_username = _decode_sqlite_text(r["sender_username"]).strip()
 
                 is_sent = False
@@ -5512,6 +5528,11 @@ def _collect_chat_messages(
                         "videoUrl": video_url,
                         "videoThumbUrl": video_thumb_url,
                         "voiceLength": voice_length,
+                        "voiceTranscript": native_voice_transcript,
+                        "voiceTranscriptStatus": "success" if native_voice_transcript else "idle",
+                        "voiceTranscriptError": "",
+                        "voiceTranscriptLanguage": "",
+                        "voiceTranscriptModel": "wechat-native" if native_voice_transcript else "",
                         "voipType": voip_type,
                         "quoteUsername": str(quote_username).strip(),
                         "quoteServerId": str(quote_server_id).strip(),
@@ -6495,6 +6516,11 @@ def list_chat_messages(
                 create_time = int(r["create_time"] or 0)
                 sort_seq = int(r["sort_seq"] or 0) if r["sort_seq"] is not None else 0
                 local_type = int(r["local_type"] or 0)
+                native_voice_transcript = (
+                    _extract_voice_transcript_from_packed_info(_row_get_value(r, "packed_info_data"))
+                    if local_type == 34
+                    else ""
+                )
                 sender_username = _decode_sqlite_text(r["sender_username"]).strip()
 
                 is_sent = False
@@ -6878,6 +6904,11 @@ def list_chat_messages(
                         "videoUrl": video_url,
                         "videoThumbUrl": video_thumb_url,
                         "voiceLength": voice_length,
+                        "voiceTranscript": native_voice_transcript,
+                        "voiceTranscriptStatus": "success" if native_voice_transcript else "idle",
+                        "voiceTranscriptError": "",
+                        "voiceTranscriptLanguage": "",
+                        "voiceTranscriptModel": "wechat-native" if native_voice_transcript else "",
                         "voipType": voip_type,
                         "quoteUsername": str(quote_username).strip(),
                         "quoteServerId": str(quote_server_id).strip(),

--- a/src/wechat_decrypt_tool/routers/chat_media.py
+++ b/src/wechat_decrypt_tool/routers/chat_media.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 import requests
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictStr
 
 from ..account_source_policy import account_prefers_decrypted_snapshot
 from ..avatar_cache import (
@@ -83,6 +83,15 @@ from ..voice_transcription import (
     load_voice_data,
     set_voice_transcription_device,
 )
+from ..native_voice_transcription import (
+    NativeVoiceTriggerError,
+    lookup_native_voice_transcript_cache,
+    normalize_native_voice_conversation,
+    parse_native_voice_message_id,
+    resolve_native_voice_target,
+    trigger_native_voice_transcription,
+)
+from ..native_core_voice_asr import native_core_voice_asr_status as native_bridge_status
 
 logger = get_logger(__name__)
 
@@ -109,6 +118,66 @@ class VoiceTranscriptionCacheLookupRequest(BaseModel):
 
 class VoiceTranscriptionSettingsRequest(BaseModel):
     device: str = Field(..., description="推理设备：cpu 或 cuda")
+
+
+class NativeVoiceTranscriptionTriggerRequest(BaseModel):
+    server_id: Optional[StrictStr] = Field(
+        None,
+        description="语音消息服务端 ID（精确十进制字符串）",
+    )
+    local_id: Optional[StrictStr] = Field(
+        None,
+        description="语音消息本地 ID（精确十进制字符串）",
+    )
+    account: StrictStr = Field(..., description="账号目录名（必填）")
+    username: StrictStr = Field(..., description="会话 username")
+
+
+class NativeVoiceTranscriptCacheLookupItem(BaseModel):
+    server_id: StrictStr = Field(..., description="语音消息服务端 ID（精确十进制字符串）")
+    local_id: StrictStr = Field(..., description="语音消息本地 ID（精确十进制字符串）")
+
+
+class NativeVoiceTranscriptCacheLookupRequest(BaseModel):
+    account: StrictStr = Field(..., description="账号目录名（必填）")
+    username: StrictStr = Field(..., description="会话 username")
+    items: list[NativeVoiceTranscriptCacheLookupItem] = Field(
+        default_factory=list,
+        description="当前会话中待恢复的精确消息 identity",
+    )
+
+
+def _is_loopback_host(host: str) -> bool:
+    value = str(host or "").strip().strip("[]")
+    if value.lower() == "localhost":
+        return True
+    try:
+        address = ipaddress.ip_address(value)
+        return bool(
+            address.is_loopback
+            or (
+                isinstance(address, ipaddress.IPv6Address)
+                and address.ipv4_mapped
+                and address.ipv4_mapped.is_loopback
+            )
+        )
+    except ValueError:
+        return False
+
+
+def _require_local_voice_mutation(request: Request) -> None:
+    """Block cross-origin or LAN callers from triggering local native work."""
+
+    client_host = str(getattr(request.client, "host", "") or "").strip()
+    if not _is_loopback_host(client_host):
+        raise HTTPException(status_code=403, detail="仅允许本机执行语音转写操作。")
+
+    origin = str(request.headers.get("origin") or "").strip()
+    if not origin:
+        return
+    parsed = urlparse(origin)
+    if parsed.scheme not in {"http", "https"} or not _is_loopback_host(parsed.hostname or ""):
+        raise HTTPException(status_code=403, detail="拒绝非本机页面发起语音转写操作。")
 
 
 def _avatar_trace_enabled() -> bool:
@@ -3666,6 +3735,277 @@ async def transcribe_chat_voice(req: VoiceTranscriptionRequest):
             "dependency_missing": 503,
             "model_load_failed": 503,
         }.get(exc.code, 500)
+        raise HTTPException(
+            status_code=status_code,
+            detail={"code": exc.code, "message": exc.user_message},
+        ) from exc
+
+
+@router.get(
+    "/api/chat/media/voice/transcription/native",
+    summary="读取单条微信原生语音转写结果（不触发识别）",
+)
+async def get_chat_native_voice_transcription(
+    request: Request,
+    response: Response,
+    account: StrictStr,
+    username: StrictStr,
+    server_id: StrictStr,
+    local_id: StrictStr,
+    request_id: Optional[StrictStr] = None,
+):
+    _require_local_voice_mutation(request)
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        account_name = str(account).strip()
+        if not account_name:
+            raise NativeVoiceTriggerError("invalid_account", "缺少 account。")
+        conversation = normalize_native_voice_conversation(str(username))
+        target_server_id = parse_native_voice_message_id(str(server_id), "server_id")
+        target_local_id = parse_native_voice_message_id(str(local_id), "local_id")
+        native_request_id = str(request_id or "").strip()
+        if native_request_id and (
+            len(native_request_id.encode("utf-8")) > 256
+            or any(ord(char) < 0x20 or ord(char) == 0x7F for char in native_request_id)
+        ):
+            raise NativeVoiceTriggerError(
+                "invalid_request_id",
+                "request_id 格式无效。",
+            )
+        account_dir = _resolve_account_dir(account_name)
+
+        if native_request_id:
+            entry = await asyncio.to_thread(
+                lookup_native_voice_transcript_cache,
+                account_dir,
+                target_server_id,
+                conversation=conversation,
+                local_id=target_local_id,
+                request_id=native_request_id,
+                strict=True,
+            )
+            if entry is None or entry.request_id != native_request_id:
+                return {
+                    "status": "expired",
+                    "serverId": str(target_server_id),
+                    "localId": str(target_local_id),
+                    "requestId": native_request_id,
+                    "text": "",
+                    "language": "",
+                    "model": "",
+                    "code": "native_result_expired",
+                    "message": "微信原生语音转文字任务不存在或已过期。",
+                }
+            if entry.status == "error":
+                return {
+                    "status": "error",
+                    "serverId": str(target_server_id),
+                    "localId": str(target_local_id),
+                    "requestId": native_request_id,
+                    "text": "",
+                    "language": "",
+                    "model": "",
+                    "code": entry.error_code or "native_transcript_failed",
+                    "message": entry.error_message or "微信原生语音转文字未能返回结果。",
+                }
+            text = entry.text if entry.status == "success" else ""
+            return {
+                "status": "success" if text else "pending",
+                "serverId": str(target_server_id),
+                "localId": str(target_local_id),
+                "requestId": native_request_id,
+                "text": text,
+                "language": "",
+                "model": "wechat-native" if text else "",
+            }
+
+        resolved_local_id, resolved_server_id, text = await asyncio.to_thread(
+            resolve_native_voice_target,
+            account_dir,
+            conversation=conversation,
+            server_id=target_server_id,
+            local_id=target_local_id,
+        )
+        return {
+            "status": "success" if text else "pending",
+            "serverId": str(resolved_server_id),
+            "localId": str(resolved_local_id),
+            "requestId": "",
+            "text": text,
+            "language": "",
+            "model": "wechat-native" if text else "",
+        }
+    except NativeVoiceTriggerError as exc:
+        status_code = {
+            "invalid_account": 400,
+            "invalid_conversation": 400,
+            "invalid_message_id": 400,
+            "invalid_request_id": 400,
+            "voice_message_not_found": 404,
+            "voice_message_id_mismatch": 409,
+            "voice_message_ambiguous": 409,
+            "voice_message_unsynced": 409,
+            "native_message_lookup_unavailable": 503,
+            "native_result_store_unavailable": 503,
+        }.get(exc.code, 502)
+        raise HTTPException(
+            status_code=status_code,
+            detail={"code": exc.code, "message": exc.user_message},
+        ) from exc
+
+
+@router.get(
+    "/api/chat/media/voice/transcription/native/status",
+    summary="检查微信原生语音转写桥接能力（只读）",
+)
+async def get_chat_native_voice_transcription_status(
+    request: Request,
+    response: Response,
+    account: StrictStr,
+):
+    _require_local_voice_mutation(request)
+    response.headers["Cache-Control"] = "no-store"
+    account_name = str(account).strip()
+    if not account_name:
+        raise HTTPException(status_code=400, detail="Missing account.")
+    account_dir = _resolve_account_dir(account_name)
+    return await asyncio.to_thread(native_bridge_status, account_dir)
+
+
+@router.post(
+    "/api/chat/media/voice/transcription/native/cache_lookup",
+    summary="批量读取项目保存的微信原生语音转写结果",
+)
+async def lookup_chat_native_voice_transcription_cache(
+    req: NativeVoiceTranscriptCacheLookupRequest,
+    request: Request,
+    response: Response,
+):
+    _require_local_voice_mutation(request)
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        account = str(req.account).strip()
+        if not account:
+            raise NativeVoiceTriggerError("invalid_account", "缺少 account。")
+        conversation = normalize_native_voice_conversation(str(req.username))
+        if len(req.items) > 512:
+            raise NativeVoiceTriggerError(
+                "invalid_message_id",
+                "单次最多读取 512 条微信原生转写缓存。",
+            )
+        account_dir = _resolve_account_dir(account)
+        identities: list[tuple[int, int]] = []
+        seen: set[tuple[int, int]] = set()
+        for item in req.items:
+            server_id = parse_native_voice_message_id(str(item.server_id), "server_id")
+            local_id = parse_native_voice_message_id(str(item.local_id), "local_id")
+            identity = (server_id, local_id)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            identities.append(identity)
+
+        def read_entries() -> list[dict[str, str]]:
+            results: list[dict[str, str]] = []
+            for server_id, local_id in identities:
+                entry = lookup_native_voice_transcript_cache(
+                    account_dir,
+                    server_id,
+                    conversation=conversation,
+                    local_id=local_id,
+                    strict=True,
+                )
+                if entry is None:
+                    continue
+                item = {
+                    "serverId": str(server_id),
+                    "localId": str(local_id),
+                    "status": entry.status,
+                    "requestId": entry.request_id,
+                }
+                if entry.status == "success" and entry.text:
+                    item.update(
+                        {
+                            "text": entry.text,
+                            "language": "",
+                            "model": "wechat-native",
+                        }
+                    )
+                elif entry.status == "pending":
+                    item["pollAfterMs"] = 1200
+                elif entry.status == "error":
+                    item.update(
+                        {
+                            "code": entry.error_code,
+                            "message": entry.error_message,
+                        }
+                    )
+                else:
+                    continue
+                results.append(item)
+            return results
+
+        return {
+            "status": "success",
+            "items": await asyncio.to_thread(read_entries),
+        }
+    except NativeVoiceTriggerError as exc:
+        status_code = {
+            "invalid_account": 400,
+            "invalid_conversation": 400,
+            "invalid_message_id": 400,
+            "native_result_store_unavailable": 503,
+        }.get(exc.code, 502)
+        raise HTTPException(
+            status_code=status_code,
+            detail={"code": exc.code, "message": exc.user_message},
+        ) from exc
+
+
+@router.post(
+    "/api/chat/media/voice/transcription/native/trigger",
+    summary="触发单条微信原生语音转写",
+)
+async def trigger_chat_native_voice_transcription(
+    req: NativeVoiceTranscriptionTriggerRequest,
+    request: Request,
+    response: Response,
+):
+    _require_local_voice_mutation(request)
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        account = str(req.account).strip()
+        if not account:
+            raise NativeVoiceTriggerError("invalid_account", "缺少 account。")
+        account_dir = _resolve_account_dir(account)
+        return await asyncio.to_thread(
+            trigger_native_voice_transcription,
+            account_dir=account_dir,
+            conversation=req.username,
+            server_id=req.server_id,
+            local_id=req.local_id,
+        )
+    except NativeVoiceTriggerError as exc:
+        status_code = {
+            "invalid_message_id": 400,
+            "missing_message_id": 400,
+            "invalid_account": 400,
+            "invalid_conversation": 400,
+            "voice_message_not_found": 404,
+            "voice_message_id_mismatch": 409,
+            "voice_message_ambiguous": 409,
+            "voice_message_unsynced": 409,
+            "native_message_lookup_unavailable": 503,
+            "native_transport_unavailable": 503,
+            "native_asr_not_authorized": 403,
+            "native_weixin_not_running": 503,
+            "native_weixin_version_unsupported": 503,
+            "native_transport_busy": 429,
+            "native_trigger_timeout": 504,
+            "native_trigger_rejected": 409,
+            "native_transport_failed": 502,
+            "native_transport_invalid_response": 502,
+        }.get(exc.code, 502)
         raise HTTPException(
             status_code=status_code,
             detail={"code": exc.code, "message": exc.user_message},

--- a/src/wechat_decrypt_tool/voice_transcription.py
+++ b/src/wechat_decrypt_tool/voice_transcription.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import sqlite3
+import stat
 import subprocess
 import tempfile
 import threading
@@ -22,6 +23,8 @@ _OPENCC_LOOKED_UP = False
 _CUDA_PROBE_CACHE_TTL_SECONDS = 5.0
 _CUDA_PROBE_CACHE_LOCK = threading.Lock()
 _CUDA_PROBE_CACHE: Optional[tuple[float, dict[str, Any]]] = None
+_VOICE_TRANSCRIPT_CACHE_LOCK = threading.Lock()
+_VOICE_TRANSCRIPT_CACHE_EPOCHS: dict[str, int] = {}
 
 from .runtime_settings import (
     VOICE_TRANSCRIPTION_DEVICE_CPU,
@@ -35,6 +38,110 @@ class VoiceTranscriptionError(RuntimeError):
         super().__init__(message)
         self.code = str(code or "voice_transcription_failed")
         self.user_message = str(message or "Voice transcription failed.")
+
+
+def _path_is_link_or_junction(path: Path) -> bool:
+    try:
+        if path.is_symlink():
+            return True
+        if os.name == "nt":
+            attributes = int(getattr(path.lstat(), "st_file_attributes", 0) or 0)
+            return bool(attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    except OSError:
+        return False
+    return False
+
+
+def _voice_transcript_cache_account_key(account_dir: Path) -> str:
+    try:
+        value = str(Path(account_dir).resolve(strict=False))
+    except OSError:
+        value = str(Path(account_dir).absolute())
+    return os.path.normcase(value)
+
+
+def _voice_transcript_cache_path(account_dir: Path) -> Path:
+    return Path(account_dir) / "_cache" / "voice_transcripts.sqlite3"
+
+
+def _delete_voice_transcript_cache_unlocked(
+    account_dir: Path,
+    *,
+    expected_root: Optional[Path] = None,
+) -> dict[str, Any]:
+    """Delete project-generated Whisper rows without touching WeChat metadata."""
+
+    account_path = Path(account_dir)
+    account_key = _voice_transcript_cache_account_key(account_path)
+    cache_path = _voice_transcript_cache_path(account_path)
+    deleted_rows = 0
+    deleted_messages = 0
+    if expected_root is not None:
+        root = Path(expected_root)
+        try:
+            account_is_owned = (
+                not _path_is_link_or_junction(root)
+                and not _path_is_link_or_junction(account_path)
+                and account_path.absolute().parent == root.absolute()
+                and account_path.resolve(strict=True).parent == root.resolve(strict=True)
+            )
+        except OSError:
+            account_is_owned = False
+        if not account_is_owned:
+            raise VoiceTranscriptionError(
+                "unsafe_account_path",
+                "账号缓存目录不安全，已拒绝删除。",
+            )
+    if _path_is_link_or_junction(cache_path.parent) or _path_is_link_or_junction(cache_path):
+        raise VoiceTranscriptionError(
+            "unsafe_cache_path",
+            "语音转写缓存路径不安全，已拒绝删除。",
+        )
+    _VOICE_TRANSCRIPT_CACHE_EPOCHS[account_key] = int(
+        _VOICE_TRANSCRIPT_CACHE_EPOCHS.get(account_key, 0)
+    ) + 1
+    if cache_path.is_file():
+        conn: Optional[sqlite3.Connection] = None
+        try:
+            conn = sqlite3.connect(str(cache_path))
+            table_exists = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'transcript' LIMIT 1"
+            ).fetchone()
+            if table_exists:
+                row = conn.execute(
+                    "SELECT COUNT(*), COUNT(DISTINCT server_id) FROM transcript"
+                ).fetchone()
+                deleted_rows = int(row[0] or 0) if row else 0
+                deleted_messages = int(row[1] or 0) if row else 0
+                conn.execute("DELETE FROM transcript")
+                conn.commit()
+        except (OSError, sqlite3.Error) as exc:
+            if conn is not None:
+                try:
+                    conn.rollback()
+                except sqlite3.Error:
+                    pass
+            raise VoiceTranscriptionError(
+                "cache_delete_failed",
+                "本项目语音转写记录删除失败，请重试。",
+            ) from exc
+        finally:
+            if conn is not None:
+                conn.close()
+    return {
+        "status": "success",
+        "account": account_path.name,
+        "deletedRows": deleted_rows,
+        "deletedMessages": deleted_messages,
+        "nativeDeleted": 0,
+    }
+
+
+def delete_voice_transcript_cache(account_dir: Path) -> dict[str, Any]:
+    """Delete only project-generated transcripts for one resolved account."""
+
+    with _VOICE_TRANSCRIPT_CACHE_LOCK:
+        return _delete_voice_transcript_cache_unlocked(account_dir)
 
 
 @dataclass(frozen=True)
@@ -375,6 +482,15 @@ def _coerce_blob(value: Any) -> bytes:
     return text.encode("utf-8", "replace")
 
 
+def _numbered_db_shards(root: Path, prefix: str) -> list[Path]:
+    pattern = re.compile(rf"^{re.escape(prefix)}_[0-9]+\.db$", re.IGNORECASE)
+    return [
+        path
+        for path in sorted(Path(root).glob(f"{prefix}_*.db"))
+        if path.is_file() and pattern.fullmatch(path.name)
+    ]
+
+
 def _convert_silk_to_browser_audio(data: bytes, *, preferred_format: str) -> tuple[bytes, str, str]:
     from .media_helpers import _convert_silk_to_browser_audio as convert
 
@@ -434,6 +550,219 @@ def load_voice_data(account_dir: Path, server_id: int) -> bytes:
     return b""
 
 
+def list_native_voice_transcripts(
+    account_dir: Path,
+    *,
+    cancel_event: Optional[threading.Event] = None,
+    errors: Optional[list[str]] = None,
+    voice_server_ids: Optional[set[int]] = None,
+    target_server_id: Optional[int] = None,
+) -> dict[int, str]:
+    """Read completed WeChat-native transcripts keyed by server ID."""
+
+    from .chat_helpers import _extract_voice_transcript_from_packed_info
+
+    result: dict[int, str] = {}
+    account_path = Path(account_dir)
+    target_id = int(target_server_id or 0)
+    local_errors: list[str] = []
+    local_successes = 0
+    for db_path in _numbered_db_shards(account_path, "message"):
+        if cancel_event is not None and cancel_event.is_set():
+            break
+        conn: Optional[sqlite3.Connection] = None
+        try:
+            conn = sqlite3.connect(str(db_path))
+            tables = [
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'Msg_%'"
+                )
+            ]
+            for table in tables:
+                if cancel_event is not None and cancel_event.is_set():
+                    break
+                quoted = '"' + table.replace('"', '""') + '"'
+                try:
+                    target_where = " AND server_id = ?" if target_id > 0 else ""
+                    target_params = (target_id,) if target_id > 0 else ()
+                    try:
+                        rows = conn.execute(
+                            f"SELECT server_id, packed_info_data FROM {quoted} "
+                            "WHERE local_type = 34 AND server_id > 0"
+                            + target_where,
+                            target_params,
+                        )
+                    except sqlite3.OperationalError:
+                        rows = conn.execute(
+                            f"SELECT server_id, NULL AS packed_info_data FROM {quoted} "
+                            "WHERE local_type = 34 AND server_id > 0"
+                            + target_where,
+                            target_params,
+                        )
+                    for server_id, packed_info in rows:
+                        sid = int(server_id or 0)
+                        if sid <= 0:
+                            continue
+                        if voice_server_ids is not None:
+                            voice_server_ids.add(sid)
+                        if sid in result or packed_info is None:
+                            continue
+                        text = _extract_voice_transcript_from_packed_info(packed_info)
+                        if text:
+                            result[sid] = text
+                except Exception as exc:
+                    local_errors.append(f"{db_path.name}/{table}: {type(exc).__name__}")
+                    continue
+            local_successes += 1
+        except Exception as exc:
+            local_errors.append(f"{db_path.name}: {type(exc).__name__}")
+        finally:
+            if conn is not None:
+                conn.close()
+    if target_id > 0 and target_id in result:
+        return result
+    realtime_errors: list[str] = []
+    from .account_source_policy import account_prefers_decrypted_snapshot
+
+    if not account_prefers_decrypted_snapshot(account_path):
+        for server_id, text in _list_realtime_native_voice_transcripts(
+            account_path,
+            cancel_event=cancel_event,
+            errors=realtime_errors,
+            voice_server_ids=voice_server_ids,
+            target_server_id=target_id if target_id > 0 else None,
+        ).items():
+            result.setdefault(server_id, text)
+    if errors is not None:
+        errors.extend(local_errors)
+        if local_successes == 0:
+            errors.extend(realtime_errors)
+    return result
+
+
+def _list_realtime_native_voice_transcripts(
+    account_dir: Path,
+    *,
+    cancel_event: Optional[threading.Event] = None,
+    errors: Optional[list[str]] = None,
+    voice_server_ids: Optional[set[int]] = None,
+    target_server_id: Optional[int] = None,
+) -> dict[int, str]:
+    """Best-effort native transcript lookup for direct/realtime WCDB mode."""
+
+    from .chat_helpers import _extract_voice_transcript_from_packed_info
+
+    result: dict[int, str] = {}
+    target_id = int(target_server_id or 0)
+    try:
+        from .wcdb_realtime import WCDB_REALTIME, exec_query as _wcdb_exec_query
+
+        realtime = WCDB_REALTIME.ensure_connected(Path(account_dir))
+        message_dir = Path(realtime.db_storage_dir) / "message"
+        for db_path in _numbered_db_shards(message_dir, "message"):
+            if cancel_event is not None and cancel_event.is_set():
+                break
+            try:
+                with realtime.lock:
+                    table_rows = _wcdb_exec_query(
+                        realtime.handle,
+                        kind="message",
+                        path=str(db_path),
+                        sql="SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'Msg_%'",
+                    )
+            except Exception as exc:
+                if errors is not None:
+                    errors.append(f"{db_path.name}: {type(exc).__name__}")
+                continue
+            for table_row in table_rows or []:
+                if cancel_event is not None and cancel_event.is_set():
+                    break
+                if not isinstance(table_row, dict):
+                    continue
+                table = str(
+                    next(
+                        (value for key, value in table_row.items() if str(key).lower() == "name"),
+                        "",
+                    )
+                    or ""
+                ).strip()
+                if not table.lower().startswith("msg_"):
+                    continue
+                quoted = '"' + table.replace('"', '""') + '"'
+                try:
+                    with realtime.lock:
+                        try:
+                            target_where = f" AND server_id = {target_id}" if target_id > 0 else ""
+                            rows = _wcdb_exec_query(
+                                realtime.handle,
+                                kind="message",
+                                path=str(db_path),
+                                sql=(
+                                    f"SELECT server_id, packed_info_data FROM {quoted} "
+                                    "WHERE local_type = 34 AND server_id > 0"
+                                    + target_where
+                                ),
+                            )
+                        except Exception:
+                            rows = _wcdb_exec_query(
+                                realtime.handle,
+                                kind="message",
+                                path=str(db_path),
+                                sql=(
+                                    f"SELECT server_id, NULL AS packed_info_data FROM {quoted} "
+                                    "WHERE local_type = 34 AND server_id > 0"
+                                    + target_where
+                                ),
+                            )
+                except Exception as exc:
+                    if errors is not None:
+                        errors.append(f"{db_path.name}/{table}: {type(exc).__name__}")
+                    continue
+                for row in rows or []:
+                    if not isinstance(row, dict):
+                        continue
+                    values = {str(key).lower(): value for key, value in row.items()}
+                    try:
+                        server_id = int(values.get("server_id") or 0)
+                    except Exception:
+                        continue
+                    if server_id <= 0 or server_id in result:
+                        continue
+                    if voice_server_ids is not None:
+                        voice_server_ids.add(server_id)
+                    if values.get("packed_info_data") is None:
+                        continue
+                    text = _extract_voice_transcript_from_packed_info(values.get("packed_info_data"))
+                    if text:
+                        result[server_id] = text
+    except Exception as exc:
+        if errors is not None:
+            errors.append(f"realtime message: {type(exc).__name__}")
+    return result
+
+
+def lookup_native_voice_transcript(
+    account_dir: Path,
+    server_id: int,
+    *,
+    errors: Optional[list[str]] = None,
+) -> str:
+    """Read one completed WeChat-native transcript without triggering recognition."""
+
+    target_id = int(server_id or 0)
+    if target_id <= 0:
+        return ""
+    return str(
+        list_native_voice_transcripts(
+            account_dir,
+            errors=errors,
+            target_server_id=target_id,
+        ).get(target_id)
+        or ""
+    ).strip()
+
+
 class VoiceTranscriptionService:
     def __init__(
         self,
@@ -449,7 +778,7 @@ class VoiceTranscriptionService:
         self._fallback_reason = ""
         self._model_lock = threading.Lock()
         self._inference_lock = threading.Lock()
-        self._cache_lock = threading.Lock()
+        self._cache_lock = _VOICE_TRANSCRIPT_CACHE_LOCK
         self._model_readiness_lock = threading.Lock()
         self._model_readiness_cache: Optional[tuple[float, dict[str, Any]]] = None
 

--- a/tests/test_chat_voice_native_transcript.py
+++ b/tests/test_chat_voice_native_transcript.py
@@ -1,0 +1,153 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from wechat_decrypt_tool.chat_helpers import _extract_voice_transcript_from_packed_info
+from wechat_decrypt_tool.routers.chat import _append_full_messages_from_rows
+from wechat_decrypt_tool.voice_transcription import (
+    VoiceTranscriptionConfig,
+    VoiceTranscriptionService,
+    delete_voice_transcript_cache,
+)
+
+
+SYNTHETIC_TRANSCRIPT = "这是一条合成测试转写。"
+SYNTHETIC_TRANSCRIPT_BLOB = bytes.fromhex(
+    "084310042a2508021221e8bf99e698afe4b880e69da1e59088e68890e6b58be8af95e8bdace58699e38082"
+)
+
+
+class NativeVoiceTranscriptTest(unittest.TestCase):
+    def test_extracts_exact_wechat_native_transcript(self):
+        self.assertEqual(
+            _extract_voice_transcript_from_packed_info(SYNTHETIC_TRANSCRIPT_BLOB),
+            SYNTHETIC_TRANSCRIPT,
+        )
+        self.assertEqual(
+            _extract_voice_transcript_from_packed_info(SYNTHETIC_TRANSCRIPT_BLOB.hex()),
+            SYNTHETIC_TRANSCRIPT,
+        )
+
+    def test_rejects_non_final_or_malformed_payloads(self):
+        # Top-level field 5 contains nested status=0/text and status=3/text.
+        self.assertEqual(
+            _extract_voice_transcript_from_packed_info(bytes.fromhex("2a0708001203616263")),
+            "",
+        )
+        self.assertEqual(
+            _extract_voice_transcript_from_packed_info(bytes.fromhex("2a0708031203616263")),
+            "",
+        )
+        self.assertEqual(_extract_voice_transcript_from_packed_info(b"\x2a\x7fbroken"), "")
+
+    def test_chat_message_exposes_native_transcript_without_whisper(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """
+            CREATE TABLE message (
+                local_id INTEGER,
+                server_id INTEGER,
+                create_time INTEGER,
+                sort_seq INTEGER,
+                local_type INTEGER,
+                sender_username TEXT,
+                real_sender_id INTEGER,
+                compress_content BLOB,
+                message_content BLOB,
+                msg_source BLOB,
+                packed_info_data BLOB
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO message VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                7,
+                9007199254740993,
+                1700000000,
+                1700000000,
+                34,
+                "wxid_sender_fixture",
+                9,
+                b'<msg><voicemsg voicelength="1234" /></msg>',
+                b"",
+                b"",
+                SYNTHETIC_TRANSCRIPT_BLOB,
+            ),
+        )
+        rows = conn.execute("SELECT * FROM message").fetchall()
+
+        merged = []
+        _append_full_messages_from_rows(
+            merged=merged,
+            sender_usernames=[],
+            quote_usernames=[],
+            pat_usernames=set(),
+            rows=rows,
+            db_path=Path("message_0.db"),
+            table_name="Msg_voice_fixture",
+            username="fixture@chatroom",
+            account_dir=Path("wxid_voice_fixture"),
+            is_group=True,
+            my_rowid=1,
+            resource_conn=None,
+            resource_chat_id=None,
+        )
+
+        self.assertEqual(len(merged), 1)
+        message = merged[0]
+        self.assertEqual(message["voiceTranscript"], SYNTHETIC_TRANSCRIPT)
+        self.assertEqual(message["voiceTranscriptStatus"], "success")
+        self.assertEqual(message["voiceTranscriptModel"], "wechat-native")
+        self.assertEqual(message["voiceTranscriptLanguage"], "")
+
+    def test_deleting_project_transcripts_preserves_wechat_packed_info(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            account_dir = Path(tmp) / "wxid_native_fixture"
+            account_dir.mkdir()
+            service = VoiceTranscriptionService(VoiceTranscriptionConfig(model="small"))
+            with patch(
+                "wechat_decrypt_tool.voice_transcription.normalize_transcript_text",
+                side_effect=lambda value: str(value or "").strip(),
+            ):
+                service._write_cache(
+                    account_dir,
+                    9007199254740993,
+                    "project-cache",
+                    {"text": "本项目转写", "language": "zh", "duration": 1.0},
+                )
+            message_db = account_dir / "message_0.db"
+            conn = sqlite3.connect(str(message_db))
+            try:
+                conn.execute("CREATE TABLE message (server_id INTEGER, packed_info_data BLOB)")
+                conn.execute(
+                    "INSERT INTO message VALUES (?, ?)",
+                    (9007199254740993, SYNTHETIC_TRANSCRIPT_BLOB),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+            deleted = delete_voice_transcript_cache(account_dir)
+            conn = sqlite3.connect(str(message_db))
+            try:
+                packed_info = conn.execute(
+                    "SELECT packed_info_data FROM message WHERE server_id = ?",
+                    (9007199254740993,),
+                ).fetchone()[0]
+            finally:
+                conn.close()
+
+        self.assertEqual(deleted["deletedRows"], 1)
+        self.assertEqual(deleted["nativeDeleted"], 0)
+        self.assertEqual(packed_info, SYNTHETIC_TRANSCRIPT_BLOB)
+        self.assertEqual(_extract_voice_transcript_from_packed_info(packed_info), SYNTHETIC_TRANSCRIPT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_core_client_asr.py
+++ b/tests/test_native_core_client_asr.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import ctypes
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+
+from wechat_decrypt_tool import native_core_client as native
+from wechat_decrypt_tool.native_core_client import (
+    NativeCoreAsrReason,
+    NativeCoreAsrRequestState,
+    NativeCoreClient,
+    NativeCoreFeature,
+    NativeCoreProtocolError,
+    NativeCoreStatus,
+)
+
+
+_REQUIRED_SYMBOLS = (
+    "wce_client_abi_version",
+    "wce_client_build_id",
+    "wce_client_create",
+    "wce_client_destroy",
+    "wce_client_get_status",
+    "wce_client_prove_license_challenge",
+    "wce_client_install_lease",
+    "wce_client_authorize",
+    "wce_database_open",
+    "wce_database_close",
+    "wce_query_open",
+    "wce_query_fetch",
+    "wce_query_close",
+    "wce_export_begin",
+    "wce_export_write",
+    "wce_export_finish",
+    "wce_export_abort",
+    "wce_export_encrypt_begin",
+    "wce_export_encrypt_write",
+    "wce_export_encrypt_finish",
+    "wce_export_encrypt_abort",
+    "wce_buffer_release",
+    "wce_status_message",
+)
+_NATIVE_ASR_SYMBOLS = (
+    "wce_native_asr_get_status",
+    "wce_native_asr_begin",
+    "wce_native_asr_poll",
+    "wce_native_asr_close",
+)
+
+
+class _FakeFunction:
+    def __init__(self, callback: Callable[..., Any] | None = None) -> None:
+        self.callback = callback or (lambda *_args: 0)
+        self.argtypes: list[Any] | None = None
+        self.restype: Any = None
+
+    def __call__(self, *args: Any) -> Any:
+        return self.callback(*args)
+
+
+def _abi_library(*, native_asr_symbols: tuple[str, ...] = ()) -> SimpleNamespace:
+    functions = {name: _FakeFunction() for name in _REQUIRED_SYMBOLS}
+    functions.update({name: _FakeFunction() for name in native_asr_symbols})
+    return SimpleNamespace(**functions)
+
+
+def _configure_client(library: SimpleNamespace) -> NativeCoreClient:
+    client = object.__new__(NativeCoreClient)
+    client._library = library
+    client._build_manifest = SimpleNamespace(root_public_key_compiled=False)
+    client._configure_abi()
+    return client
+
+
+def _dereference(pointer: Any, value_type: type[ctypes.Structure]) -> Any:
+    return ctypes.cast(pointer, ctypes.POINTER(value_type)).contents
+
+
+def _write_fixed_utf8(
+    value: native._WceNativeAsrStatus,
+    field_name: str,
+    payload: bytes,
+) -> None:
+    field = getattr(type(value), field_name)
+    assert len(payload) <= 32
+    ctypes.memmove(ctypes.addressof(value) + field.offset, payload, len(payload))
+
+
+class _AsrStub:
+    def __init__(self, *, poll_payload: bytes = "转写完成".encode()) -> None:
+        self.poll_payload = poll_payload
+        self.close_status = NativeCoreStatus.OK
+        self.poll_buffers: list[Any] = []
+        self.releases: list[tuple[int, bool]] = []
+        self.status_calls: list[tuple[bytes, bytes]] = []
+        self.begin_calls: list[tuple[bytes, bytes, bytes, int, int, int]] = []
+        self.poll_calls: list[tuple[int, int]] = []
+        self.close_calls: list[tuple[int, int]] = []
+        self.library = SimpleNamespace(
+            wce_native_asr_get_status=_FakeFunction(self._get_status),
+            wce_native_asr_begin=_FakeFunction(self._begin),
+            wce_native_asr_poll=_FakeFunction(self._poll),
+            wce_native_asr_close=_FakeFunction(self._close),
+            wce_buffer_release=_FakeFunction(self._release),
+            wce_status_message=_FakeFunction(lambda _status: b"status"),
+        )
+
+    def _get_status(self, _client: Any, options_pointer: Any, status_pointer: Any) -> int:
+        options = _dereference(options_pointer, native._WceNativeAsrStatusOptions)
+        status = _dereference(status_pointer, native._WceNativeAsrStatus)
+        self.status_calls.append((bytes(options.account_utf8), bytes(options.account_directory_utf8)))
+        assert options.struct_size == ctypes.sizeof(native._WceNativeAsrStatusOptions)
+        assert options.reserved == 0
+        status.reason = int(NativeCoreAsrReason.READY)
+        status.platform_supported = 1
+        status.ready = 1
+        status.wechat_process_id = 4321
+        status.reserved = 0
+        _write_fixed_utf8(status, "expected_wechat_version", b"4.1.12.26\0")
+        _write_fixed_utf8(status, "actual_wechat_version", b"4.1.12.26\0")
+        status.expected_weixin_sha256[:] = bytes(range(32))
+        status.actual_weixin_sha256[:] = bytes(reversed(range(32)))
+        return int(NativeCoreStatus.OK)
+
+    def _begin(self, _client: Any, options_pointer: Any, output_pointer: Any) -> int:
+        options = _dereference(options_pointer, native._WceNativeAsrBeginOptions)
+        self.begin_calls.append(
+            (
+                bytes(options.account_utf8),
+                bytes(options.account_directory_utf8),
+                bytes(options.conversation_utf8),
+                int(options.server_id),
+                int(options.local_id),
+                int(options.operation_nonce),
+            )
+        )
+        output = ctypes.cast(output_pointer, ctypes.POINTER(ctypes.c_uint64))
+        output[0] = 73
+        return int(NativeCoreStatus.OK)
+
+    def _poll(
+        self,
+        _client: Any,
+        options_pointer: Any,
+        result_pointer: Any,
+        output_pointer: Any,
+    ) -> int:
+        options = _dereference(options_pointer, native._WceNativeAsrPollOptions)
+        result = _dereference(result_pointer, native._WceNativeAsrPollResult)
+        output = _dereference(output_pointer, native._WceOwnedBuffer)
+        self.poll_calls.append((int(options.request_handle), int(options.operation_nonce)))
+        result.state = int(NativeCoreAsrRequestState.SUCCEEDED)
+        result.reason = int(NativeCoreAsrReason.READY)
+        result.terminal_status = int(NativeCoreStatus.OK)
+        result.server_id = 1_265_681_483_748_099_968
+        result.local_id = 342
+        result.reserved = 0
+        buffer = (ctypes.c_uint8 * len(self.poll_payload)).from_buffer_copy(
+            self.poll_payload
+        )
+        self.poll_buffers.append(buffer)
+        output.flags = 0
+        output.data = ctypes.cast(buffer, ctypes.POINTER(ctypes.c_uint8))
+        output.size = len(self.poll_payload)
+        return int(NativeCoreStatus.OK)
+
+    def _close(self, _client: Any, options_pointer: Any) -> int:
+        options = _dereference(options_pointer, native._WceNativeAsrCloseOptions)
+        self.close_calls.append(
+            (int(options.request_handle), int(options.operation_nonce))
+        )
+        return int(self.close_status)
+
+    def _release(self, output_pointer: Any) -> None:
+        output = _dereference(output_pointer, native._WceOwnedBuffer)
+        self.releases.append((int(output.size), bool(output.data)))
+        output.data = ctypes.POINTER(ctypes.c_uint8)()
+        output.size = 0
+
+
+def _asr_client(stub: _AsrStub) -> NativeCoreClient:
+    client = object.__new__(NativeCoreClient)
+    client._supports_native_asr = True
+    client._library = stub.library
+    client._lock = threading.RLock()
+    client._closed = False
+    client._handle = ctypes.c_void_p(0x1234)
+    client._native_asr_handles = set()
+    return client
+
+
+def test_native_asr_ctypes_layout_matches_public_abi() -> None:
+    assert ctypes.sizeof(native._WceNativeAsrStatusOptions) == 24
+    assert ctypes.sizeof(native._WceNativeAsrStatus) == 152
+    assert ctypes.sizeof(native._WceNativeAsrBeginOptions) == 56
+    assert ctypes.sizeof(native._WceNativeAsrPollOptions) == 24
+    assert ctypes.sizeof(native._WceNativeAsrPollResult) == 32
+    assert ctypes.sizeof(native._WceNativeAsrCloseOptions) == 24
+    assert NativeCoreFeature.NATIVE_ASR == 1 << 4
+
+
+def test_old_runtime_without_asr_exports_keeps_core_abi_usable() -> None:
+    library = _abi_library()
+
+    client = _configure_client(library)
+
+    assert client.supports_native_asr is False
+    assert library.wce_database_open.argtypes is not None
+    with pytest.raises(NativeCoreProtocolError, match="does not implement"):
+        client.get_native_asr_status("wxid_example", Path.cwd().resolve())
+
+
+def test_partial_native_asr_exports_are_rejected_as_incomplete_abi() -> None:
+    library = _abi_library(native_asr_symbols=("wce_native_asr_get_status",))
+
+    with pytest.raises(NativeCoreProtocolError, match="incomplete native ASR ABI") as caught:
+        _configure_client(library)
+
+    assert "wce_native_asr_begin" in str(caught.value)
+    assert "wce_native_asr_poll" in str(caught.value)
+    assert "wce_native_asr_close" in str(caught.value)
+
+
+def test_complete_native_asr_exports_are_bound_as_one_optional_feature() -> None:
+    library = _abi_library(native_asr_symbols=_NATIVE_ASR_SYMBOLS)
+
+    client = _configure_client(library)
+
+    assert client.supports_native_asr is True
+    assert library.wce_native_asr_get_status.argtypes == [
+        ctypes.c_void_p,
+        ctypes.POINTER(native._WceNativeAsrStatusOptions),
+        ctypes.POINTER(native._WceNativeAsrStatus),
+    ]
+    assert library.wce_native_asr_poll.argtypes == [
+        ctypes.c_void_p,
+        ctypes.POINTER(native._WceNativeAsrPollOptions),
+        ctypes.POINTER(native._WceNativeAsrPollResult),
+        ctypes.POINTER(native._WceOwnedBuffer),
+    ]
+
+
+def test_native_asr_status_begin_poll_and_close_round_trip(tmp_path: Path) -> None:
+    stub = _AsrStub()
+    client = _asr_client(stub)
+    account_directory = tmp_path.resolve()
+
+    status = client.get_native_asr_status("wxid_测试", account_directory)
+    request_handle = client.begin_native_asr(
+        "wxid_测试",
+        account_directory,
+        "wxid_hh0lft94go3y22",
+        1_265_681_483_748_099_968,
+        342,
+    )
+    result = client.poll_native_asr(request_handle)
+    client.close_native_asr(request_handle)
+
+    assert status.reason is NativeCoreAsrReason.READY
+    assert status.platform_supported is True
+    assert status.ready is True
+    assert status.wechat_process_id == 4321
+    assert status.expected_wechat_version == "4.1.12.26"
+    assert status.actual_wechat_version == "4.1.12.26"
+    assert status.expected_weixin_sha256 == bytes(range(32))
+    assert status.actual_weixin_sha256 == bytes(reversed(range(32)))
+    assert request_handle == 73
+    assert result.state is NativeCoreAsrRequestState.SUCCEEDED
+    assert result.reason is NativeCoreAsrReason.READY
+    assert result.terminal_status is NativeCoreStatus.OK
+    assert result.server_id == 1_265_681_483_748_099_968
+    assert result.local_id == 342
+    assert result.text == "转写完成"
+    assert stub.status_calls == [
+        ("wxid_测试".encode(), str(account_directory).encode())
+    ]
+    assert stub.begin_calls[0][:5] == (
+        "wxid_测试".encode(),
+        str(account_directory).encode(),
+        b"wxid_hh0lft94go3y22",
+        1_265_681_483_748_099_968,
+        342,
+    )
+    assert stub.begin_calls[0][5] != 0
+    assert stub.poll_calls[0][0] == 73
+    assert stub.poll_calls[0][1] != 0
+    assert stub.close_calls[0][0] == 73
+    assert stub.close_calls[0][1] != 0
+    assert stub.releases == [(len("转写完成".encode()), True)]
+    assert client._native_asr_handles == set()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        NativeCoreStatus.NOT_FOUND,
+        NativeCoreStatus.LICENSE_REQUIRED,
+        NativeCoreStatus.LEASE_INVALID,
+        NativeCoreStatus.LEASE_EXPIRED,
+        NativeCoreStatus.FEATURE_DENIED,
+        NativeCoreStatus.BUILD_MISMATCH,
+        NativeCoreStatus.DEVICE_MISMATCH,
+        NativeCoreStatus.TAMPER_DETECTED,
+        NativeCoreStatus.LIMIT,
+    ],
+)
+def test_native_asr_close_discards_handle_after_broker_cleanup_status(
+    status: NativeCoreStatus,
+) -> None:
+    stub = _AsrStub()
+    stub.close_status = status
+    client = _asr_client(stub)
+    client._native_asr_handles.add(73)
+
+    client.close_native_asr(73)
+
+    assert client._native_asr_handles == set()
+
+
+def test_native_asr_poll_rejects_non_utf8_text_and_releases_owned_buffer() -> None:
+    stub = _AsrStub(poll_payload=b"\xff")
+    client = _asr_client(stub)
+    client._native_asr_handles.add(73)
+
+    with pytest.raises(NativeCoreProtocolError, match="non-UTF-8 text"):
+        client.poll_native_asr(73)
+
+    assert stub.releases == [(1, True)]
+    assert client._native_asr_handles == {73}
+
+
+@pytest.mark.parametrize("corruption", ["struct_size", "flags", "oversize"])
+def test_native_asr_poll_rejects_malformed_owned_buffer_and_releases_it(
+    corruption: str,
+) -> None:
+    stub = _AsrStub(poll_payload=b"ok")
+    original_poll = stub._poll
+
+    def malformed_poll(
+        client_pointer: Any,
+        options_pointer: Any,
+        result_pointer: Any,
+        output_pointer: Any,
+    ) -> int:
+        rc = original_poll(
+            client_pointer,
+            options_pointer,
+            result_pointer,
+            output_pointer,
+        )
+        output = _dereference(output_pointer, native._WceOwnedBuffer)
+        if corruption == "struct_size":
+            output.struct_size = 0
+        elif corruption == "flags":
+            output.flags = 1
+        else:
+            output.size = 64 * 1024 + 1
+        return rc
+
+    stub.library.wce_native_asr_poll = _FakeFunction(malformed_poll)
+    client = _asr_client(stub)
+    client._native_asr_handles.add(73)
+
+    with pytest.raises(NativeCoreProtocolError, match="invalid owned buffer"):
+        client.poll_native_asr(73)
+
+    assert len(stub.releases) == 1
+
+
+def test_native_asr_status_rejects_non_canonical_fixed_utf8() -> None:
+    stub = _AsrStub()
+
+    def malformed_status(_client: Any, options_pointer: Any, status_pointer: Any) -> int:
+        rc = stub._get_status(_client, options_pointer, status_pointer)
+        status = _dereference(status_pointer, native._WceNativeAsrStatus)
+        _write_fixed_utf8(status, "actual_wechat_version", b"4.1\0garbage")
+        return rc
+
+    stub.library.wce_native_asr_get_status = _FakeFunction(malformed_status)
+    client = _asr_client(stub)
+
+    with pytest.raises(NativeCoreProtocolError, match="actual_wechat_version"):
+        client.get_native_asr_status("wxid_example", Path.cwd().resolve())
+
+
+@pytest.mark.parametrize(
+    ("account", "directory", "conversation", "server_id", "local_id"),
+    [
+        ("wxid\0bad", Path.cwd().resolve(), "friend", 1, 0),
+        ("wxid", Path("relative"), "friend", 1, 0),
+        ("wxid", Path.cwd().resolve(), "friend\0bad", 1, 0),
+        ("wxid", Path.cwd().resolve(), "friend", 0, 0),
+        ("wxid", Path.cwd().resolve(), "friend", 1, -1),
+    ],
+)
+def test_native_asr_begin_validates_utf8_paths_and_integer_ranges(
+    account: str,
+    directory: Path,
+    conversation: str,
+    server_id: int,
+    local_id: int,
+) -> None:
+    client = _asr_client(_AsrStub())
+
+    with pytest.raises(ValueError):
+        client.begin_native_asr(
+            account,
+            directory,
+            conversation,
+            server_id,
+            local_id,
+        )

--- a/tests/test_native_core_license_policy.py
+++ b/tests/test_native_core_license_policy.py
@@ -40,6 +40,7 @@ from wechat_decrypt_tool.native_core_client import (
     NativeCorePolicyError,
     NativeCoreProtocolError,
     NativeCoreRuntimeStatus,
+    NativeCoreStatus,
     NativeCoreUnavailableError,
 )
 from wechat_decrypt_tool.native_core_lease import ENV_LICENSE_TOKEN, ENV_LICENSE_URL
@@ -362,8 +363,9 @@ def test_expired_production_manifest_fails_closed_before_native_loading() -> Non
             buildExpiresAtUnix=now,
         )
 
-        with pytest.raises(NativeCorePolicyError, match="fixed expiration"):
+        with pytest.raises(NativeCorePolicyError, match="fixed expiration") as caught:
             native_core_client._load_native_core_build_manifest(component)
+        assert caught.value.status == NativeCoreStatus.BUILD_MISMATCH
 
 
 @pytest.mark.parametrize("development", [True, False])
@@ -1169,6 +1171,42 @@ def test_valid_lease_path_never_waits_for_the_background_refresh_lock() -> None:
     )
 
 
+def test_refresh_rejects_new_lease_shorter_than_requested_validity() -> None:
+    class NearExpiryClient(_FakeClient):
+        def install_lease(self, lease: bytes) -> None:
+            self.installed.append(bytes(lease))
+            self._status = replace(
+                self._status,
+                license_state=NativeCoreLicenseState.ACTIVE,
+                lease_expires_unix=int(time.time()) + 179,
+                feature_bits=NativeCoreFeature.NATIVE_ASR,
+            )
+
+    client = NearExpiryClient(_manifest(development=True))
+    with (
+        patch.object(
+            native_core_lease,
+            "validate_native_core_authorization_policy",
+            return_value="development",
+        ),
+        patch(
+            "wechat_decrypt_tool.native_core_dev_lease.issue_development_lease",
+            return_value=b"l" * 224,
+        ),
+    ):
+        with pytest.raises(NativeCorePolicyError) as caught:
+            native_core_lease._refresh_native_core_lease_internal(
+                client,
+                NativeCoreFeature.NATIVE_ASR,
+                minimum_validity_seconds=180,
+                force_online=False,
+                background=False,
+            )
+
+    assert caught.value.status == NativeCoreStatus.LEASE_EXPIRED
+    assert client.installed == [b"l" * 224]
+
+
 def test_heartbeat_worker_runs_online_refresh_in_the_background() -> None:
     client = _FakeClient(_manifest(development=False))
     attempted = threading.Event()
@@ -1417,7 +1455,7 @@ def test_production_refresh_rejects_broker_restart_after_challenge() -> None:
             "get_status",
             side_effect=[initial_status, restarted_status],
         ),
-        pytest.raises(NativeCorePolicyError, match="identity changed"),
+        pytest.raises(NativeCorePolicyError, match="identity changed") as caught,
     ):
         native_core_lease.refresh_native_core_lease(
             client,
@@ -1425,6 +1463,7 @@ def test_production_refresh_rejects_broker_restart_after_challenge() -> None:
         )
 
     assert len(opener.requests) == 1
+    assert caught.value.status == NativeCoreStatus.TAMPER_DETECTED
     assert client.proof_calls == []
     assert client.installed == []
 
@@ -1455,7 +1494,7 @@ def test_production_refresh_rejects_proof_for_a_different_broker_state() -> None
             "build_opener",
             return_value=opener,
         ),
-        pytest.raises(NativeCorePolicyError, match="challenged broker state"),
+        pytest.raises(NativeCorePolicyError, match="challenged broker state") as caught,
     ):
         native_core_lease.refresh_native_core_lease(
             client,
@@ -1463,6 +1502,7 @@ def test_production_refresh_rejects_proof_for_a_different_broker_state() -> None
         )
 
     assert len(opener.requests) == 1
+    assert caught.value.status == NativeCoreStatus.TAMPER_DETECTED
     assert client.installed == []
 
 

--- a/tests/test_native_core_voice_asr.py
+++ b/tests/test_native_core_voice_asr.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from wechat_decrypt_tool import native_core_voice_asr as module
+from wechat_decrypt_tool.native_core_client import (
+    NativeCoreAsrPollResult,
+    NativeCoreAsrReason,
+    NativeCoreAsrRequestState,
+    NativeCoreAsrStatus,
+    NativeCoreError,
+    NativeCorePolicyError,
+    NativeCoreProtocolError,
+    NativeCoreStatus,
+    NativeCoreUnavailableError,
+)
+from wechat_decrypt_tool.native_voice_transcription import (
+    NativeVoiceTriggerCommand,
+    NativeVoiceTriggerError,
+)
+
+
+class _Operation:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ImmediateThread:
+    def __init__(self, *, target, args, **_kwargs) -> None:
+        self._target = target
+        self._args = args
+
+    def start(self) -> None:
+        self._target(*self._args)
+
+
+def _ready_status() -> NativeCoreAsrStatus:
+    return NativeCoreAsrStatus(
+        reason=NativeCoreAsrReason.READY,
+        platform_supported=True,
+        ready=True,
+        wechat_process_id=1234,
+        expected_wechat_version="4.1.12.26",
+        actual_wechat_version="4.1.12.26",
+        expected_weixin_sha256=b"a" * 32,
+        actual_weixin_sha256=b"a" * 32,
+    )
+
+
+def test_status_maps_version_mismatch_to_product_reason(monkeypatch, tmp_path: Path):
+    operation = _Operation()
+    status = NativeCoreAsrStatus(
+        reason=NativeCoreAsrReason.WECHAT_VERSION_MISMATCH,
+        platform_supported=True,
+        ready=False,
+        wechat_process_id=4321,
+        expected_wechat_version="4.1.12.26",
+        actual_wechat_version="4.1.13.1",
+        expected_weixin_sha256=b"a" * 32,
+        actual_weixin_sha256=b"b" * 32,
+    )
+    client = SimpleNamespace(
+        supports_native_asr=True,
+        get_native_asr_status=lambda *_args: status,
+    )
+    monkeypatch.setattr(module.os, "name", "nt")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: client)
+
+    assert module.native_core_voice_asr_status(tmp_path / "wxid_test") == {
+        "available": False,
+        "reason": "weixin_version_unsupported",
+        "version": "4.1.12.26",
+        "pid": 4321,
+    }
+    assert operation.closed is True
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_code"),
+    [
+        (NativeCoreError("busy", status=NativeCoreStatus.BUSY), "native_transport_busy"),
+        (
+            NativeCoreError("timeout", status=NativeCoreStatus.TIMEOUT),
+            "native_trigger_timeout",
+        ),
+        (
+            NativeCorePolicyError(
+                "build mismatch", status=NativeCoreStatus.BUILD_MISMATCH
+            ),
+            "native_transport_unavailable",
+        ),
+        (
+            NativeCorePolicyError(
+                "tamper", status=NativeCoreStatus.TAMPER_DETECTED
+            ),
+            "native_transport_unavailable",
+        ),
+        (
+            NativeCorePolicyError(
+                "feature denied", status=NativeCoreStatus.FEATURE_DENIED
+            ),
+            "native_asr_not_authorized",
+        ),
+        (NativeCoreUnavailableError("missing"), "native_transport_unavailable"),
+        (
+            NativeCoreUnavailableError("pipe", status=NativeCoreStatus.IO),
+            "native_transport_unavailable",
+        ),
+        (NativeCoreProtocolError("protocol"), "native_transport_unavailable"),
+        (NativeCorePolicyError("policy"), "native_asr_not_authorized"),
+    ],
+)
+def test_native_core_errors_preserve_machine_status(error, expected_code):
+    assert module._native_core_error(error).code == expected_code
+
+
+def test_terminal_status_overrides_only_security_and_transport_failures():
+    lease_error = module._native_core_status_error(
+        NativeCoreStatus.LEASE_EXPIRED,
+        include_generic=False,
+    ) or module._reason_error(NativeCoreAsrReason.CALLBACK_FAILED)
+    assert lease_error.code == "native_asr_not_authorized"
+
+    provider_error = module._native_core_status_error(
+        NativeCoreStatus.UNAVAILABLE,
+        include_generic=False,
+    ) or module._reason_error(NativeCoreAsrReason.PROVIDER_UNAVAILABLE)
+    assert provider_error.code == "native_trigger_rejected"
+
+
+def test_transport_polls_success_and_persists_without_logging_text(
+    monkeypatch, tmp_path: Path
+):
+    operation = _Operation()
+    stored: list[tuple[str, dict[str, object]]] = []
+
+    class Client:
+        supports_native_asr = True
+
+        def get_native_asr_status(self, *_args):
+            return _ready_status()
+
+        def begin_native_asr(self, *_args):
+            return 99
+
+        def poll_native_asr(self, request_handle):
+            assert request_handle == 99
+            return NativeCoreAsrPollResult(
+                state=NativeCoreAsrRequestState.SUCCEEDED,
+                reason=NativeCoreAsrReason.READY,
+                terminal_status=NativeCoreStatus.OK,
+                server_id=1265681483748099968,
+                local_id=342,
+                text="private transcript",
+            )
+
+        def close_native_asr(self, request_handle):
+            assert request_handle == 99
+
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
+    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
+    monkeypatch.setattr(module.secrets, "token_urlsafe", lambda _size: "opaque")
+    monkeypatch.setattr(module.threading, "Thread", _ImmediateThread)
+    def store_pending(**kwargs):
+        stored.append(("pending", kwargs))
+        return SimpleNamespace(status="pending", request_id=kwargs["request_id"])
+
+    monkeypatch.setattr(module, "mark_native_voice_transcript_pending", store_pending)
+    monkeypatch.setattr(
+        module,
+        "mark_native_voice_transcript_success",
+        lambda **kwargs: stored.append(("success", kwargs)),
+    )
+
+    transport = module.NativeCoreVoiceAsrTransport()
+    receipt = transport.trigger(
+        NativeVoiceTriggerCommand(
+            account_dir=tmp_path / "wxid_test",
+            account="wxid_test",
+            conversation="wxid_peer",
+            server_id=1265681483748099968,
+            local_id=342,
+        )
+    )
+
+    assert receipt.status == "accepted"
+    assert receipt.request_id == "native-core:opaque"
+    assert [kind for kind, _ in stored] == ["pending", "success"]
+    assert stored[1][1]["text"] == "private transcript"
+    assert operation.closed is True
+
+
+def test_transport_fails_closed_on_account_mismatch(monkeypatch, tmp_path: Path):
+    operation = _Operation()
+    status = NativeCoreAsrStatus(
+        reason=NativeCoreAsrReason.ACCOUNT_MISMATCH,
+        platform_supported=True,
+        ready=False,
+        wechat_process_id=1234,
+        expected_wechat_version="4.1.12.26",
+        actual_wechat_version="4.1.12.26",
+        expected_weixin_sha256=b"a" * 32,
+        actual_weixin_sha256=b"a" * 32,
+    )
+    client = SimpleNamespace(
+        supports_native_asr=True,
+        get_native_asr_status=lambda *_args: status,
+    )
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: client)
+
+    with pytest.raises(NativeVoiceTriggerError) as caught:
+        module.NativeCoreVoiceAsrTransport().trigger(
+            NativeVoiceTriggerCommand(
+                account_dir=tmp_path / "wxid_test",
+                account="wxid_test",
+                conversation="wxid_peer",
+                server_id=1,
+                local_id=2,
+            )
+        )
+
+    assert caught.value.code == "native_trigger_rejected"
+    assert operation.closed is True
+
+
+def test_near_expiry_lease_fails_before_native_begin(monkeypatch, tmp_path: Path):
+    operation = _Operation()
+    begin_called = False
+
+    class Client:
+        supports_native_asr = True
+
+        def get_native_asr_status(self, *_args):
+            return _ready_status()
+
+        def begin_native_asr(self, *_args):
+            nonlocal begin_called
+            begin_called = True
+            return 99
+
+    def reject_short_lease(*_args, **_kwargs):
+        raise NativeCorePolicyError(
+            "lease expires too soon",
+            status=NativeCoreStatus.LEASE_EXPIRED,
+        )
+
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
+    monkeypatch.setattr(module, "refresh_native_core_lease", reject_short_lease)
+
+    with pytest.raises(NativeVoiceTriggerError) as caught:
+        module.NativeCoreVoiceAsrTransport().trigger(
+            NativeVoiceTriggerCommand(
+                account_dir=tmp_path / "wxid_test",
+                account="wxid_test",
+                conversation="wxid_peer",
+                server_id=1,
+                local_id=2,
+            )
+        )
+
+    assert caught.value.code == "native_asr_not_authorized"
+    assert begin_called is False
+    assert operation.closed is True
+
+
+def test_thread_start_failure_releases_operation_and_active_slot(
+    monkeypatch, tmp_path: Path
+):
+    operation = _Operation()
+    closed: list[int] = []
+
+    class Client:
+        supports_native_asr = True
+
+        def get_native_asr_status(self, *_args):
+            return _ready_status()
+
+        def begin_native_asr(self, *_args):
+            return 99
+
+        def close_native_asr(self, request_handle):
+            closed.append(request_handle)
+
+    class BrokenThread:
+        def __init__(self, **_kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread unavailable")
+
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
+    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
+    monkeypatch.setattr(module.secrets, "token_urlsafe", lambda _size: "opaque")
+    monkeypatch.setattr(module.threading, "Thread", BrokenThread)
+    monkeypatch.setattr(
+        module,
+        "mark_native_voice_transcript_pending",
+        lambda **kwargs: SimpleNamespace(
+            status="pending", request_id=kwargs["request_id"]
+        ),
+    )
+    transport = module.NativeCoreVoiceAsrTransport()
+    command = NativeVoiceTriggerCommand(
+        account_dir=tmp_path / "wxid_test",
+        account="wxid_test",
+        conversation="wxid_peer",
+        server_id=1,
+        local_id=2,
+    )
+
+    with pytest.raises(NativeVoiceTriggerError) as caught:
+        transport.trigger(command)
+
+    assert caught.value.code == "native_transport_failed"
+    assert operation.closed is True
+    assert transport._active is None
+    assert closed
+
+
+def test_concurrent_cached_success_wins_and_new_native_handle_is_closed(
+    monkeypatch, tmp_path: Path
+):
+    operation = _Operation()
+    closed: list[int] = []
+
+    class Client:
+        supports_native_asr = True
+
+        def get_native_asr_status(self, *_args):
+            return _ready_status()
+
+        def begin_native_asr(self, *_args):
+            return 99
+
+        def close_native_asr(self, request_handle):
+            closed.append(request_handle)
+
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
+    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
+    monkeypatch.setattr(module.secrets, "token_urlsafe", lambda _size: "new")
+    monkeypatch.setattr(
+        module,
+        "mark_native_voice_transcript_pending",
+        lambda **_kwargs: SimpleNamespace(status="success", request_id="winner"),
+    )
+    transport = module.NativeCoreVoiceAsrTransport()
+
+    receipt = transport.trigger(
+        NativeVoiceTriggerCommand(
+            account_dir=tmp_path / "wxid_test",
+            account="wxid_test",
+            conversation="wxid_peer",
+            server_id=1,
+            local_id=2,
+        )
+    )
+
+    assert receipt.status == "pending"
+    assert receipt.request_id == "winner"
+    assert closed == [99]
+    assert operation.closed is True
+    assert transport._active is None
+
+
+def test_worker_retries_transient_close_failure(monkeypatch, tmp_path: Path):
+    operation = _Operation()
+    close_calls = 0
+
+    class Client:
+        supports_native_asr = True
+
+        def get_native_asr_status(self, *_args):
+            return _ready_status()
+
+        def begin_native_asr(self, *_args):
+            return 99
+
+        def poll_native_asr(self, _request_handle):
+            return NativeCoreAsrPollResult(
+                state=NativeCoreAsrRequestState.SUCCEEDED,
+                reason=NativeCoreAsrReason.READY,
+                terminal_status=NativeCoreStatus.OK,
+                server_id=1,
+                local_id=2,
+                text="result",
+            )
+
+        def close_native_asr(self, _request_handle):
+            nonlocal close_calls
+            close_calls += 1
+            if close_calls == 1:
+                raise NativeCoreUnavailableError("temporary pipe failure")
+
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
+    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
+    monkeypatch.setattr(module.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(module, "_CLOSE_RETRY_DELAYS_SECONDS", (0.0,))
+    monkeypatch.setattr(
+        module,
+        "mark_native_voice_transcript_pending",
+        lambda **kwargs: SimpleNamespace(
+            status="pending", request_id=kwargs["request_id"]
+        ),
+    )
+    monkeypatch.setattr(module, "mark_native_voice_transcript_success", lambda **_k: None)
+    transport = module.NativeCoreVoiceAsrTransport()
+
+    receipt = transport.trigger(
+        NativeVoiceTriggerCommand(
+            account_dir=tmp_path / "wxid_test",
+            account="wxid_test",
+            conversation="wxid_peer",
+            server_id=1,
+            local_id=2,
+        )
+    )
+
+    assert receipt.status == "accepted"
+    assert close_calls == 2
+    assert operation.closed is True
+    assert transport.restart_required is False
+    assert transport._active is None
+
+
+def test_persistent_worker_close_failure_requires_restart(monkeypatch, tmp_path: Path):
+    operation = _Operation()
+
+    class Client:
+        supports_native_asr = True
+
+        def get_native_asr_status(self, *_args):
+            return _ready_status()
+
+        def begin_native_asr(self, *_args):
+            return 99
+
+        def poll_native_asr(self, _request_handle):
+            return NativeCoreAsrPollResult(
+                state=NativeCoreAsrRequestState.SUCCEEDED,
+                reason=NativeCoreAsrReason.READY,
+                terminal_status=NativeCoreStatus.OK,
+                server_id=1,
+                local_id=2,
+                text="result",
+            )
+
+        def close_native_asr(self, _request_handle):
+            raise NativeCoreUnavailableError("persistent pipe failure")
+
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
+    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
+    monkeypatch.setattr(module.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(module, "_CLOSE_RETRY_DELAYS_SECONDS", ())
+    monkeypatch.setattr(
+        module,
+        "mark_native_voice_transcript_pending",
+        lambda **kwargs: SimpleNamespace(
+            status="pending", request_id=kwargs["request_id"]
+        ),
+    )
+    monkeypatch.setattr(module, "mark_native_voice_transcript_success", lambda **_k: None)
+    transport = module.NativeCoreVoiceAsrTransport()
+    command = NativeVoiceTriggerCommand(
+        account_dir=tmp_path / "wxid_test",
+        account="wxid_test",
+        conversation="wxid_peer",
+        server_id=1,
+        local_id=2,
+    )
+
+    assert transport.trigger(command).status == "accepted"
+    assert transport.restart_required is True
+    assert operation.closed is False
+    with pytest.raises(NativeVoiceTriggerError) as caught:
+        transport.trigger(command)
+    assert caught.value.code == "native_trigger_rejected"
+    assert "完全退出微信" in caught.value.user_message
+    assert "重启本应用" in caught.value.user_message
+
+
+def test_pending_store_and_close_failure_retain_native_generation(
+    monkeypatch, tmp_path: Path
+):
+    operation = _Operation()
+
+    class Client:
+        supports_native_asr = True
+
+        def get_native_asr_status(self, *_args):
+            return _ready_status()
+
+        def begin_native_asr(self, *_args):
+            return 99
+
+        def close_native_asr(self, _request_handle):
+            raise NativeCoreUnavailableError("persistent pipe failure")
+
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
+    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
+    monkeypatch.setattr(module, "_CLOSE_RETRY_DELAYS_SECONDS", ())
+    monkeypatch.setattr(
+        module,
+        "mark_native_voice_transcript_pending",
+        lambda **_kwargs: (_ for _ in ()).throw(OSError("cache unavailable")),
+    )
+    transport = module.NativeCoreVoiceAsrTransport()
+
+    with pytest.raises(NativeVoiceTriggerError) as caught:
+        transport.trigger(
+            NativeVoiceTriggerCommand(
+                account_dir=tmp_path / "wxid_test",
+                account="wxid_test",
+                conversation="wxid_peer",
+                server_id=1,
+                local_id=2,
+            )
+        )
+
+    assert caught.value.code == "native_trigger_rejected"
+    assert transport.restart_required is True
+    assert operation.closed is False

--- a/tests/test_native_voice_transcript_polling_api.py
+++ b/tests/test_native_voice_transcript_polling_api.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from wechat_decrypt_tool import voice_transcription  # noqa: E402
+from wechat_decrypt_tool.routers import chat_media  # noqa: E402
+
+
+def _varint(value: int) -> bytes:
+    encoded = bytearray()
+    remaining = int(value)
+    while True:
+        byte = remaining & 0x7F
+        remaining >>= 7
+        encoded.append(byte | (0x80 if remaining else 0))
+        if not remaining:
+            return bytes(encoded)
+
+
+def _completed_native_payload(text: str) -> bytes:
+    text_bytes = text.encode("utf-8")
+    nested = b"\x08\x02\x12" + _varint(len(text_bytes)) + text_bytes
+    return b"\x2a" + _varint(len(nested)) + nested
+
+
+class NativeVoiceTranscriptPollingApiTest(unittest.TestCase):
+    def setUp(self) -> None:
+        app = FastAPI()
+        app.include_router(chat_media.router)
+        self.client = TestClient(
+            app,
+            base_url="http://127.0.0.1:10392",
+            client=("127.0.0.1", 50000),
+        )
+
+    def test_targeted_lookup_reads_only_requested_completed_message(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            account_dir = Path(tmp)
+            conn = sqlite3.connect(str(account_dir / "message_0.db"))
+            try:
+                conn.execute(
+                    "CREATE TABLE Msg_demo (server_id INTEGER, local_type INTEGER, packed_info_data BLOB)"
+                )
+                conn.executemany(
+                    "INSERT INTO Msg_demo VALUES (?, 34, ?)",
+                    [
+                        (111, _completed_native_payload("不是目标")),
+                        (222, _completed_native_payload("目标微信原生文字")),
+                    ],
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+            with patch.object(
+                voice_transcription,
+                "_list_realtime_native_voice_transcripts",
+            ) as realtime_lookup:
+                text = voice_transcription.lookup_native_voice_transcript(account_dir, 222)
+
+        self.assertEqual(text, "目标微信原生文字")
+        realtime_lookup.assert_not_called()
+
+    def test_native_poll_endpoint_preserves_large_server_id_and_does_not_use_whisper(self):
+        server_id = 9007199254740993
+        account_dir = Path("wxid_native_poll")
+        with (
+            patch.object(chat_media, "_resolve_account_dir", return_value=account_dir) as resolve,
+            patch.object(
+                chat_media,
+                "resolve_native_voice_target",
+                return_value=(4294967295, server_id, "微信已经生成的文字"),
+            ) as lookup,
+            patch.object(chat_media, "get_voice_transcription_service") as whisper,
+        ):
+            response = self.client.get(
+                "/api/chat/media/voice/transcription/native",
+                params={
+                    "account": "wxid_native_poll",
+                    "username": "wxid_friend",
+                    "server_id": str(server_id),
+                    "local_id": "4294967295",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "success",
+                "serverId": str(server_id),
+                "localId": "4294967295",
+                "requestId": "",
+                "text": "微信已经生成的文字",
+                "language": "",
+                "model": "wechat-native",
+            },
+        )
+        self.assertEqual(response.headers.get("cache-control"), "no-store")
+        resolve.assert_called_once_with("wxid_native_poll")
+        lookup.assert_called_once_with(
+            account_dir,
+            conversation="wxid_friend",
+            server_id=server_id,
+            local_id=4294967295,
+        )
+        whisper.assert_not_called()
+
+    def test_native_status_is_passive_and_scoped_to_selected_account(self):
+        account_dir = Path("wxid_native_status")
+        expected = {
+            "available": False,
+            "reason": "runtime_trigger_e2e_not_validated",
+            "version": "4.1.12.26",
+            "pid": 42,
+        }
+        with (
+            patch.object(chat_media, "_resolve_account_dir", return_value=account_dir) as resolve,
+            patch.object(chat_media, "native_bridge_status", return_value=expected) as status,
+        ):
+            response = self.client.get(
+                "/api/chat/media/voice/transcription/native/status",
+                params={"account": "wxid_native_status"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+        self.assertEqual(response.headers.get("cache-control"), "no-store")
+        resolve.assert_called_once_with("wxid_native_status")
+        status.assert_called_once_with(account_dir)
+
+    def test_targeted_lookup_uses_exact_server_id_in_realtime_wcdb(self):
+        server_id = 9007199254740993
+        with tempfile.TemporaryDirectory() as tmp:
+            account_dir = Path(tmp) / "account"
+            message_dir = Path(tmp) / "raw" / "message"
+            message_dir.mkdir(parents=True)
+            (message_dir / "message_0.db").touch()
+            realtime = Mock(db_storage_dir=message_dir.parent, handle=1, lock=threading.Lock())
+
+            def exec_query(_handle, *, kind, path, sql):
+                self.assertEqual(kind, "message")
+                self.assertTrue(str(path).endswith("message_0.db"))
+                if "sqlite_master" in sql:
+                    return [{"name": "Msg_demo"}]
+                self.assertIn(f"server_id = {server_id}", sql)
+                return [{
+                    "server_id": server_id,
+                    "packed_info_data": _completed_native_payload("realtime 定向结果").hex(),
+                }]
+
+            with (
+                patch(
+                    "wechat_decrypt_tool.wcdb_realtime.WCDB_REALTIME.ensure_connected",
+                    return_value=realtime,
+                ),
+                patch(
+                    "wechat_decrypt_tool.wcdb_realtime.exec_query",
+                    side_effect=exec_query,
+                ),
+            ):
+                text = voice_transcription.lookup_native_voice_transcript(account_dir, server_id)
+
+        self.assertEqual(text, "realtime 定向结果")
+
+    def test_native_poll_endpoint_returns_pending_without_triggering_recognition(self):
+        with (
+            patch.object(chat_media, "_resolve_account_dir", return_value=Path("wxid_pending")),
+            patch.object(chat_media, "resolve_native_voice_target", return_value=(9, 123, "")),
+        ):
+            response = self.client.get(
+                "/api/chat/media/voice/transcription/native",
+                params={
+                    "account": "wxid_pending",
+                    "username": "wxid_friend",
+                    "server_id": "123",
+                    "local_id": "9",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "pending",
+                "serverId": "123",
+                "localId": "9",
+                "requestId": "",
+                "text": "",
+                "language": "",
+                "model": "",
+            },
+        )
+
+    def test_native_poll_endpoint_rejects_non_positive_server_id(self):
+        response = self.client.get(
+            "/api/chat/media/voice/transcription/native",
+            params={
+                "account": "wxid_pending",
+                "username": "wxid_friend",
+                "server_id": "0",
+                "local_id": "9",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_native_poll_reads_only_the_exact_callback_request(self):
+        server_id = 9007199254740993
+        entry = SimpleNamespace(
+            request_id="request-current",
+            status="success",
+            text="bridge 回调文字",
+            error_code="",
+            error_message="",
+        )
+        with (
+            patch.object(chat_media, "_resolve_account_dir", return_value=Path("wxid_callback")),
+            patch.object(
+                chat_media,
+                "lookup_native_voice_transcript_cache",
+                return_value=entry,
+            ) as lookup,
+        ):
+            response = self.client.get(
+                "/api/chat/media/voice/transcription/native",
+                params={
+                    "account": "wxid_callback",
+                    "username": "wxid_friend",
+                    "server_id": str(server_id),
+                    "local_id": "7",
+                    "request_id": "request-current",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "success")
+        self.assertEqual(response.json()["model"], "wechat-native")
+        self.assertEqual(response.json()["requestId"], "request-current")
+        self.assertEqual(response.headers.get("cache-control"), "no-store")
+        lookup.assert_called_once_with(
+            Path("wxid_callback"),
+            server_id,
+            conversation="wxid_friend",
+            local_id=7,
+            request_id="request-current",
+            strict=True,
+        )
+
+    def test_native_poll_does_not_return_a_different_request_generation(self):
+        entry = SimpleNamespace(
+            request_id="request-newer",
+            status="success",
+            text="不应返回",
+            error_code="",
+            error_message="",
+        )
+        with (
+            patch.object(chat_media, "_resolve_account_dir", return_value=Path("wxid_callback")),
+            patch.object(chat_media, "lookup_native_voice_transcript_cache", return_value=entry),
+        ):
+            response = self.client.get(
+                "/api/chat/media/voice/transcription/native",
+                params={
+                    "account": "wxid_callback",
+                    "username": "wxid_friend",
+                    "server_id": "123",
+                    "local_id": "7",
+                    "request_id": "request-old",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "expired")
+        self.assertEqual(response.json()["text"], "")
+        self.assertEqual(response.json()["code"], "native_result_expired")
+
+    def test_native_poll_surfaces_cached_terminal_error_without_text(self):
+        entry = SimpleNamespace(
+            request_id="request-error",
+            status="error",
+            text="",
+            error_code="native_callback_released",
+            error_message="微信原生语音转文字未返回结果。",
+        )
+        with (
+            patch.object(chat_media, "_resolve_account_dir", return_value=Path("wxid_callback")),
+            patch.object(chat_media, "lookup_native_voice_transcript_cache", return_value=entry),
+        ):
+            response = self.client.get(
+                "/api/chat/media/voice/transcription/native",
+                params={
+                    "account": "wxid_callback",
+                    "username": "wxid_friend",
+                    "server_id": "123",
+                    "local_id": "7",
+                    "request_id": "request-error",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "error")
+        self.assertEqual(response.json()["text"], "")
+        self.assertEqual(response.json()["code"], "native_callback_released")
+
+    def test_native_poll_rejects_malformed_request_id_without_touching_cache(self):
+        with patch.object(chat_media, "lookup_native_voice_transcript_cache") as lookup:
+            response = self.client.get(
+                "/api/chat/media/voice/transcription/native",
+                params={
+                    "account": "wxid_callback",
+                    "username": "wxid_friend",
+                    "server_id": "123",
+                    "local_id": "7",
+                    "request_id": "x" * 257,
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"]["code"], "invalid_request_id")
+        lookup.assert_not_called()
+
+    def test_native_result_get_requires_loopback_client(self):
+        remote = TestClient(
+            self.client.app,
+            base_url="http://127.0.0.1:10392",
+            client=("192.0.2.10", 50000),
+        )
+        response = remote.get(
+            "/api/chat/media/voice/transcription/native",
+            params={
+                "account": "wxid_callback",
+                "username": "wxid_friend",
+                "server_id": "123",
+                "local_id": "7",
+                "request_id": "request-1",
+            },
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_native_cache_batch_restores_only_exact_conversation_and_local_id(self):
+        account_dir = Path("wxid_callback")
+        entry = SimpleNamespace(
+            status="success",
+            request_id="request-success",
+            text="持久 callback 结果",
+            error_code="",
+            error_message="",
+        )
+        with (
+            patch.object(chat_media, "_resolve_account_dir", return_value=account_dir),
+            patch.object(
+                chat_media,
+                "lookup_native_voice_transcript_cache",
+                return_value=entry,
+            ) as lookup,
+            patch.object(chat_media, "get_voice_transcription_service") as whisper,
+        ):
+            response = self.client.post(
+                "/api/chat/media/voice/transcription/native/cache_lookup",
+                json={
+                    "account": "wxid_callback",
+                    "username": "wxid_friend",
+                    "items": [{"server_id": "9007199254740993", "local_id": "7"}],
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("cache-control"), "no-store")
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "success",
+                "items": [{
+                    "serverId": "9007199254740993",
+                    "localId": "7",
+                    "status": "success",
+                    "requestId": "request-success",
+                    "text": "持久 callback 结果",
+                    "language": "",
+                    "model": "wechat-native",
+                }],
+            },
+        )
+        lookup.assert_called_once_with(
+            account_dir,
+            9007199254740993,
+            conversation="wxid_friend",
+            local_id=7,
+            strict=True,
+        )
+        whisper.assert_not_called()
+
+    def test_native_cache_batch_restores_pending_and_error_generations(self):
+        account_dir = Path("wxid_callback")
+        cases = (
+            (
+                SimpleNamespace(
+                    status="pending",
+                    request_id="request-pending",
+                    text="",
+                    error_code="",
+                    error_message="",
+                ),
+                {
+                    "serverId": "9007199254740993",
+                    "localId": "7",
+                    "status": "pending",
+                    "requestId": "request-pending",
+                    "pollAfterMs": 1200,
+                },
+            ),
+            (
+                SimpleNamespace(
+                    status="error",
+                    request_id="request-error",
+                    text="",
+                    error_code="native_trigger_timeout",
+                    error_message="微信原生语音转文字等待超时。",
+                ),
+                {
+                    "serverId": "9007199254740993",
+                    "localId": "7",
+                    "status": "error",
+                    "requestId": "request-error",
+                    "code": "native_trigger_timeout",
+                    "message": "微信原生语音转文字等待超时。",
+                },
+            ),
+        )
+        for entry, expected in cases:
+            with (
+                self.subTest(status=entry.status),
+                patch.object(chat_media, "_resolve_account_dir", return_value=account_dir),
+                patch.object(
+                    chat_media,
+                    "lookup_native_voice_transcript_cache",
+                    return_value=entry,
+                ),
+                patch.object(chat_media, "get_voice_transcription_service") as whisper,
+            ):
+                response = self.client.post(
+                    "/api/chat/media/voice/transcription/native/cache_lookup",
+                    json={
+                        "account": "wxid_callback",
+                        "username": "wxid_friend",
+                        "items": [{"server_id": "9007199254740993", "local_id": "7"}],
+                    },
+                )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), {"status": "success", "items": [expected]})
+            whisper.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_voice_transcription_cache.py
+++ b/tests/test_native_voice_transcription_cache.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from wechat_decrypt_tool import native_voice_transcription as native  # noqa: E402
+
+
+def _varint(value: int) -> bytes:
+    encoded = bytearray()
+    remaining = int(value)
+    while True:
+        byte = remaining & 0x7F
+        remaining >>= 7
+        encoded.append(byte | (0x80 if remaining else 0))
+        if not remaining:
+            return bytes(encoded)
+
+
+def _completed_native_payload(text: str) -> bytes:
+    text_bytes = text.encode("utf-8")
+    nested = b"\x08\x02\x12" + _varint(len(text_bytes)) + text_bytes
+    return b"\x2a" + _varint(len(nested)) + nested
+
+
+def _seed_voice_row(
+    account_dir: Path,
+    *,
+    conversation: str,
+    local_id: int,
+    server_id: int,
+    packed_info_data: bytes,
+) -> None:
+    table = f"Msg_{hashlib.md5(conversation.encode('utf-8')).hexdigest()}"
+    conn = sqlite3.connect(str(account_dir / "message_0.db"))
+    try:
+        conn.execute(
+            f'CREATE TABLE "{table}" '
+            "(local_id INTEGER, server_id INTEGER, local_type INTEGER, packed_info_data BLOB)"
+        )
+        conn.execute(
+            f'INSERT INTO "{table}" VALUES (?, ?, 34, ?)',
+            (local_id, server_id, packed_info_data),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_success_cache_is_persistent_normalized_and_scoped(tmp_path: Path):
+    account_dir = tmp_path / "wxid_first"
+    account_dir.mkdir()
+    other_account = tmp_path / "wxid_second"
+    server_id = (1 << 64) - 1
+
+    stored = native.mark_native_voice_transcript_success(
+        account_dir=account_dir,
+        conversation="room@chatroom",
+        server_id=server_id,
+        local_id=7279,
+        request_id="request-1",
+        text="  Cafe\u0301\r\n第二行  ",
+    )
+
+    assert stored.status == "success"
+    assert stored.text == "Café\n第二行"
+    assert stored.expires_at is None
+    assert native.lookup_cached_native_voice_transcript(account_dir, server_id) == "Café\n第二行"
+    assert native.lookup_native_voice_transcript_cache(
+        account_dir,
+        server_id,
+        conversation="room@chatroom",
+        local_id=7279,
+        now=stored.updated_at + 10 * 365 * 24 * 60 * 60,
+    ) == stored
+    assert native.lookup_native_voice_transcript_cache(
+        account_dir,
+        server_id,
+        conversation="wxid_wrong",
+        local_id=7279,
+    ) is None
+    assert native.lookup_native_voice_transcript_cache(
+        account_dir,
+        server_id,
+        conversation="room@chatroom",
+        local_id=7280,
+    ) is None
+    assert native.lookup_native_voice_transcript_cache(other_account, server_id) is None
+    assert not (other_account / "_cache").exists()
+    assert (account_dir / "_cache" / "native_voice_transcripts.sqlite3").is_file()
+
+
+def test_pending_and_error_expire_while_success_does_not(monkeypatch, tmp_path: Path):
+    account_dir = tmp_path / "wxid_ttl"
+    account_dir.mkdir()
+    clock = [100.0]
+    monkeypatch.setattr(native.time, "time", lambda: clock[0])
+    key = {
+        "account_dir": account_dir,
+        "conversation": "wxid_friend",
+        "server_id": 123,
+        "local_id": 7,
+        "request_id": "request-ttl",
+    }
+
+    pending = native.mark_native_voice_transcript_pending(**key, ttl_seconds=2.0)
+    assert native.lookup_native_voice_transcript_cache(account_dir, 123, now=101.9) == pending
+    assert native.lookup_native_voice_transcript_cache(account_dir, 123, now=102.0) is None
+    assert native.lookup_native_voice_transcript_cache(
+        account_dir,
+        123,
+        request_id="request-ttl",
+        now=102.0,
+        include_expired=True,
+    ) == pending
+    assert native.lookup_native_voice_transcript_cache(
+        account_dir,
+        123,
+        request_id="different-request",
+        include_expired=True,
+    ) is None
+
+    clock[0] = 200.0
+    error = native.mark_native_voice_transcript_error(
+        **key,
+        error_code="native_failed",
+        error_message="temporary failure",
+        ttl_seconds=3.0,
+    )
+    assert error.status == "error"
+    assert error.text == ""
+    clock[0] = 201.0
+    assert native.mark_native_voice_transcript_pending(**key) == error
+    assert native.lookup_native_voice_transcript_cache(account_dir, 123, now=202.9) == error
+    assert native.lookup_native_voice_transcript_cache(account_dir, 123, now=203.0) is None
+
+    clock[0] = 300.0
+    success = native.mark_native_voice_transcript_success(**key, text="永久结果")
+    assert success.expires_at is None
+    assert native.lookup_native_voice_transcript_cache(account_dir, 123, now=10**12) == success
+
+
+def test_callback_race_cannot_downgrade_success_or_overwrite_new_request(monkeypatch, tmp_path: Path):
+    account_dir = tmp_path / "wxid_race"
+    account_dir.mkdir()
+    clock = [100.0]
+    monkeypatch.setattr(native.time, "time", lambda: clock[0])
+    common = {
+        "account_dir": account_dir,
+        "conversation": "wxid_friend",
+        "server_id": 456,
+        "local_id": 8,
+    }
+
+    success = native.mark_native_voice_transcript_success(
+        **common,
+        request_id="request-a",
+        text="先完成",
+    )
+    clock[0] = 101.0
+    assert native.mark_native_voice_transcript_pending(
+        **common,
+        request_id="request-a",
+    ) == success
+
+    second = {**common, "server_id": 457}
+    native.mark_native_voice_transcript_pending(
+        **second,
+        request_id="request-old",
+        ttl_seconds=1.0,
+    )
+    clock[0] = 102.0
+    pending_new = native.mark_native_voice_transcript_pending(
+        **second,
+        request_id="request-new",
+    )
+    clock[0] = 103.0
+    stale = native.mark_native_voice_transcript_error(
+        **second,
+        request_id="request-old",
+        error_code="late_error",
+    )
+    assert stale == pending_new
+    assert native.lookup_native_voice_transcript_cache(account_dir, 457) == pending_new
+
+
+def test_new_pending_request_replaces_live_orphan_after_backend_restart(monkeypatch, tmp_path: Path):
+    account_dir = tmp_path / "wxid_restart"
+    account_dir.mkdir()
+    clock = [100.0]
+    monkeypatch.setattr(native.time, "time", lambda: clock[0])
+    common = {
+        "account_dir": account_dir,
+        "conversation": "wxid_friend",
+        "server_id": 458,
+        "local_id": 9,
+    }
+    native.mark_native_voice_transcript_pending(
+        **common,
+        request_id="request-before-restart",
+    )
+
+    clock[0] = 101.0
+    after_restart = native.mark_native_voice_transcript_pending(
+        **common,
+        request_id="request-after-restart",
+    )
+    stale_callback = native.mark_native_voice_transcript_success(
+        **common,
+        request_id="request-before-restart",
+        text="过期任务的回调",
+    )
+
+    assert after_restart.status == "pending"
+    assert after_restart.request_id == "request-after-restart"
+    assert stale_callback == after_restart
+    assert native.lookup_native_voice_transcript_cache(account_dir, 458) == after_restart
+
+
+def test_concurrent_pending_and_success_writes_finish_as_success(tmp_path: Path):
+    account_dir = tmp_path / "wxid_threads"
+    account_dir.mkdir()
+    common = {
+        "account_dir": account_dir,
+        "conversation": "wxid_friend",
+        "server_id": 789,
+        "local_id": 9,
+        "request_id": "request-threaded",
+    }
+
+    def write(index: int):
+        if index % 2:
+            return native.mark_native_voice_transcript_success(**common, text="并发完成")
+        return native.mark_native_voice_transcript_pending(**common)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        entries = list(executor.map(write, range(24)))
+
+    assert len(entries) == 24
+    final = native.lookup_native_voice_transcript_cache(account_dir, 789)
+    assert final is not None
+    assert final.status == "success"
+    assert final.text == "并发完成"
+
+
+def test_resolve_prefers_project_callback_success_over_packed_info(monkeypatch, tmp_path: Path):
+    conversation = "wxid_friend"
+    local_id = 7279
+    server_id = 9007199254740993
+    _seed_voice_row(
+        tmp_path,
+        conversation=conversation,
+        local_id=local_id,
+        server_id=server_id,
+        packed_info_data=_completed_native_payload("packed_info 旧结果"),
+    )
+    native.mark_native_voice_transcript_success(
+        account_dir=tmp_path,
+        conversation=conversation,
+        server_id=server_id,
+        local_id=local_id,
+        request_id="request-callback",
+        text="项目回调结果",
+    )
+    monkeypatch.setattr(
+        native,
+        "_query_realtime_voice_targets",
+        lambda *_args, **_kwargs: native._VoiceTargetQueryResult(set(), {}, 0, []),
+    )
+
+    assert native.resolve_native_voice_target(
+        tmp_path,
+        conversation=conversation,
+        server_id=server_id,
+        local_id=local_id,
+    ) == (local_id, server_id, "项目回调结果")
+
+
+def test_corrupt_project_cache_falls_back_to_packed_info(monkeypatch, tmp_path: Path):
+    conversation = "wxid_friend"
+    local_id = 42
+    server_id = 2468
+    _seed_voice_row(
+        tmp_path,
+        conversation=conversation,
+        local_id=local_id,
+        server_id=server_id,
+        packed_info_data=_completed_native_payload("packed_info 可用结果"),
+    )
+    cache_path = tmp_path / "_cache" / "native_voice_transcripts.sqlite3"
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"not a sqlite database")
+    monkeypatch.setattr(
+        native,
+        "_query_realtime_voice_targets",
+        lambda *_args, **_kwargs: native._VoiceTargetQueryResult(set(), {}, 0, []),
+    )
+
+    assert native.resolve_native_voice_target(
+        tmp_path,
+        conversation=conversation,
+        server_id=server_id,
+        local_id=local_id,
+    ) == (local_id, server_id, "packed_info 可用结果")
+
+    with pytest.raises(native.NativeVoiceTriggerError) as raised:
+        native.lookup_native_voice_transcript_cache(tmp_path, server_id, strict=True)
+    assert raised.value.code == "native_result_store_unavailable"

--- a/tests/test_native_voice_transcription_trigger_api.py
+++ b/tests/test_native_voice_transcription_trigger_api.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from wechat_decrypt_tool import native_voice_transcription  # noqa: E402
+from wechat_decrypt_tool.native_voice_transcription import (  # noqa: E402
+    NativeVoiceTriggerError,
+    NativeVoiceTriggerReceipt,
+    parse_native_voice_message_id,
+    trigger_native_voice_transcription,
+)
+from wechat_decrypt_tool.routers import chat_media  # noqa: E402
+
+
+class FakeNativeVoiceTriggerTransport:
+    def __init__(self, status: str = "accepted", request_id: str = "native-request-1") -> None:
+        self.status = status
+        self.request_id = request_id
+        self.commands = []
+
+    def trigger(self, command):
+        self.commands.append(command)
+        return NativeVoiceTriggerReceipt(status=self.status, request_id=self.request_id)
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(chat_media.router)
+    return TestClient(
+        app,
+        base_url="http://127.0.0.1:10392",
+        client=("127.0.0.1", 50000),
+    )
+
+
+def _seed_voice_row(
+    account_dir: Path,
+    *,
+    conversation: str,
+    local_id: int,
+    server_id: int,
+    local_type: int = 34,
+    packed_info_data: bytes | None = None,
+    db_name: str = "message_0.db",
+) -> None:
+    table = f"Msg_{hashlib.md5(conversation.encode('utf-8')).hexdigest()}"
+    db_path = account_dir / db_name
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            f'CREATE TABLE IF NOT EXISTS "{table}" '
+            "(local_id INTEGER, server_id INTEGER, local_type INTEGER, packed_info_data BLOB)"
+        )
+        conn.execute(
+            f'INSERT INTO "{table}" VALUES (?, ?, ?, ?)',
+            (local_id, server_id, local_type, packed_info_data),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _varint(value: int) -> bytes:
+    encoded = bytearray()
+    remaining = int(value)
+    while True:
+        byte = remaining & 0x7F
+        remaining >>= 7
+        encoded.append(byte | (0x80 if remaining else 0))
+        if not remaining:
+            return bytes(encoded)
+
+
+def _completed_native_payload(text: str) -> bytes:
+    text_bytes = text.encode("utf-8")
+    nested = b"\x08\x02\x12" + _varint(len(text_bytes)) + text_bytes
+    return b"\x2a" + _varint(len(nested)) + nested
+
+
+def test_trigger_fast_path_returns_existing_native_text_without_transport(monkeypatch, tmp_path: Path):
+    server_id = "9007199254740993"
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_friend",
+        local_id=7279,
+        server_id=int(server_id),
+        packed_info_data=_completed_native_payload("微信已有文字"),
+    )
+
+    class MustNotRun:
+        def trigger(self, _command):
+            raise AssertionError("transport must not run for an existing transcript")
+
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    monkeypatch.setattr(
+        native_voice_transcription,
+        "get_native_voice_trigger_transport",
+        lambda: MustNotRun(),
+    )
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={
+            "account": "wxid_account",
+            "username": "wxid_friend",
+            "server_id": server_id,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("cache-control") == "no-store"
+    assert response.json() == {
+        "status": "success",
+        "serverId": server_id,
+        "localId": "7279",
+        "account": tmp_path.name,
+        "conversation": "wxid_friend",
+        "language": "",
+        "text": "微信已有文字",
+        "model": "wechat-native",
+        "requestId": "",
+        "pollAfterMs": 0,
+    }
+
+
+def test_trigger_dispatches_once_and_returns_accepted_without_polling(monkeypatch, tmp_path: Path):
+    transport = FakeNativeVoiceTriggerTransport()
+    (tmp_path / "account.json").write_text(
+        '{"username":"wxid_native_account"}',
+        encoding="utf-8",
+    )
+    _seed_voice_row(
+        tmp_path,
+        conversation="room@chatroom",
+        local_id=7279,
+        server_id=9038636853230485365,
+    )
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    monkeypatch.setattr(
+        native_voice_transcription,
+        "get_native_voice_trigger_transport",
+        lambda: transport,
+    )
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={
+            "account": "wxid_account",
+            "username": "room@chatroom",
+            "server_id": "9038636853230485365",
+            "local_id": "7279",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "accepted"
+    assert payload["serverId"] == "9038636853230485365"
+    assert payload["localId"] == "7279"
+    assert payload["requestId"] == "native-request-1"
+    assert payload["pollAfterMs"] == 1200
+    assert len(transport.commands) == 1
+    command = transport.commands[0]
+    assert command.account_dir == tmp_path
+    assert command.account == "wxid_native_account"
+    assert command.conversation == "room@chatroom"
+    assert command.server_id == 9038636853230485365
+    assert command.local_id == 7279
+
+
+def test_imported_snapshot_lookup_never_falls_through_to_realtime(monkeypatch, tmp_path: Path):
+    transport = FakeNativeVoiceTriggerTransport()
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_friend",
+        local_id=7279,
+        server_id=9038636853230485365,
+    )
+    (tmp_path / "session.db").touch()
+    (tmp_path / "contact.db").touch()
+    (tmp_path / "_source.json").write_text(
+        '{"import_mode":"manual_import"}',
+        encoding="utf-8",
+    )
+
+    def fail_realtime(*_args, **_kwargs):
+        raise AssertionError("imported snapshot must not query realtime WCDB")
+
+    monkeypatch.setattr(
+        native_voice_transcription,
+        "_query_realtime_voice_targets",
+        fail_realtime,
+    )
+
+    result = trigger_native_voice_transcription(
+        account_dir=tmp_path,
+        conversation="wxid_friend",
+        server_id="9038636853230485365",
+        local_id="7279",
+        transport=transport,
+    )
+
+    assert result["status"] == "accepted"
+    assert len(transport.commands) == 1
+
+
+def test_local_id_is_resolved_in_the_selected_conversation_before_dispatch(tmp_path: Path):
+    conversation = "wxid_friend"
+    server_id = 9038636853230485365
+    table = f"Msg_{hashlib.md5(conversation.encode('utf-8')).hexdigest()}"
+    db_path = tmp_path / "message_0.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            f'CREATE TABLE "{table}" (local_id INTEGER, server_id INTEGER, local_type INTEGER)'
+        )
+        conn.executemany(
+            f'INSERT INTO "{table}" VALUES (?, ?, ?)',
+            [
+                (7279, server_id, 34),
+                (7279, server_id + 1, 3),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    transport = FakeNativeVoiceTriggerTransport(status="pending", request_id="already-running")
+
+    result = trigger_native_voice_transcription(
+        account_dir=tmp_path,
+        conversation=conversation,
+        local_id="7279",
+        transport=transport,
+    )
+
+    assert result["status"] == "pending"
+    assert result["serverId"] == str(server_id)
+    assert result["localId"] == "7279"
+    assert result["requestId"] == "already-running"
+    assert len(transport.commands) == 1
+    assert transport.commands[0].server_id == server_id
+
+
+@pytest.mark.parametrize("request_id", ["", "x" * 257, "bad\nrequest"])
+def test_transport_must_return_a_valid_request_id(tmp_path: Path, request_id: str):
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_friend",
+        local_id=7,
+        server_id=123,
+    )
+    transport = FakeNativeVoiceTriggerTransport(request_id=request_id)
+
+    with pytest.raises(NativeVoiceTriggerError) as caught:
+        trigger_native_voice_transcription(
+            account_dir=tmp_path,
+            conversation="wxid_friend",
+            server_id="123",
+            local_id="7",
+            transport=transport,
+        )
+
+    assert caught.value.code == "native_transport_invalid_response"
+    assert len(transport.commands) == 1
+
+
+def test_trigger_request_rejects_json_numbers_instead_of_coercing_them():
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={
+            "account": "wxid_account",
+            "username": "wxid_friend",
+            "server_id": 9007199254740993,
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_unavailable_transport_is_explicitly_reported(monkeypatch, tmp_path: Path):
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_friend",
+        local_id=7,
+        server_id=123,
+    )
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    monkeypatch.setattr(
+        native_voice_transcription,
+        "get_native_voice_trigger_transport",
+        lambda: native_voice_transcription.UnavailableNativeVoiceTriggerTransport(),
+    )
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={"account": "wxid_account", "username": "wxid_friend", "server_id": "123"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "native_transport_unavailable"
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["native_weixin_not_running", "native_weixin_version_unsupported"],
+)
+def test_native_weixin_unavailable_errors_are_503(monkeypatch, tmp_path: Path, error_code: str):
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_friend",
+        local_id=7,
+        server_id=123,
+    )
+
+    class RejectingTransport:
+        def trigger(self, _command):
+            raise NativeVoiceTriggerError(error_code, "native unavailable")
+
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    monkeypatch.setattr(
+        native_voice_transcription,
+        "get_native_voice_trigger_transport",
+        lambda: RejectingTransport(),
+    )
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={"account": "wxid_account", "username": "wxid_friend", "server_id": "123"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == error_code
+
+
+def test_trigger_rejects_noncanonical_or_missing_string_ids(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    client = _client()
+
+    leading_zero = client.post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={"account": "wxid_account", "username": "wxid_friend", "server_id": "00123"},
+    )
+    missing = client.post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={"account": "wxid_account", "username": "wxid_friend"},
+    )
+
+    assert leading_zero.status_code == 400
+    assert leading_zero.json()["detail"]["code"] == "invalid_message_id"
+    assert missing.status_code == 400
+    assert missing.json()["detail"]["code"] == "missing_message_id"
+
+
+def test_fast_path_cannot_read_a_server_id_from_another_conversation(monkeypatch, tmp_path: Path):
+    server_id = 9007199254740993
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_other_friend",
+        local_id=8,
+        server_id=server_id,
+        packed_info_data=_completed_native_payload("不应跨会话读取"),
+    )
+    transport = FakeNativeVoiceTriggerTransport()
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    monkeypatch.setattr(
+        native_voice_transcription,
+        "get_native_voice_trigger_transport",
+        lambda: transport,
+    )
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={
+            "account": "wxid_account",
+            "username": "wxid_selected_friend",
+            "server_id": str(server_id),
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "voice_message_not_found"
+    assert transport.commands == []
+
+
+def test_two_supplied_ids_must_map_to_the_same_voice_row(monkeypatch, tmp_path: Path):
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_friend",
+        local_id=7,
+        server_id=101,
+    )
+    _seed_voice_row(
+        tmp_path,
+        conversation="wxid_friend",
+        local_id=8,
+        server_id=102,
+    )
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={
+            "account": "wxid_account",
+            "username": "wxid_friend",
+            "server_id": "102",
+            "local_id": "7",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "voice_message_id_mismatch"
+
+
+def test_two_supplied_ids_allow_local_id_reuse_in_another_message_shard(
+    monkeypatch,
+    tmp_path: Path,
+):
+    conversation = "wxid_friend"
+    exact_server_id = 1265681483748099968
+    _seed_voice_row(
+        tmp_path,
+        conversation=conversation,
+        local_id=342,
+        server_id=5067469402983745468,
+        db_name="message_1.db",
+    )
+    _seed_voice_row(
+        tmp_path,
+        conversation=conversation,
+        local_id=342,
+        server_id=exact_server_id,
+        db_name="message_5.db",
+    )
+    transport = FakeNativeVoiceTriggerTransport()
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    monkeypatch.setattr(
+        native_voice_transcription,
+        "get_native_voice_trigger_transport",
+        lambda: transport,
+    )
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={
+            "account": "wxid_account",
+            "username": conversation,
+            "server_id": str(exact_server_id),
+            "local_id": "342",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "accepted"
+    assert response.json()["serverId"] == str(exact_server_id)
+    assert response.json()["localId"] == "342"
+    assert len(transport.commands) == 1
+    assert transport.commands[0].server_id == exact_server_id
+    assert transport.commands[0].local_id == 342
+
+
+def test_account_is_required_and_blank_account_is_rejected():
+    client = _client()
+
+    missing = client.post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={"username": "wxid_friend", "server_id": "123"},
+    )
+    blank = client.post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={"account": "   ", "username": "wxid_friend", "server_id": "123"},
+    )
+
+    assert missing.status_code == 422
+    assert blank.status_code == 400
+    assert blank.json()["detail"]["code"] == "invalid_account"
+
+
+def test_server_id_validation_falls_back_to_realtime_wcdb(monkeypatch, tmp_path: Path):
+    conversation = "wxid_realtime_friend"
+    server_id = 9038636853230485365
+    (tmp_path / "message_0.db").write_bytes(b"not a sqlite database")
+    message_dir = tmp_path / "raw" / "message"
+    message_dir.mkdir(parents=True)
+    (message_dir / "message_0.db").touch()
+    realtime = Mock(db_storage_dir=message_dir.parent, handle=1, lock=threading.Lock())
+    table = f"Msg_{hashlib.md5(conversation.encode('utf-8')).hexdigest()}"
+    sql_calls = []
+
+    def exec_query(_handle, *, kind, path, sql):
+        assert kind == "message"
+        assert str(path).endswith("message_0.db")
+        sql_calls.append(sql)
+        if "sqlite_master" in sql:
+            return [{"name": table}]
+        assert f"server_id = {server_id}" in sql
+        return [{"local_id": 7279, "server_id": server_id}]
+
+    monkeypatch.setattr(
+        "wechat_decrypt_tool.wcdb_realtime.WCDB_REALTIME.ensure_connected",
+        lambda _account_dir: realtime,
+    )
+    monkeypatch.setattr("wechat_decrypt_tool.wcdb_realtime.exec_query", exec_query)
+    transport = FakeNativeVoiceTriggerTransport()
+
+    result = trigger_native_voice_transcription(
+        account_dir=tmp_path,
+        conversation=conversation,
+        server_id=str(server_id),
+        transport=transport,
+    )
+
+    assert result["status"] == "accepted"
+    assert result["serverId"] == str(server_id)
+    assert result["localId"] == "7279"
+    assert len(sql_calls) == 2
+    assert len(transport.commands) == 1
+
+
+def test_all_message_sources_failing_returns_explicit_503(monkeypatch, tmp_path: Path):
+    (tmp_path / "message_0.db").write_bytes(b"not a sqlite database")
+    monkeypatch.setattr(chat_media, "_resolve_account_dir", lambda _account: tmp_path)
+    monkeypatch.setattr(
+        "wechat_decrypt_tool.wcdb_realtime.WCDB_REALTIME.ensure_connected",
+        lambda _account_dir: (_ for _ in ()).throw(RuntimeError("wcdb unavailable")),
+    )
+
+    response = _client().post(
+        "/api/chat/media/voice/transcription/native/trigger",
+        json={"account": "wxid_account", "username": "wxid_friend", "server_id": "123"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "native_message_lookup_unavailable"
+
+
+def test_server_and_local_id_abi_boundaries_are_enforced():
+    assert parse_native_voice_message_id(str((1 << 64) - 1), "server_id") == (1 << 64) - 1
+    assert parse_native_voice_message_id(str((1 << 32) - 1), "local_id") == (1 << 32) - 1
+
+    with pytest.raises(NativeVoiceTriggerError) as server_error:
+        parse_native_voice_message_id(str(1 << 64), "server_id")
+    with pytest.raises(NativeVoiceTriggerError) as local_error:
+        parse_native_voice_message_id(str(1 << 32), "local_id")
+
+    assert server_error.value.code == "invalid_message_id"
+    assert local_error.value.code == "invalid_message_id"

--- a/tests/test_voice_transcription_contract.py
+++ b/tests/test_voice_transcription_contract.py
@@ -31,9 +31,10 @@ class TestVoiceTranscriptionContract(unittest.TestCase):
         self.assertIn(':src="message.voiceUrl"', content)
         self.assertIn("message.voiceTranscriptStatus === 'loading'", content)
         self.assertIn("message.voiceTranscriptStatus === 'success'", content)
-        self.assertIn("transcribeVoice(message, { force: true })", content)
+        self.assertIn("transcribeVoice(message)", content)
+        self.assertNotIn("transcribeVoice(message, { force: true })", content)
         self.assertIn("const transcribeVoice = async", messages)
-        self.assertIn("api.transcribeChatVoice", messages)
+        self.assertIn("api.triggerNativeVoiceTranscription", messages)
 
     def test_export_option_is_wired_from_dialog_to_backend(self):
         dialog = (ROOT / "frontend" / "components" / "chat" / "ChatExportDialog.vue").read_text(encoding="utf-8")


### PR DESCRIPTION
## 概要

将微信内置语音转文字能力接入受保护的 native-core 路径：WDA 只通过 `wechatdb_client.dll` 的 ASR C ABI 与 broker 通信，注入载荷已融合到签名 client，由 broker 执行 feature bit 16、lease、nonce、账号、微信版本和模块哈希门禁。

## 主要变更

- 新增 native-core ASR status / begin / poll / close Python 绑定与持久 worker
- 新增精确 account / conversation / server_id / local_id 定位、requestId 代际绑定和 SQLite 回调缓存
- 前端改为微信原生 status → trigger → exact request poll → restore 链路
- 不再静默回退 Whisper；切换账号/会话可安全取消并恢复 pending/error/success
- 固定支持微信 `4.1.12.26` 与精确 `Weixin.dll` SHA-256，版本不符给出友好提示
- 打包前验证 manifest ASR ABI/feature/target 与 client 四个导出，拒绝旧 standalone hook/controller
- source-public runtime promotion 改为精确 Release asset + 外部 SHA-256 pin 后才解压/执行 verifier
- 更新 README，明确登录、账号、在线 ASR、明文缓存、进程驻留和版本边界

## 供应链

- signed fused build: `wcdb-prod-20260816-native-asr-2`
- source-public runtime tag: `windows-source-runtime-20260816-dfd3ebe2-31937143227`
- runtime pin SHA-256: `c3ca8fef41c9b83bd1c620a07b80df3e7b67c329bfd38ca570613f050f0f8ad5`

## 验证

- native private Debug/Release CTest: 13/13
- desktop packaging/bootstrap/promotion: 37/37
- backend ASR/account-isolation targeted suites: 176 passed + 2 subtests
- frontend Node/Vitest: 27/27 + 36/36
- Nuxt production build: pass
- `git diff --check`: pass
- security/product final review: P0=0, P1=0

## 上线边界

代码与 PR 可合并，但在宣称正式可用前仍需：

1. 将 license server 升级到支持 `native-asr` feature bit 16，并为当前 build/authorization 配置 entitlement；
2. 完全退出旧微信进程后，用微信 `4.1.12.26`、真实登录账号和未缓存语音完成一次干净产品 E2E。