### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ npm run dist:mac
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LifeArchiveProject/WeChatDataAnalysis&type=Date)](https://www.star-history.com/#LifeArchiveProject/WeChatDataAnalysis&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=LifeArchiveProject/WeChatDataAnalysis&type=Date)](https://star-history.dera.page/#LifeArchiveProject/WeChatDataAnalysis&type=Date)
 
 ## 贡献
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已经失效，无法正常展示项目的星标历史趋势。本次修改将图表地址切换到可用的服务，修复后图表即可正常渲染。