### PR TITLE
chore(release): prepare v2.1.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wechat-data-analysis-desktop",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wechat-data-analysis-desktop",
-      "version": "2.0.11",
+      "version": "2.1.0",
       "dependencies": {
         "electron-updater": "^6.7.3",
         "ffmpeg-static": "^5.3.0"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wechat-data-analysis-desktop",
   "private": true,
-  "version": "2.0.11",
+  "version": "2.1.0",
   "main": "src/main.cjs",
   "scripts": {
     "dev": "node scripts/dev.cjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wechat-decrypt-tool"
-version = "2.0.11"
+version = "2.1.0"
 description = "Modern WeChat database decryption tool with React frontend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wechat_decrypt_tool/__init__.py
+++ b/src/wechat_decrypt_tool/__init__.py
@@ -1,5 +1,5 @@
 """微信数据库解密工具
 """
 
-__version__ = "2.0.11"
+__version__ = "2.1.0"
 __author__ = "WeChat Decrypt Tool"

--- a/uv.lock
+++ b/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "wechat-decrypt-tool"
-version = "2.0.11"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## 变更
- 将 Python 包版本更新到 `2.1.0`
- 将 Electron 桌面端及 lockfile 版本更新到 `2.1.0`
- 同步 `uv.lock` 项目版本

## 验证
- 版本六处一致性：`2.1.0`
- `uv lock --check`
- Windows 发布 Python 定向测试：41 passed + 12 subtests
- Desktop 发布契约测试：73 passed

## 发布
合并后将在 exact `main` commit 创建 `v2.1.0` 标签，触发 Windows + macOS ARM64 发布工作流。