### PR TITLE
fix(release): consume pinned macOS integrity release

### DIFF
--- a/.github/workflows/macos-private-build.yml
+++ b/.github/workflows/macos-private-build.yml
@@ -59,6 +59,7 @@ jobs:
       WCE_NATIVE_CORE_ALLOW_DEVELOPMENT_ARTIFACTS: "0"
       WCE_INTEGRITY_ARTIFACT_REPOSITORY: ${{ vars.WCE_INTEGRITY_ARTIFACT_REPOSITORY }}
       WCE_INTEGRITY_ARTIFACT_RUN_ID: ${{ vars.WCE_INTEGRITY_ARTIFACT_RUN_ID }}
+      WCE_INTEGRITY_ARTIFACT_SHA256: ${{ vars.WCE_INTEGRITY_ARTIFACT_SHA256 }}
       WCE_INTEGRITY_SOURCE_REVISION: ${{ vars.WCE_INTEGRITY_SOURCE_REVISION }}
       WCE_INTEGRITY_BUILD_ID: ${{ vars.WCE_INTEGRITY_BUILD_ID }}
       WCE_INTEGRITY_BINARY_SHA256: ${{ vars.WCE_INTEGRITY_BINARY_SHA256 }}
@@ -144,6 +145,8 @@ jobs:
           test "$WCE_NATIVE_CORE_HOST_SIGNING_IDENTIFIER" = "com.lifearchive.wechatdataanalysis.backend"
           [[ "$WCE_INTEGRITY_ARTIFACT_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
           [[ "$WCE_INTEGRITY_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$WCE_INTEGRITY_ARTIFACT_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          [[ ! "$WCE_INTEGRITY_ARTIFACT_SHA256" =~ ^0{64}$ ]]
           [[ "$WCE_INTEGRITY_SOURCE_REVISION" =~ ^[0-9a-f]{40}$ ]]
           [[ "$WCE_INTEGRITY_BUILD_ID" =~ ^[A-Za-z0-9._-]{8,128}$ ]]
           [[ "$WCE_INTEGRITY_BINARY_SHA256" =~ ^[0-9a-f]{64}$ ]]
@@ -218,15 +221,18 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
+          release_tag="macos-integrity-$WCE_INTEGRITY_BUILD_ID"
+          asset_name="wce-integrity-macos-arm64-production-$WCE_INTEGRITY_BUILD_ID.zip"
+          archive="$RUNNER_TEMP/$asset_name"
           artifact_dir="$RUNNER_TEMP/wce-integrity-macos-arm64-production"
           downloaded=0
+          test ! -e "$artifact_dir"
           for attempt in 1 2 3; do
-            rm -rf "$artifact_dir"
-            mkdir -p "$artifact_dir"
-            if gh run download "$WCE_INTEGRITY_ARTIFACT_RUN_ID" \
+            rm -f "$archive"
+            if gh release download "$release_tag" \
               --repo "$WCE_INTEGRITY_ARTIFACT_REPOSITORY" \
-              --name wce-integrity-macos-arm64-production \
-              --dir "$artifact_dir"
+              --pattern "$asset_name" \
+              --dir "$RUNNER_TEMP"
             then
               downloaded=1
               break
@@ -236,6 +242,11 @@ jobs:
             fi
           done
           test "$downloaded" = 1
+          test -s "$archive"
+          actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          test "$actual_sha256" = "$WCE_INTEGRITY_ARTIFACT_SHA256"
+          mkdir -p "$artifact_dir"
+          /usr/bin/unzip -q "$archive" -d "$artifact_dir"
           test -f "$artifact_dir/libwce_integrity.dylib"
           test -f "$artifact_dir/wce_integrity_build.json"
           test -f "$artifact_dir/provenance.json"

--- a/desktop/tests/macos-xkey-signing.test.cjs
+++ b/desktop/tests/macos-xkey-signing.test.cjs
@@ -147,11 +147,34 @@ test("macOS private workflow keeps the canonical Producer and WCDA certificate v
   assert.match(workflow, /wechatdb-native-macos-arm64-production/);
   assert.match(workflow, /macos-native-core-packaging\.cjs/);
   assert.match(workflow, /WCE_NATIVE_CORE_PRIVATE_ROOT_SHA256/);
+  assert.match(workflow, /WCE_INTEGRITY_ARTIFACT_SHA256/);
   assert.match(workflow, /WCE_MACOS_PRIVATE_ROOT_CERT_PATH/);
   assert.match(workflow, /macos-private-pki-root\.cer/);
   assert.match(workflow, /consumer-smoke-macos-arm64/);
   assert.match(workflow, /needs: build-macos-arm64/);
   assert.match(workflow, /macos-private-pki-runtime\.test\.cjs/);
+});
+
+test("macOS private workflow verifies the pinned integrity Release before extraction", () => {
+  assert.match(workflow, /release_tag="macos-integrity-\$WCE_INTEGRITY_BUILD_ID"/);
+  assert.match(
+    workflow,
+    /asset_name="wce-integrity-macos-arm64-production-\$WCE_INTEGRITY_BUILD_ID\.zip"/
+  );
+  assert.match(workflow, /gh release download "\$release_tag"/);
+  assert.match(workflow, /shasum -a 256 "\$archive"/);
+  assert.match(workflow, /test "\$actual_sha256" = "\$WCE_INTEGRITY_ARTIFACT_SHA256"/);
+  assert.match(workflow, /\/usr\/bin\/unzip -q "\$archive" -d "\$artifact_dir"/);
+  assert.doesNotMatch(
+    workflow,
+    /gh run download "\$WCE_INTEGRITY_ARTIFACT_RUN_ID"/
+  );
+
+  const downloadIndex = workflow.indexOf('gh release download "$release_tag"');
+  const hashIndex = workflow.indexOf('shasum -a 256 "$archive"');
+  const extractIndex = workflow.indexOf('/usr/bin/unzip -q "$archive"');
+  assert.ok(downloadIndex >= 0 && downloadIndex < hashIndex);
+  assert.ok(hashIndex < extractIndex);
 });
 
 test("macOS private workflow retries transient Producer artifact downloads from a clean directory", () => {


### PR DESCRIPTION
## 根因
v2.1.0 首轮 macOS 构建在 export-integrity producer 的 Actions artifact 存储限额处失败。producer 已改为私有 Release 分发，但 consumer 仍读取 Actions artifact。

## 修复
- 按精确 integrity build ID 下载私有 Release ZIP
- 新增固定 `WCE_INTEGRITY_ARTIFACT_SHA256`
- 在解压和执行制品前完成 SHA-256 校验
- 保留 run ID/source revision/build ID/binary SHA/UI revision 的既有验证

## 验证
- macOS workflow + package release contract: 31 passed
- workflow YAML parse / diff check