### PR TITLE
fix(build): load os for packaged OpenCC smoke

### DIFF
--- a/desktop/scripts/build-backend.cjs
+++ b/desktop/scripts/build-backend.cjs
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 const {

--- a/tests/test_voice_transcription_contract.py
+++ b/tests/test_voice_transcription_contract.py
@@ -66,6 +66,7 @@ class TestVoiceTranscriptionContract(unittest.TestCase):
         self.assertIn('"ctranslate2"', build)
         self.assertIn('"av"', build)
         self.assertIn('"opencc"', build)
+        self.assertIn('const os = require("os");', build)
         self.assertIn('"--smoke-opencc"', build)
         self.assertNotIn("windowsNativeCandidates", build)
         self.assertIn("buildIntegrityNativeBinary()", build)


### PR DESCRIPTION
## 根因
v2.1.0 首轮 Windows 发布已完成 UI/Python/native staging，但在打包后 OpenCC smoke 启动前报 `os is not defined`。`runPackagedOpenccSmoke()` 使用 `os.tmpdir()`，文件顶部未导入 `node:os`。

## 修复
- 补充 `const os = require("os")`
- 契约测试锁定该 import

## 验证
- build-backend module load
- voice transcription contract: 6 passed
- desktop native/macOS/release contracts: 47 passed