### PR TITLE
fix(asr): inherit protected DLL access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,8 +236,9 @@ jobs:
             throw "GitHub releases require the shared public native distribution mode."
           }
           if ([uint64]$manifest.offlineBootstrapFeatureBits -ne 3 -or
+              $manifest.nativeAsrAuthorization -cne 'database-read' -or
               $manifest.offlineExportSealFormat -cne 'WES2') {
-            throw "Native production artifact does not provide the required offline 3/WES2 contract."
+            throw "Native production artifact does not provide the required offline 3/WES2 and database-read ASR contract."
           }
           if ($manifest.securityNoticeId -cne
                 'WCE-AUTOMATED-ANALYSIS-NOTICE-V2' -or
@@ -283,6 +284,8 @@ jobs:
                 [long]$manifest.buildExpiresAtUnix -or
               [uint64]$provenance.build.offlineBootstrapFeatureBits -ne
                 [uint64]$manifest.offlineBootstrapFeatureBits -or
+              $provenance.build.nativeAsrAuthorization -cne
+                $manifest.nativeAsrAuthorization -or
               $provenance.build.offlineExportSealFormat -cne
                 $manifest.offlineExportSealFormat -or
               $provenance.build.workflowRunId -cne $env:WCE_NATIVE_CORE_ARTIFACT_RUN_ID -or
@@ -611,6 +614,7 @@ jobs:
               buildId = $env:NATIVE_BUILD_ID
               distributionMode = 'public'
               offlineBootstrapFeatureBits = [uint64]3
+              nativeAsrAuthorization = 'database-read'
               offlineExportSealFormat = 'WES2'
               securityNoticeId = 'WCE-AUTOMATED-ANALYSIS-NOTICE-V2'
               securityNoticeSha256 = $env:WCE_NATIVE_CORE_SECURITY_NOTICE_SHA256

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 
 主操作不会在原生路径失败或不可用时自动回退到 Whisper，避免用户在不知情时切换识别来源。成功结果以**明文**持久化到账号目录的 `_cache/native_voice_transcripts.sqlite3`；需要按本地聊天数据同等敏感级别保护、备份或删除该文件。
 
-远端 hook 与固定版本适配器已编入现有签名的 `wechatdb_client.dll`，控制器由 `wechatdb_broker.exe` 持有；每次开始、轮询和关闭任务都经过 native-core 会话、一次性 nonce 和独立的 `native-asr` 在线授权。该功能不属于离线默认权限，也不再分发独立 hook 或明文 Python controller。
+远端 hook 与固定版本适配器已编入现有签名的 `wechatdb_client.dll`，控制器由 `wechatdb_broker.exe` 持有；每次开始、轮询和关闭任务都经过 native-core 会话与一次性 nonce，并继承该 DLL 已有的数据库读取授权，不再要求单独的 `native-asr` 在线授权。该能力仍受 DLL 签名、固定构建有效期和目标微信版本校验约束，也不再分发独立 hook 或明文 Python controller。
 
 原生 hook 首次使用后会随当前微信进程驻留，直到微信完全退出，目的是避免微信异步回调落入已经卸载的 DLL。不要在同一微信进程内尝试卸载或重复注入；如果 bridge 已经加载后又重启了本项目后端，必须先完全退出并重新启动微信，再使用原生转写。
 

--- a/desktop/resources/native-core-source-windows.json
+++ b/desktop/resources/native-core-source-windows.json
@@ -3,9 +3,9 @@
   "platform": "win32",
   "architecture": "x64",
   "publisherRepository": "LifeArchiveProject/WeChatDataAnalysis",
-  "releaseTag": "windows-source-runtime-20260816-dfd3ebe2-31937143227",
+  "releaseTag": "windows-source-runtime-20260817-7795dced-32004006556",
   "assetName": "wechatdataanalysis-windows-source-runtime-x64-v1.tar.gz",
-  "assetSha256": "c3ca8fef41c9b83bd1c620a07b80df3e7b67c329bfd38ca570613f050f0f8ad5",
-  "runtimeManifestSha256": "e9b7b381a12ad90c93b6e18718aa17fa85d837baf6054d8e4cb8af576802a661",
-  "expiresAtUnix": 1790757765
+  "assetSha256": "5e7eeb7e824616aa462f5cbb5b21369516014b5a323c41b6456d71ec1d860ec9",
+  "runtimeManifestSha256": "e6902d4a6d3536ff96e2d58bff5af5287bec216423d1f2c224b29c16dc3cb0d9",
+  "expiresAtUnix": 1790838083
 }

--- a/desktop/src/windows-native-asr-capability.cjs
+++ b/desktop/src/windows-native-asr-capability.cjs
@@ -5,9 +5,15 @@ const path = require("node:path");
 
 const WINDOWS_NATIVE_ASR_ABI_VERSION = 1;
 const WINDOWS_NATIVE_ASR_FEATURE_BIT = 16;
+const WINDOWS_NATIVE_ASR_AUTHORIZATION = "database-read";
+const WINDOWS_NATIVE_ASR_DISABLED_AUTHORIZATION = "none";
 const WINDOWS_NATIVE_ASR_TARGET = Object.freeze({
   wechatVersion: "4.1.12.26",
   weixinSha256: "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46",
+});
+const WINDOWS_NATIVE_ASR_DISABLED_TARGET = Object.freeze({
+  wechatVersion: "",
+  weixinSha256: "",
 });
 const WINDOWS_NATIVE_ASR_EXPORTS = Object.freeze([
   "wce_native_asr_get_status",
@@ -184,11 +190,23 @@ function readWindowsPeExportNames(clientPath, fsImpl = fs) {
 
 function windowsNativeAsrManifestErrors(manifest) {
   const errors = [];
-  if (manifest?.nativeAsrAbiVersion !== WINDOWS_NATIVE_ASR_ABI_VERSION) {
-    errors.push(`nativeAsrAbiVersion must equal ${WINDOWS_NATIVE_ASR_ABI_VERSION}`);
+  const fused = manifest?.developmentBuild === false;
+  const expectedAbiVersion = fused ? WINDOWS_NATIVE_ASR_ABI_VERSION : 0;
+  const expectedFeatureBit = fused ? WINDOWS_NATIVE_ASR_FEATURE_BIT : 0;
+  const expectedAuthorization = fused
+    ? WINDOWS_NATIVE_ASR_AUTHORIZATION
+    : WINDOWS_NATIVE_ASR_DISABLED_AUTHORIZATION;
+  const expectedTarget = fused
+    ? WINDOWS_NATIVE_ASR_TARGET
+    : WINDOWS_NATIVE_ASR_DISABLED_TARGET;
+  if (manifest?.nativeAsrAbiVersion !== expectedAbiVersion) {
+    errors.push(`nativeAsrAbiVersion must equal ${expectedAbiVersion}`);
   }
-  if (manifest?.nativeAsrFeatureBit !== WINDOWS_NATIVE_ASR_FEATURE_BIT) {
-    errors.push(`nativeAsrFeatureBit must equal ${WINDOWS_NATIVE_ASR_FEATURE_BIT}`);
+  if (manifest?.nativeAsrFeatureBit !== expectedFeatureBit) {
+    errors.push(`nativeAsrFeatureBit must equal ${expectedFeatureBit}`);
+  }
+  if (manifest?.nativeAsrAuthorization !== expectedAuthorization) {
+    errors.push(`nativeAsrAuthorization must equal ${expectedAuthorization}`);
   }
   const target = manifest?.nativeAsrTarget;
   if (!target || Array.isArray(target) || typeof target !== "object") {
@@ -202,14 +220,14 @@ function windowsNativeAsrManifestErrors(manifest) {
     ) {
       errors.push("nativeAsrTarget must contain exactly wechatVersion and weixinSha256");
     }
-    if (target.wechatVersion !== WINDOWS_NATIVE_ASR_TARGET.wechatVersion) {
+    if (target.wechatVersion !== expectedTarget.wechatVersion) {
       errors.push(
-        `nativeAsrTarget.wechatVersion must equal ${WINDOWS_NATIVE_ASR_TARGET.wechatVersion}`
+        `nativeAsrTarget.wechatVersion must equal ${expectedTarget.wechatVersion}`
       );
     }
-    if (target.weixinSha256 !== WINDOWS_NATIVE_ASR_TARGET.weixinSha256) {
+    if (target.weixinSha256 !== expectedTarget.weixinSha256) {
       errors.push(
-        `nativeAsrTarget.weixinSha256 must equal ${WINDOWS_NATIVE_ASR_TARGET.weixinSha256}`
+        `nativeAsrTarget.weixinSha256 must equal ${expectedTarget.weixinSha256}`
       );
     }
   }
@@ -221,6 +239,16 @@ function assertWindowsNativeAsrCapability({ nativeDir, manifest, fsImpl = fs }) 
   if (manifestErrors.length > 0) {
     throw new Error(`Windows native-core manifest ${manifestErrors.join("; ")}`);
   }
+  if (manifest.developmentBuild === true) {
+    return Object.freeze({
+      available: false,
+      abiVersion: 0,
+      featureBit: 0,
+      authorization: WINDOWS_NATIVE_ASR_DISABLED_AUTHORIZATION,
+      target: WINDOWS_NATIVE_ASR_DISABLED_TARGET,
+      exports: Object.freeze([]),
+    });
+  }
   const clientPath = path.join(path.resolve(String(nativeDir || "")), "wechatdb_client.dll");
   const exports = readWindowsPeExportNames(clientPath, fsImpl);
   const missing = WINDOWS_NATIVE_ASR_EXPORTS.filter((name) => !exports.has(name));
@@ -230,8 +258,10 @@ function assertWindowsNativeAsrCapability({ nativeDir, manifest, fsImpl = fs }) 
     );
   }
   return Object.freeze({
+    available: true,
     abiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
     featureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
+    authorization: WINDOWS_NATIVE_ASR_AUTHORIZATION,
     target: WINDOWS_NATIVE_ASR_TARGET,
     exports: WINDOWS_NATIVE_ASR_EXPORTS,
   });
@@ -239,6 +269,9 @@ function assertWindowsNativeAsrCapability({ nativeDir, manifest, fsImpl = fs }) 
 
 module.exports = {
   WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_AUTHORIZATION,
+  WINDOWS_NATIVE_ASR_DISABLED_AUTHORIZATION,
+  WINDOWS_NATIVE_ASR_DISABLED_TARGET,
   WINDOWS_NATIVE_ASR_FEATURE_BIT,
   WINDOWS_NATIVE_ASR_EXPORTS,
   WINDOWS_NATIVE_ASR_TARGET,

--- a/desktop/tests/native-core-before-pack.test.cjs
+++ b/desktop/tests/native-core-before-pack.test.cjs
@@ -13,6 +13,7 @@ const {
 } = require("../scripts/native-core-before-pack.cjs");
 const {
   WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_AUTHORIZATION,
   WINDOWS_NATIVE_ASR_EXPORTS,
   WINDOWS_NATIVE_ASR_FEATURE_BIT,
   WINDOWS_NATIVE_ASR_TARGET,
@@ -45,6 +46,7 @@ const PRODUCTION_MANIFEST = Object.freeze({
   securityCheckpointCount: 7,
   securityCheckpointSetSha256: "bb".repeat(32),
   nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+  nativeAsrAuthorization: WINDOWS_NATIVE_ASR_AUTHORIZATION,
   nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
   nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
 });

--- a/desktop/tests/native-core-packaging.test.cjs
+++ b/desktop/tests/native-core-packaging.test.cjs
@@ -13,6 +13,7 @@ const {
 } = require("../scripts/build-backend.cjs");
 const {
   WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_AUTHORIZATION,
   WINDOWS_NATIVE_ASR_EXPORTS,
   WINDOWS_NATIVE_ASR_FEATURE_BIT,
   WINDOWS_NATIVE_ASR_TARGET,
@@ -45,6 +46,7 @@ const PRODUCTION_MANIFEST = Object.freeze({
   securityCheckpointCount: 7,
   securityCheckpointSetSha256: "bb".repeat(32),
   nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+  nativeAsrAuthorization: WINDOWS_NATIVE_ASR_AUTHORIZATION,
   nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
   nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
 });
@@ -67,9 +69,10 @@ const DEVELOPMENT_MANIFEST = Object.freeze({
   securityCheckpointSetId: "WCE-AI-CHECKPOINT-SET-V3",
   securityCheckpointCount: 7,
   securityCheckpointSetSha256: "bb".repeat(32),
-  nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
-  nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
-  nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
+  nativeAsrAbiVersion: 0,
+  nativeAsrAuthorization: "none",
+  nativeAsrFeatureBit: 0,
+  nativeAsrTarget: { wechatVersion: "", weixinSha256: "" },
 });
 
 const MACOS_DEVELOPMENT_MANIFEST = Object.freeze({
@@ -253,6 +256,7 @@ test("Windows staging rejects a manifest without the fused ASR contract", () => 
   const artifactDir = path.join(root, "artifacts");
   const legacyManifest = { ...PRODUCTION_MANIFEST };
   delete legacyManifest.nativeAsrAbiVersion;
+  delete legacyManifest.nativeAsrAuthorization;
   delete legacyManifest.nativeAsrFeatureBit;
   delete legacyManifest.nativeAsrTarget;
   writeArtifactSet(artifactDir, "win32", legacyManifest);
@@ -264,7 +268,29 @@ test("Windows staging rejects a manifest without the fused ASR contract", () => 
           env: { WCE_NATIVE_CORE_ARTIFACT_DIR: artifactDir },
           platform: "win32",
         }),
-      /nativeAsrAbiVersion must equal 1.*nativeAsrFeatureBit must equal 16.*nativeAsrTarget must be an object/
+      /nativeAsrAbiVersion must equal 1.*nativeAsrFeatureBit must equal 16.*nativeAsrAuthorization must equal database-read.*nativeAsrTarget must be an object/
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Windows staging rejects a fused ASR runtime with a separate entitlement contract", () => {
+  const root = makeTempDir();
+  const artifactDir = path.join(root, "artifacts");
+  writeArtifactSet(artifactDir, "win32", {
+    ...PRODUCTION_MANIFEST,
+    nativeAsrAuthorization: "native-asr",
+  });
+
+  try {
+    assert.throws(
+      () =>
+        resolveNativeCoreArtifacts({
+          env: { WCE_NATIVE_CORE_ARTIFACT_DIR: artifactDir },
+          platform: "win32",
+        }),
+      /nativeAsrAuthorization must equal database-read/
     );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -496,7 +522,9 @@ test("development artifacts require an explicit local override", () => {
   const artifactDir = path.join(root, "artifacts");
   const destination = path.join(root, "stage");
   fs.mkdirSync(destination, { recursive: true });
-  writeArtifactSet(artifactDir, "win32", DEVELOPMENT_MANIFEST);
+  writeArtifactSet(artifactDir, "win32", DEVELOPMENT_MANIFEST, {
+    clientExports: ["wce_client_abi_version"],
+  });
 
   try {
     assert.throws(
@@ -539,6 +567,7 @@ test("development artifacts require an explicit local override", () => {
     });
     assert.equal(result.staged, true);
     assert.equal(result.allowDevelopment, true);
+    assert.equal(result.manifest.nativeAsrAuthorization, "none");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/desktop/tests/package-config.test.cjs
+++ b/desktop/tests/package-config.test.cjs
@@ -165,6 +165,8 @@ test("Windows release uses protected cloud private-PKI signing and installer smo
   assert.match(windowsJob, /\$provenance\.build\.distributionMode -cne 'public'/);
   assert.match(windowsJob, /distributionMode = 'public'/);
   assert.match(windowsJob, /offlineBootstrapFeatureBits -ne 3/);
+  assert.match(windowsJob, /nativeAsrAuthorization -cne 'database-read'/);
+  assert.match(windowsJob, /nativeAsrAuthorization = 'database-read'/);
   assert.match(windowsJob, /offlineExportSealFormat -cne 'WES2'/);
   assert.match(windowsJob, /WCE-AUTOMATED-ANALYSIS-NOTICE-V2/);
   assert.match(windowsJob, /WCE-AI-CHECKPOINT-SET-V3/);

--- a/desktop/tests/windows-source-native-core-bootstrap.test.cjs
+++ b/desktop/tests/windows-source-native-core-bootstrap.test.cjs
@@ -257,12 +257,12 @@ test("tracked Windows source pin selects the exact immutable public Release asse
   assert.equal(
     publicReleaseUrl(trackedPin),
     "https://github.com/LifeArchiveProject/WeChatDataAnalysis/releases/download/" +
-      "windows-source-runtime-20260816-dfd3ebe2-31937143227/" +
+      "windows-source-runtime-20260817-7795dced-32004006556/" +
       "wechatdataanalysis-windows-source-runtime-x64-v1.tar.gz"
   );
-  assert.equal(trackedPin.assetSha256, "c3ca8fef41c9b83bd1c620a07b80df3e7b67c329bfd38ca570613f050f0f8ad5");
-  assert.equal(trackedPin.runtimeManifestSha256, "e9b7b381a12ad90c93b6e18718aa17fa85d837baf6054d8e4cb8af576802a661");
-  assert.equal(trackedPin.expiresAtUnix, 1790757765);
+  assert.equal(trackedPin.assetSha256, "5e7eeb7e824616aa462f5cbb5b21369516014b5a323c41b6456d71ec1d860ec9");
+  assert.equal(trackedPin.runtimeManifestSha256, "e6902d4a6d3536ff96e2d58bff5af5287bec216423d1f2c224b29c16dc3cb0d9");
+  assert.equal(trackedPin.expiresAtUnix, 1790838083);
 });
 
 test("generic source bootstrap wires the verified Windows directory without macOS-only variables", () =>

--- a/desktop/tests/windows-source-native-core-bootstrap.test.cjs
+++ b/desktop/tests/windows-source-native-core-bootstrap.test.cjs
@@ -18,6 +18,7 @@ const {
 } = require("../src/source-native-core-bootstrap.cjs");
 const {
   WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_AUTHORIZATION,
   WINDOWS_NATIVE_ASR_EXPORTS,
   WINDOWS_NATIVE_ASR_FEATURE_BIT,
   WINDOWS_NATIVE_ASR_TARGET,
@@ -59,6 +60,7 @@ const NATIVE_MANIFEST = Object.freeze({
   sourceRuntime: true,
   windowsHostVerification: "same-user-direct-parent",
   nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+  nativeAsrAuthorization: WINDOWS_NATIVE_ASR_AUTHORIZATION,
   nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
   nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
 });

--- a/desktop/tests/windows-source-runtime-promotion.test.cjs
+++ b/desktop/tests/windows-source-runtime-promotion.test.cjs
@@ -13,6 +13,7 @@ const {
 } = require("../scripts/windows-source-runtime-promotion.cjs");
 const {
   WINDOWS_NATIVE_ASR_ABI_VERSION,
+  WINDOWS_NATIVE_ASR_AUTHORIZATION,
   WINDOWS_NATIVE_ASR_EXPORTS,
   WINDOWS_NATIVE_ASR_FEATURE_BIT,
   WINDOWS_NATIVE_ASR_TARGET,
@@ -58,6 +59,7 @@ function fixture({ clientExports = WINDOWS_NATIVE_ASR_EXPORTS } = {}) {
     securityCheckpointSetId: "WCE-AI-CHECKPOINT-SET-V3",
     securityCheckpointCount: 7,
     nativeAsrAbiVersion: WINDOWS_NATIVE_ASR_ABI_VERSION,
+    nativeAsrAuthorization: WINDOWS_NATIVE_ASR_AUTHORIZATION,
     nativeAsrFeatureBit: WINDOWS_NATIVE_ASR_FEATURE_BIT,
     nativeAsrTarget: WINDOWS_NATIVE_ASR_TARGET,
   });
@@ -135,6 +137,27 @@ test("Windows promotion rejects a source runtime without fused ASR exports", () 
         nowUnix: NOW,
       }),
       /missing fused ASR ABI exports/
+    );
+  } finally {
+    fs.rmSync(value.root, { recursive: true, force: true });
+  }
+});
+
+test("Windows promotion rejects a source runtime with separate ASR authorization", () => {
+  const value = fixture();
+  try {
+    const manifestPath = path.join(value.coreDir, "wechatdb_native_build.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    manifest.nativeAsrAuthorization = "native-asr";
+    write(manifestPath, manifest);
+    assert.throws(
+      () => stageWindowsSourceRuntimeBundle({
+        coreDir: value.coreDir,
+        stageDir: path.join(value.root, "stage"),
+        releaseTag: "windows-source-runtime-20260808-aaaaaaaa",
+        nowUnix: NOW,
+      }),
+      /nativeAsrAuthorization must equal database-read/
     );
   } finally {
     fs.rmSync(value.root, { recursive: true, force: true });

--- a/frontend/composables/chat/useChatMessages.js
+++ b/frontend/composables/chat/useChatMessages.js
@@ -212,6 +212,7 @@ export const useChatMessages = ({
       weixin_version_unsupported: '当前微信版本暂不支持微信原生语音转文字。请使用微信 4.1.12.26，并完全退出、重新启动微信后再试。',
       active_account_mismatch: '当前项目账号与已登录微信账号不一致。',
       active_account_unverified: '无法确认当前项目账号与已登录微信账号一致。',
+      protected_build_unavailable: '当前受保护 DLL 或构建中的微信原生语音转文字功能不可用。',
       bridge_manager_unavailable: '微信原生语音转文字服务尚未就绪。',
       inspection_failed: '无法检查微信原生语音转文字状态。请重启本应用和微信后再试。',
       bridge_restart_required: '桥接状态已失效。请完全退出微信，重启本应用（开发模式下同时重启后端）后，再重新打开并登录微信。'

--- a/frontend/tests/native-voice-transcript-polling.test.js
+++ b/frontend/tests/native-voice-transcript-polling.test.js
@@ -679,6 +679,24 @@ describe('微信原生转写 native-first 编排', () => {
     wrapper.unmount()
   })
 
+  it('受保护 DLL 或构建不可用时不显示单独 ASR 授权提示', async () => {
+    const api = {
+      getNativeVoiceTranscriptionStatus: vi.fn().mockResolvedValue({
+        available: false,
+        reason: 'protected_build_unavailable'
+      })
+    }
+    const { state, wrapper } = mountChatMessagesState(api)
+
+    await state.refreshNativeVoiceTranscriptionStatus({ force: true })
+
+    expect(state.nativeVoiceTranscriptionUnavailableReason.value).toBe(
+      '当前受保护 DLL 或构建中的微信原生语音转文字功能不可用。'
+    )
+    expect(state.nativeVoiceTranscriptionUnavailableReason.value).not.toContain('授权')
+    wrapper.unmount()
+  })
+
   it.each([
     'native_transport_unavailable',
     'native_weixin_not_running',

--- a/src/wechat_decrypt_tool/native_core_client.py
+++ b/src/wechat_decrypt_tool/native_core_client.py
@@ -143,6 +143,13 @@ class NativeCoreAsrRequestState(IntEnum):
 _NATIVE_CORE_OFFLINE_BOOTSTRAP_FEATURES = (
     NativeCoreFeature.DATABASE_READ | NativeCoreFeature.EXPORT
 )
+_NATIVE_CORE_WINDOWS_NATIVE_ASR_ABI_VERSION = 1
+_NATIVE_CORE_WINDOWS_NATIVE_ASR_FEATURE_BIT = int(NativeCoreFeature.NATIVE_ASR)
+_NATIVE_CORE_WINDOWS_NATIVE_ASR_AUTHORIZATION = "database-read"
+_NATIVE_CORE_WINDOWS_NATIVE_ASR_WECHAT_VERSION = "4.1.12.26"
+_NATIVE_CORE_WINDOWS_NATIVE_ASR_WEIXIN_SHA256 = (
+    "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46"
+)
 
 
 class NativeCoreDatabaseKeyMode(IntEnum):
@@ -520,6 +527,11 @@ class NativeCoreBuildManifest:
     distribution_mode: str = "public"
     distribution_capsule: str | None = field(default=None, repr=False)
     platform: str = "windows"
+    native_asr_abi_version: int = 0
+    native_asr_feature_bit: int = 0
+    native_asr_authorization: str = ""
+    native_asr_target_wechat_version: str = ""
+    native_asr_target_weixin_sha256: str = ""
     macos_client_signer_sha256: bytes = field(default=b"\0" * 32, repr=False)
     macos_broker_signer_sha256: bytes = field(default=b"\0" * 32, repr=False)
     macos_host_signer_sha256: bytes = field(default=b"\0" * 32, repr=False)
@@ -941,6 +953,10 @@ def _load_native_core_build_manifest(
     offline_bootstrap_feature_bits_value = payload.get(
         "offlineBootstrapFeatureBits"
     )
+    native_asr_abi_version_value = payload.get("nativeAsrAbiVersion", 0)
+    native_asr_feature_bit_value = payload.get("nativeAsrFeatureBit", 0)
+    native_asr_authorization_value = payload.get("nativeAsrAuthorization", "")
+    native_asr_target_value = payload.get("nativeAsrTarget")
     offline_export_seal_format = payload.get("offlineExportSealFormat")
     distribution_mode_value = payload.get("distributionMode")
     distribution_capsule_value = payload.get("distributionCapsule")
@@ -1131,10 +1147,31 @@ def _load_native_core_build_manifest(
             raise NativeCoreProtocolError(
                 "wechatdb native build manifest contains an invalid macOS private-PKI policy."
             )
+    if native_asr_target_value is None:
+        native_asr_target_wechat_version = ""
+        native_asr_target_weixin_sha256 = ""
+    elif (
+        not isinstance(native_asr_target_value, dict)
+        or frozenset(native_asr_target_value)
+        != frozenset({"wechatVersion", "weixinSha256"})
+        or not isinstance(native_asr_target_value.get("wechatVersion"), str)
+        or not isinstance(native_asr_target_value.get("weixinSha256"), str)
+    ):
+        raise NativeCoreProtocolError(
+            "wechatdb native build manifest contains an invalid native ASR target."
+        )
+    else:
+        native_asr_target_wechat_version = native_asr_target_value["wechatVersion"]
+        native_asr_target_weixin_sha256 = native_asr_target_value["weixinSha256"]
     if (
         type(offline_bootstrap_feature_bits_value) is not int
         or offline_bootstrap_feature_bits_value < 0
         or not isinstance(offline_export_seal_format, str)
+        or type(native_asr_abi_version_value) is not int
+        or native_asr_abi_version_value < 0
+        or type(native_asr_feature_bit_value) is not int
+        or native_asr_feature_bit_value < 0
+        or not isinstance(native_asr_authorization_value, str)
     ):
         raise NativeCoreProtocolError(
             "wechatdb native build manifest contains invalid offline bootstrap fields."
@@ -1247,6 +1284,11 @@ def _load_native_core_build_manifest(
         distribution_mode=distribution_mode,
         distribution_capsule=distribution_capsule,
         platform=manifest_platform,
+        native_asr_abi_version=native_asr_abi_version_value,
+        native_asr_feature_bit=native_asr_feature_bit_value,
+        native_asr_authorization=native_asr_authorization_value,
+        native_asr_target_wechat_version=native_asr_target_wechat_version,
+        native_asr_target_weixin_sha256=native_asr_target_weixin_sha256,
         macos_client_signer_sha256=macos_client_signer_digest,
         macos_broker_signer_sha256=macos_broker_signer_digest,
         macos_host_signer_sha256=macos_host_signer_digest,
@@ -1776,6 +1818,16 @@ class NativeCoreClient:
             manifest.distribution_mode != self._build_manifest.distribution_mode
             or manifest.distribution_capsule
             != self._build_manifest.distribution_capsule
+            or manifest.native_asr_authorization
+            != self._build_manifest.native_asr_authorization
+            or manifest.native_asr_abi_version
+            != self._build_manifest.native_asr_abi_version
+            or manifest.native_asr_feature_bit
+            != self._build_manifest.native_asr_feature_bit
+            or manifest.native_asr_target_wechat_version
+            != self._build_manifest.native_asr_target_wechat_version
+            or manifest.native_asr_target_weixin_sha256
+            != self._build_manifest.native_asr_target_weixin_sha256
         ):
             raise NativeCoreProtocolError(
                 "wechatdb native distribution identity changed after client initialization."
@@ -1867,7 +1919,76 @@ class NativeCoreClient:
                 "wechatdb native client has an incomplete native ASR ABI: "
                 + ", ".join(missing_native_asr_symbols)
             )
-        self._supports_native_asr = bool(available_native_asr_symbols)
+        formal_windows_build = (
+            self._build_manifest.platform == "windows"
+            and not self._build_manifest.development_build
+        )
+        disabled_native_asr_contract = (
+            self._build_manifest.native_asr_abi_version == 0
+            and self._build_manifest.native_asr_feature_bit == 0
+            and self._build_manifest.native_asr_authorization in {"", "none"}
+            and self._build_manifest.native_asr_target_wechat_version == ""
+            and self._build_manifest.native_asr_target_weixin_sha256 == ""
+        )
+        fused_native_asr_contract = (
+            formal_windows_build and not disabled_native_asr_contract
+        )
+        if fused_native_asr_contract:
+            native_asr_manifest_errors: list[str] = []
+            if (
+                self._build_manifest.native_asr_abi_version
+                != _NATIVE_CORE_WINDOWS_NATIVE_ASR_ABI_VERSION
+            ):
+                native_asr_manifest_errors.append(
+                    "nativeAsrAbiVersion must equal "
+                    f"{_NATIVE_CORE_WINDOWS_NATIVE_ASR_ABI_VERSION}"
+                )
+            if (
+                self._build_manifest.native_asr_feature_bit
+                != _NATIVE_CORE_WINDOWS_NATIVE_ASR_FEATURE_BIT
+            ):
+                native_asr_manifest_errors.append(
+                    "nativeAsrFeatureBit must equal "
+                    f"{_NATIVE_CORE_WINDOWS_NATIVE_ASR_FEATURE_BIT}"
+                )
+            if (
+                self._build_manifest.native_asr_authorization
+                != _NATIVE_CORE_WINDOWS_NATIVE_ASR_AUTHORIZATION
+            ):
+                native_asr_manifest_errors.append(
+                    "nativeAsrAuthorization must equal "
+                    f"{_NATIVE_CORE_WINDOWS_NATIVE_ASR_AUTHORIZATION}"
+                )
+            if (
+                self._build_manifest.native_asr_target_wechat_version
+                != _NATIVE_CORE_WINDOWS_NATIVE_ASR_WECHAT_VERSION
+            ):
+                native_asr_manifest_errors.append(
+                    "nativeAsrTarget.wechatVersion must equal "
+                    f"{_NATIVE_CORE_WINDOWS_NATIVE_ASR_WECHAT_VERSION}"
+                )
+            if (
+                self._build_manifest.native_asr_target_weixin_sha256
+                != _NATIVE_CORE_WINDOWS_NATIVE_ASR_WEIXIN_SHA256
+            ):
+                native_asr_manifest_errors.append(
+                    "nativeAsrTarget.weixinSha256 must equal "
+                    f"{_NATIVE_CORE_WINDOWS_NATIVE_ASR_WEIXIN_SHA256}"
+                )
+            if native_asr_manifest_errors:
+                raise NativeCoreProtocolError(
+                    "wechatdb native ASR manifest "
+                    + "; ".join(native_asr_manifest_errors)
+                    + "."
+                )
+            if not available_native_asr_symbols:
+                raise NativeCoreProtocolError(
+                    "wechatdb native ASR manifest declares fused support, but the "
+                    "client is missing all native ASR ABI symbols."
+                )
+        self._supports_native_asr = bool(available_native_asr_symbols) and (
+            fused_native_asr_contract
+        )
         self._supports_export_verification = hasattr(lib, "wce_export_verify_seal")
         if (
             self._build_manifest.root_public_key_compiled

--- a/src/wechat_decrypt_tool/native_core_voice_asr.py
+++ b/src/wechat_decrypt_tool/native_core_voice_asr.py
@@ -16,14 +16,12 @@ from .native_core_client import (
     NativeCoreAsrRequestState,
     NativeCoreClient,
     NativeCoreError,
-    NativeCoreFeature,
     NativeCorePolicyError,
     NativeCoreProtocolError,
     NativeCoreStatus,
     NativeCoreUnavailableError,
     get_native_core_client,
 )
-from .native_core_lease import refresh_native_core_lease
 from .native_voice_transcription import (
     NativeVoiceTriggerCommand,
     NativeVoiceTriggerError,
@@ -36,7 +34,6 @@ from .native_voice_transcription import (
 
 _POLL_INTERVAL_SECONDS = 1.0
 _POLL_TIMEOUT_SECONDS = 100.0
-_LEASE_MINIMUM_VALIDITY_SECONDS = 180
 _EXPECTED_WECHAT_VERSION = "4.1.12.26"
 _CLOSE_RETRY_DELAYS_SECONDS = (0.05, 0.15)
 
@@ -149,7 +146,7 @@ def _reason_error(reason: NativeCoreAsrReason) -> NativeVoiceTriggerError:
     return NativeVoiceTriggerError(code, message)
 
 
-_NATIVE_ASR_AUTHORIZATION_STATUSES = {
+_NATIVE_ASR_POLICY_STATUSES = {
     NativeCoreStatus.LICENSE_REQUIRED,
     NativeCoreStatus.LEASE_INVALID,
     NativeCoreStatus.LEASE_EXPIRED,
@@ -183,10 +180,10 @@ def _native_core_status_error(
             "native_trigger_timeout",
             "等待微信原生语音转文字结果超时。",
         )
-    if known in _NATIVE_ASR_AUTHORIZATION_STATUSES:
+    if known in _NATIVE_ASR_POLICY_STATUSES:
         return NativeVoiceTriggerError(
-            "native_asr_not_authorized",
-            "当前授权未包含微信原生语音转文字功能，或授权已过期。",
+            "native_transport_unavailable",
+            "当前受保护 DLL 或构建中的微信原生语音转文字功能不可用。",
         )
     if known in _NATIVE_ASR_INTEGRITY_STATUSES:
         return NativeVoiceTriggerError(
@@ -222,8 +219,8 @@ def _native_core_error(exc: BaseException) -> NativeVoiceTriggerError:
             return mapped
     if isinstance(exc, NativeCorePolicyError):
         return NativeVoiceTriggerError(
-            "native_asr_not_authorized",
-            "当前授权未包含微信原生语音转文字功能，或授权已过期。",
+            "native_transport_unavailable",
+            "当前受保护 DLL 或构建中的微信原生语音转文字功能不可用。",
         )
     if isinstance(exc, (NativeCoreUnavailableError, NativeCoreProtocolError)):
         return NativeVoiceTriggerError(
@@ -237,7 +234,7 @@ def _native_core_error(exc: BaseException) -> NativeVoiceTriggerError:
 
 
 def native_core_voice_asr_status(account_dir: Optional[Path] = None) -> dict[str, object]:
-    """Passively inspect readiness through the licensed native-core broker."""
+    """Passively inspect readiness through the protected native-core broker."""
 
     result: dict[str, object] = {
         "available": False,
@@ -277,7 +274,7 @@ def native_core_voice_asr_status(account_dir: Optional[Path] = None) -> dict[str
         )
         return result
     except NativeCorePolicyError:
-        result["reason"] = "bridge_manager_unavailable"
+        result["reason"] = "protected_build_unavailable"
         return result
     except (NativeCoreError, OSError, ValueError):
         result["reason"] = "inspection_failed"
@@ -378,11 +375,6 @@ class NativeCoreVoiceAsrTransport:
                 )
                 if not status.ready or status.reason is not NativeCoreAsrReason.READY:
                     raise _reason_error(status.reason)
-                refresh_native_core_lease(
-                    client,
-                    NativeCoreFeature.NATIVE_ASR,
-                    minimum_validity_seconds=_LEASE_MINIMUM_VALIDITY_SECONDS,
-                )
                 request_handle = client.begin_native_asr(
                     command.account,
                     command.account_dir,

--- a/src/wechat_decrypt_tool/routers/chat_media.py
+++ b/src/wechat_decrypt_tool/routers/chat_media.py
@@ -4166,7 +4166,6 @@ async def trigger_chat_native_voice_transcription(
             "voice_message_unsynced": 409,
             "native_message_lookup_unavailable": 503,
             "native_transport_unavailable": 503,
-            "native_asr_not_authorized": 403,
             "native_weixin_not_running": 503,
             "native_weixin_version_unsupported": 503,
             "native_transport_busy": 429,

--- a/tests/test_native_core_client_asr.py
+++ b/tests/test_native_core_client_asr.py
@@ -50,6 +50,9 @@ _NATIVE_ASR_SYMBOLS = (
     "wce_native_asr_poll",
     "wce_native_asr_close",
 )
+_NATIVE_ASR_WEIXIN_SHA256 = (
+    "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46"
+)
 
 
 class _FakeFunction:
@@ -68,10 +71,29 @@ def _abi_library(*, native_asr_symbols: tuple[str, ...] = ()) -> SimpleNamespace
     return SimpleNamespace(**functions)
 
 
-def _configure_client(library: SimpleNamespace) -> NativeCoreClient:
+def _configure_client(
+    library: SimpleNamespace,
+    *,
+    platform: str = "windows",
+    development_build: bool = False,
+    native_asr_abi_version: int = 1,
+    native_asr_feature_bit: int = 16,
+    native_asr_authorization: str = "database-read",
+    native_asr_target_wechat_version: str = "4.1.12.26",
+    native_asr_target_weixin_sha256: str = _NATIVE_ASR_WEIXIN_SHA256,
+) -> NativeCoreClient:
     client = object.__new__(NativeCoreClient)
     client._library = library
-    client._build_manifest = SimpleNamespace(root_public_key_compiled=False)
+    client._build_manifest = SimpleNamespace(
+        root_public_key_compiled=False,
+        platform=platform,
+        development_build=development_build,
+        native_asr_abi_version=native_asr_abi_version,
+        native_asr_feature_bit=native_asr_feature_bit,
+        native_asr_authorization=native_asr_authorization,
+        native_asr_target_wechat_version=native_asr_target_wechat_version,
+        native_asr_target_weixin_sha256=native_asr_target_weixin_sha256,
+    )
     client._configure_abi()
     return client
 
@@ -203,13 +225,31 @@ def test_native_asr_ctypes_layout_matches_public_abi() -> None:
     assert NativeCoreFeature.NATIVE_ASR == 1 << 4
 
 
-def test_old_runtime_without_asr_exports_keeps_core_abi_usable() -> None:
-    library = _abi_library()
+@pytest.mark.parametrize("authorization", ["", "none"])
+@pytest.mark.parametrize(
+    "native_asr_symbols",
+    [(), _NATIVE_ASR_SYMBOLS],
+    ids=["legacy-no-exports", "generic-exports"],
+)
+def test_formal_non_fused_manifest_keeps_core_abi_usable(
+    authorization: str,
+    native_asr_symbols: tuple[str, ...],
+) -> None:
+    library = _abi_library(native_asr_symbols=native_asr_symbols)
 
-    client = _configure_client(library)
+    client = _configure_client(
+        library,
+        native_asr_abi_version=0,
+        native_asr_feature_bit=0,
+        native_asr_authorization=authorization,
+        native_asr_target_wechat_version="",
+        native_asr_target_weixin_sha256="",
+    )
 
     assert client.supports_native_asr is False
     assert library.wce_database_open.argtypes is not None
+    if native_asr_symbols:
+        assert library.wce_native_asr_get_status.argtypes is None
     with pytest.raises(NativeCoreProtocolError, match="does not implement"):
         client.get_native_asr_status("wxid_example", Path.cwd().resolve())
 
@@ -218,7 +258,15 @@ def test_partial_native_asr_exports_are_rejected_as_incomplete_abi() -> None:
     library = _abi_library(native_asr_symbols=("wce_native_asr_get_status",))
 
     with pytest.raises(NativeCoreProtocolError, match="incomplete native ASR ABI") as caught:
-        _configure_client(library)
+        _configure_client(
+            library,
+            development_build=True,
+            native_asr_abi_version=0,
+            native_asr_feature_bit=0,
+            native_asr_authorization="none",
+            native_asr_target_wechat_version="",
+            native_asr_target_weixin_sha256="",
+        )
 
     assert "wce_native_asr_begin" in str(caught.value)
     assert "wce_native_asr_poll" in str(caught.value)
@@ -228,7 +276,7 @@ def test_partial_native_asr_exports_are_rejected_as_incomplete_abi() -> None:
 def test_complete_native_asr_exports_are_bound_as_one_optional_feature() -> None:
     library = _abi_library(native_asr_symbols=_NATIVE_ASR_SYMBOLS)
 
-    client = _configure_client(library)
+    client = _configure_client(library, native_asr_authorization="database-read")
 
     assert client.supports_native_asr is True
     assert library.wce_native_asr_get_status.argtypes == [
@@ -242,6 +290,81 @@ def test_complete_native_asr_exports_are_bound_as_one_optional_feature() -> None
         ctypes.POINTER(native._WceNativeAsrPollResult),
         ctypes.POINTER(native._WceOwnedBuffer),
     ]
+
+
+def test_windows_development_exports_do_not_enable_non_fused_native_asr() -> None:
+    library = _abi_library(native_asr_symbols=_NATIVE_ASR_SYMBOLS)
+
+    client = _configure_client(
+        library,
+        development_build=True,
+        native_asr_abi_version=0,
+        native_asr_feature_bit=0,
+        native_asr_authorization="none",
+        native_asr_target_wechat_version="",
+        native_asr_target_weixin_sha256="",
+    )
+
+    assert client.supports_native_asr is False
+    assert library.wce_native_asr_get_status.argtypes is None
+    with pytest.raises(NativeCoreProtocolError, match="does not implement"):
+        client.get_native_asr_status("wxid_example", Path.cwd().resolve())
+
+
+@pytest.mark.parametrize("authorization", ["", "none"])
+def test_macos_exports_do_not_enable_or_require_windows_native_asr_contract(
+    authorization: str,
+) -> None:
+    library = _abi_library(native_asr_symbols=_NATIVE_ASR_SYMBOLS)
+
+    client = _configure_client(
+        library,
+        platform="macos",
+        native_asr_abi_version=0,
+        native_asr_feature_bit=0,
+        native_asr_authorization=authorization,
+        native_asr_target_wechat_version="",
+        native_asr_target_weixin_sha256="",
+    )
+
+    assert client.supports_native_asr is False
+    assert library.wce_native_asr_get_status.argtypes is None
+
+
+@pytest.mark.parametrize("authorization", ["", "native-asr"])
+def test_complete_native_asr_exports_require_database_read_manifest_contract(
+    authorization: str,
+) -> None:
+    library = _abi_library(native_asr_symbols=_NATIVE_ASR_SYMBOLS)
+
+    with pytest.raises(
+        NativeCoreProtocolError,
+        match="nativeAsrAuthorization must equal database-read",
+    ):
+        _configure_client(library, native_asr_authorization=authorization)
+
+
+def test_formal_windows_legacy_manifest_fails_closed() -> None:
+    library = _abi_library(native_asr_symbols=_NATIVE_ASR_SYMBOLS)
+
+    with pytest.raises(
+        NativeCoreProtocolError,
+        match="nativeAsrAuthorization must equal database-read",
+    ):
+        _configure_client(
+            library,
+            native_asr_authorization="",
+        )
+
+
+def test_formal_fused_manifest_without_asr_exports_is_rejected() -> None:
+    library = _abi_library()
+
+    with pytest.raises(
+        NativeCoreProtocolError,
+        match="manifest declares fused support.*missing all native ASR ABI symbols",
+    ):
+        _configure_client(library)
 
 
 def test_native_asr_status_begin_poll_and_close_round_trip(tmp_path: Path) -> None:

--- a/tests/test_native_core_dev_lease.py
+++ b/tests/test_native_core_dev_lease.py
@@ -62,6 +62,10 @@ def _write_component(
             "developmentBuild": True,
             "offlineBootstrapFeatureBits": 0,
             "offlineExportSealFormat": "none",
+            "nativeAsrAbiVersion": 0,
+            "nativeAsrFeatureBit": 0,
+            "nativeAsrAuthorization": "none",
+            "nativeAsrTarget": {"wechatVersion": "", "weixinSha256": ""},
             "codeSignatureEnforced": False,
             "rootPublicKeyCompiled": False,
             "testHooksEnabled": True,
@@ -77,6 +81,15 @@ def _write_component(
             "developmentBuild": False,
             "offlineBootstrapFeatureBits": 3,
             "offlineExportSealFormat": "WES2",
+            "nativeAsrAbiVersion": 1,
+            "nativeAsrFeatureBit": 16,
+            "nativeAsrAuthorization": "database-read",
+            "nativeAsrTarget": {
+                "wechatVersion": "4.1.12.26",
+                "weixinSha256": (
+                    "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46"
+                ),
+            },
             "codeSignatureEnforced": True,
             "rootPublicKeyCompiled": True,
             "testHooksEnabled": False,

--- a/tests/test_native_core_license_policy.py
+++ b/tests/test_native_core_license_policy.py
@@ -73,6 +73,15 @@ def _manifest(*, development: bool) -> NativeCoreBuildManifest:
             else NativeCoreFeature.DATABASE_READ | NativeCoreFeature.EXPORT
         ),
         offline_export_seal_format="none" if development else "WES2",
+        native_asr_abi_version=0 if development else 1,
+        native_asr_feature_bit=0 if development else 16,
+        native_asr_authorization="none" if development else "database-read",
+        native_asr_target_wechat_version="" if development else "4.1.12.26",
+        native_asr_target_weixin_sha256=(
+            ""
+            if development
+            else "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46"
+        ),
         build_issued_at_unix=0 if development else _PRODUCTION_BUILD_ISSUED_AT,
         build_expires_at_unix=0 if development else _PRODUCTION_BUILD_EXPIRES_AT,
     )
@@ -226,6 +235,13 @@ def _write_component(
                     manifest.offline_bootstrap_feature_bits
                 ),
                 "offlineExportSealFormat": manifest.offline_export_seal_format,
+                "nativeAsrAbiVersion": manifest.native_asr_abi_version,
+                "nativeAsrFeatureBit": manifest.native_asr_feature_bit,
+                "nativeAsrAuthorization": manifest.native_asr_authorization,
+                "nativeAsrTarget": {
+                    "wechatVersion": manifest.native_asr_target_wechat_version,
+                    "weixinSha256": manifest.native_asr_target_weixin_sha256,
+                },
                 "codeSignatureEnforced": manifest.code_signature_enforced,
                 "rootPublicKeyCompiled": manifest.root_public_key_compiled,
                 "testHooksEnabled": manifest.test_hooks_enabled,

--- a/tests/test_native_core_voice_asr.py
+++ b/tests/test_native_core_voice_asr.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
+from wechat_decrypt_tool import native_core_lease
 from wechat_decrypt_tool import native_core_voice_asr as module
 from wechat_decrypt_tool.native_core_client import (
     NativeCoreAsrPollResult,
@@ -83,6 +85,32 @@ def test_status_maps_version_mismatch_to_product_reason(monkeypatch, tmp_path: P
     assert operation.closed is True
 
 
+def test_status_maps_policy_failure_to_protected_build_reason(monkeypatch, tmp_path: Path):
+    operation = _Operation()
+
+    def reject_policy(*_args):
+        raise NativeCorePolicyError(
+            "feature unavailable", status=NativeCoreStatus.FEATURE_DENIED
+        )
+
+    client = SimpleNamespace(
+        supports_native_asr=True,
+        get_native_asr_status=reject_policy,
+    )
+    monkeypatch.setattr(module.os, "name", "nt")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
+    monkeypatch.setattr(module, "get_native_core_client", lambda: client)
+
+    assert module.native_core_voice_asr_status(tmp_path / "wxid_test") == {
+        "available": False,
+        "reason": "protected_build_unavailable",
+        "version": "4.1.12.26",
+        "pid": None,
+    }
+    assert operation.closed is True
+
+
 @pytest.mark.parametrize(
     ("error", "expected_code"),
     [
@@ -107,7 +135,7 @@ def test_status_maps_version_mismatch_to_product_reason(monkeypatch, tmp_path: P
             NativeCorePolicyError(
                 "feature denied", status=NativeCoreStatus.FEATURE_DENIED
             ),
-            "native_asr_not_authorized",
+            "native_transport_unavailable",
         ),
         (NativeCoreUnavailableError("missing"), "native_transport_unavailable"),
         (
@@ -115,7 +143,7 @@ def test_status_maps_version_mismatch_to_product_reason(monkeypatch, tmp_path: P
             "native_transport_unavailable",
         ),
         (NativeCoreProtocolError("protocol"), "native_transport_unavailable"),
-        (NativeCorePolicyError("policy"), "native_asr_not_authorized"),
+        (NativeCorePolicyError("policy"), "native_transport_unavailable"),
     ],
 )
 def test_native_core_errors_preserve_machine_status(error, expected_code):
@@ -127,7 +155,8 @@ def test_terminal_status_overrides_only_security_and_transport_failures():
         NativeCoreStatus.LEASE_EXPIRED,
         include_generic=False,
     ) or module._reason_error(NativeCoreAsrReason.CALLBACK_FAILED)
-    assert lease_error.code == "native_asr_not_authorized"
+    assert lease_error.code == "native_transport_unavailable"
+    assert "授权" not in lease_error.user_message
 
     provider_error = module._native_core_status_error(
         NativeCoreStatus.UNAVAILABLE,
@@ -167,7 +196,6 @@ def test_transport_polls_success_and_persists_without_logging_text(
 
     monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
     monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
-    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
     monkeypatch.setattr(module.secrets, "token_urlsafe", lambda _size: "opaque")
     monkeypatch.setattr(module.threading, "Thread", _ImmediateThread)
     def store_pending(**kwargs):
@@ -233,7 +261,9 @@ def test_transport_fails_closed_on_account_mismatch(monkeypatch, tmp_path: Path)
     assert operation.closed is True
 
 
-def test_near_expiry_lease_fails_before_native_begin(monkeypatch, tmp_path: Path):
+def test_trigger_reaches_native_begin_without_license_refresh_or_heartbeat(
+    monkeypatch, tmp_path: Path
+):
     operation = _Operation()
     begin_called = False
 
@@ -246,17 +276,13 @@ def test_near_expiry_lease_fails_before_native_begin(monkeypatch, tmp_path: Path
         def begin_native_asr(self, *_args):
             nonlocal begin_called
             begin_called = True
-            return 99
+            raise NativeCoreUnavailableError("stop after begin")
 
-    def reject_short_lease(*_args, **_kwargs):
-        raise NativeCorePolicyError(
-            "lease expires too soon",
-            status=NativeCoreStatus.LEASE_EXPIRED,
-        )
+    refresh = Mock(side_effect=AssertionError("ASR must not refresh a license"))
 
     monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
     monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
-    monkeypatch.setattr(module, "refresh_native_core_lease", reject_short_lease)
+    monkeypatch.setattr(native_core_lease, "refresh_native_core_lease", refresh)
 
     with pytest.raises(NativeVoiceTriggerError) as caught:
         module.NativeCoreVoiceAsrTransport().trigger(
@@ -269,8 +295,10 @@ def test_near_expiry_lease_fails_before_native_begin(monkeypatch, tmp_path: Path
             )
         )
 
-    assert caught.value.code == "native_asr_not_authorized"
-    assert begin_called is False
+    assert caught.value.code == "native_transport_unavailable"
+    assert "授权" not in caught.value.user_message
+    assert begin_called is True
+    refresh.assert_not_called()
     assert operation.closed is True
 
 
@@ -301,7 +329,6 @@ def test_thread_start_failure_releases_operation_and_active_slot(
 
     monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
     monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
-    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
     monkeypatch.setattr(module.secrets, "token_urlsafe", lambda _size: "opaque")
     monkeypatch.setattr(module.threading, "Thread", BrokenThread)
     monkeypatch.setattr(
@@ -349,7 +376,6 @@ def test_concurrent_cached_success_wins_and_new_native_handle_is_closed(
 
     monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
     monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
-    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
     monkeypatch.setattr(module.secrets, "token_urlsafe", lambda _size: "new")
     monkeypatch.setattr(
         module,
@@ -406,7 +432,6 @@ def test_worker_retries_transient_close_failure(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
     monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
-    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
     monkeypatch.setattr(module.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(module, "_CLOSE_RETRY_DELAYS_SECONDS", (0.0,))
     monkeypatch.setattr(
@@ -463,7 +488,6 @@ def test_persistent_worker_close_failure_requires_restart(monkeypatch, tmp_path:
 
     monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
     monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
-    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
     monkeypatch.setattr(module.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(module, "_CLOSE_RETRY_DELAYS_SECONDS", ())
     monkeypatch.setattr(
@@ -512,7 +536,6 @@ def test_pending_store_and_close_failure_retain_native_generation(
 
     monkeypatch.setattr(module, "managed_native_core_operation", lambda: operation)
     monkeypatch.setattr(module, "get_native_core_client", lambda: Client())
-    monkeypatch.setattr(module, "refresh_native_core_lease", lambda *_a, **_k: None)
     monkeypatch.setattr(module, "_CLOSE_RETRY_DELAYS_SECONDS", ())
     monkeypatch.setattr(
         module,

--- a/tests/test_wcdb_realtime_native_core_required.py
+++ b/tests/test_wcdb_realtime_native_core_required.py
@@ -35,6 +35,10 @@ def _manifest(*, development: bool) -> dict[str, object]:
             "developmentBuild": True,
             "offlineBootstrapFeatureBits": 0,
             "offlineExportSealFormat": "none",
+            "nativeAsrAbiVersion": 0,
+            "nativeAsrFeatureBit": 0,
+            "nativeAsrAuthorization": "none",
+            "nativeAsrTarget": {"wechatVersion": "", "weixinSha256": ""},
             "codeSignatureEnforced": False,
             "rootPublicKeyCompiled": False,
             "testHooksEnabled": True,
@@ -49,6 +53,15 @@ def _manifest(*, development: bool) -> dict[str, object]:
         "developmentBuild": False,
         "offlineBootstrapFeatureBits": 3,
         "offlineExportSealFormat": "WES2",
+        "nativeAsrAbiVersion": 1,
+        "nativeAsrFeatureBit": 16,
+        "nativeAsrAuthorization": "database-read",
+        "nativeAsrTarget": {
+            "wechatVersion": "4.1.12.26",
+            "weixinSha256": (
+                "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46"
+            ),
+        },
         "codeSignatureEnforced": True,
         "rootPublicKeyCompiled": True,
         "testHooksEnabled": False,

--- a/tests/test_windows_native_core_policy.py
+++ b/tests/test_windows_native_core_policy.py
@@ -25,6 +25,15 @@ def windows_manifest(*, source_runtime: bool = False) -> dict[str, object]:
         "developmentBuild": False,
         "offlineBootstrapFeatureBits": 3,
         "offlineExportSealFormat": "WES2",
+        "nativeAsrAbiVersion": 1,
+        "nativeAsrFeatureBit": 16,
+        "nativeAsrAuthorization": "database-read",
+        "nativeAsrTarget": {
+            "wechatVersion": "4.1.12.26",
+            "weixinSha256": (
+                "4914a621a810ecbc0a132b6ff8f612658cfce323d3989b3e5fe32d4ff343ba46"
+            ),
+        },
         "codeSignatureEnforced": True,
         "rootPublicKeyCompiled": True,
         "testHooksEnabled": False,
@@ -65,6 +74,10 @@ def test_windows_source_public_manifest_retains_production_security(
     assert manifest.platform == "windows"
     assert manifest.source_runtime is True
     assert manifest.windows_host_verification == "same-user-direct-parent"
+    assert manifest.native_asr_abi_version == 1
+    assert manifest.native_asr_feature_bit == 16
+    assert manifest.native_asr_authorization == "database-read"
+    assert manifest.native_asr_target_wechat_version == "4.1.12.26"
     assert native_core_client._is_source_public_native_core_build_manifest(manifest)
     assert not native_core_client._is_production_native_core_build_manifest(manifest)
     assert native_core_lease.validate_native_core_authorization_policy(manifest) == "production"


### PR DESCRIPTION
## Summary
- stop refreshing or requiring a separate native-ASR entitlement
- make the fused Windows ASR path inherit the protected DLL's `DATABASE_READ` and fixed build/integrity policy
- distinguish the new broker contract with `nativeAsrAuthorization: database-read`, while keeping formal non-fused/dev/macOS native core usable with ASR disabled
- replace the user-facing authorization error with a protected DLL/build availability message
- pin the newly signed and promoted source runtime

## Native delivery evidence
- private WCDB PR: 2977094657/WCDB#3
- producer run: 32004006556 (`wcdb-prod-20260817-native-asr-dll-auth-1`)
- public promotion run: 32005152197, attempt 2
- release tag: `windows-source-runtime-20260817-7795dced-32004006556`
- runtime SHA-256: `5e7eeb7e824616aa462f5cbb5b21369516014b5a323c41b6456d71ec1d860ec9`

## Validation
- native Debug/Release CTest: 13/13 each
- license-server: 208 passed, 5 skipped
- WDA Python: 170 passed + 18 subtests
- desktop: 63/63
- frontend: 32/32
- live public bootstrap: downloaded and validated `nativeAsrAuthorization=database-read`