### PR TITLE
docs(website): 更新消息能力展示

### DIFF
--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -536,7 +536,15 @@ main { position: relative; z-index: 1; }
 }
 .deck__name { font-size: clamp(2rem, 3.4vw, 3.5rem); font-weight: 900; line-height: 1.04; letter-spacing: -0.03em; }
 .deck__desc { margin-top: clamp(16px, 2.4vh, 26px); font-size: clamp(13px, 1.05vw, 15.5px); line-height: 1.75; color: var(--ink-dim); max-width: 40ch; }
-.deck__meta { margin-top: clamp(20px, 3vh, 34px); padding-top: 16px; border-top: 1px solid var(--line); font-size: 10.5px; letter-spacing: 0.18em; color: var(--neon); opacity: 0.9; }
+.deck__meta { margin-top: clamp(20px, 3vh, 34px); padding-top: 16px; border-top: 1px solid var(--line); font-size: 10.5px; line-height: 1.7; letter-spacing: 0.18em; color: var(--neon); opacity: 0.9; }
+.deck__meta--groups { display: grid; gap: 11px; letter-spacing: 0; }
+.deck__capability { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: 12px; align-items: start; }
+.deck__capability-label {
+  padding: 3px 5px; border: 1px solid rgba(61, 242, 141, 0.28);
+  color: var(--ink-dim); font-size: 8.5px; line-height: 1.45; letter-spacing: 0.08em;
+  text-align: center; white-space: nowrap;
+}
+.deck__capability-items { font-size: 10px; line-height: 1.75; letter-spacing: 0.08em; color: var(--neon); }
 .deck__dots { display: flex; gap: 7px; align-items: center; margin-top: 18px; }
 .deck__dots i { width: 16px; height: 2px; background: var(--line-strong); transition: width 0.4s var(--ease-out), background 0.4s, box-shadow 0.4s; }
 .deck__dots i.on { width: 34px; background: var(--neon); box-shadow: 0 0 8px var(--glow); }
@@ -984,6 +992,10 @@ main { position: relative; z-index: 1; }
   .deck__num { font-size: clamp(3rem, 12vw, 4.4rem); margin: 12px 0; }
   .deck__desc { display: none; }
   .deck__meta { margin-top: 14px; padding-top: 12px; }
+  .deck__meta--groups { gap: 7px; }
+  .deck__capability { grid-template-columns: 78px minmax(0, 1fr); gap: 8px; }
+  .deck__capability-label { font-size: 7.5px; padding: 2px 4px; }
+  .deck__capability-items { font-size: 8.5px; line-height: 1.55; letter-spacing: 0.04em; }
   .decrypt__chat { width: min(360px, 88vw); }
   .decrypt__hud { top: 84px; }
   .dtitle { top: 17vh; }

--- a/website/assets/js/main.js
+++ b/website/assets/js/main.js
@@ -809,7 +809,20 @@ function buildFeatures() {
   const META = [
     { name: "聊天记录 1:1 复刻", meta: "全消息类型 · 时间轴跳转 · 高仿界面", desc: "文本、图片、视频、语音、表情、引用、合并转发……逐一还原，样式尽可能与微信保持一致。" },
     { name: "实时消息同步", meta: "WCDB 直读 · 侧栏闪电 · 零轮询", desc: "直连微信 4.x 的 WCDB——微信开着，新消息、联系人与朋友圈也会实时流进来。" },
-    { name: "修改消息 · 随时恢复", meta: "本地改写 · 一键恢复 · 原库零改动", desc: "本地改写任意一条消息，原文永远可以一键找回。" },
+    {
+      name: "修改与补录 · 随时恢复",
+      desc: "从普通消息、媒体到结构化卡片，完整补录与修改能力一次列清。",
+      groups: [
+        {
+          label: "新增 / 补录 17",
+          items: ["文字", "图片", "文件", "语音", "更多类型"],
+        },
+        {
+          label: "修改 / 恢复",
+          items: ["修改文字", "替换图片", "修改时间", "一键恢复", "更多操作"],
+        },
+      ],
+    },
     { name: "朋友圈时光机", meta: "删除仍可见 · 历史背景图 · 缓存可调", desc: "看过的朋友圈本地留存：对方改成三天可见、甚至删除动态，你依然能翻回当年的背景图。" },
     { name: "全文搜索", meta: "毫秒级 · 跨会话 · 类型过滤", desc: "多年记录毫秒级跨会话检索，按联系人、消息类型、时间范围任意过滤，一步跳回现场。" },
     { name: "导出万物", meta: "10 类内容 × 4 种格式 · ZIP", desc: "10 类内容 × HTML / JSON / TXT / Excel，从聊天记录到转账红包、全量归档，连资源打包 ZIP。" },
@@ -844,6 +857,33 @@ function buildFeatures() {
   }
 
   let cur = -1;
+  function renderMeta(entry) {
+    const groups = Array.isArray(entry.groups) ? entry.groups : [];
+    metaEl.classList.toggle("deck__meta--groups", groups.length > 0);
+    metaEl.replaceChildren();
+
+    if (!groups.length) {
+      metaEl.textContent = entry.meta || "";
+      return;
+    }
+
+    groups.forEach((group) => {
+      const row = document.createElement("div");
+      row.className = "deck__capability";
+
+      const labelEl = document.createElement("span");
+      labelEl.className = "deck__capability-label";
+      labelEl.textContent = group.label;
+
+      const itemsEl = document.createElement("span");
+      itemsEl.className = "deck__capability-items";
+      itemsEl.textContent = group.items.join(" · ");
+
+      row.append(labelEl, itemsEl);
+      metaEl.append(row);
+    });
+  }
+
   function label(idx, animate) {
     if (idx === cur) return;
     const dir = idx > cur ? 1 : -1;
@@ -851,7 +891,7 @@ function buildFeatures() {
     dots.forEach((dd, i) => dd.classList.toggle("on", i === idx));
     numEl.textContent = String(idx + 1).padStart(2, "0");
     nameEl.textContent = META[idx].name;
-    metaEl.textContent = META[idx].meta;
+    renderMeta(META[idx]);
     descEl.textContent = META[idx].desc;
     if (animate) gsap.fromTo(".deck__capmain", { opacity: 0.2, y: dir * 12 }, { opacity: 1, y: 0, duration: 0.5, ease: "flow", overwrite: true });
   }

--- a/website/index.html
+++ b/website/index.html
@@ -189,7 +189,7 @@
             <span class="deck__num" id="deck-num">01</span>
             <h3 class="deck__name" id="deck-name">聊天记录 1:1 复刻</h3>
             <p class="deck__desc" id="deck-desc">文本、图片、视频、语音、表情、引用、合并转发……逐一还原，样式尽可能与微信保持一致。</p>
-            <p class="deck__meta mono" id="deck-meta">全消息类型 · 时间轴跳转 · 高仿界面</p>
+            <div class="deck__meta mono" id="deck-meta">全消息类型 · 时间轴跳转 · 高仿界面</div>
             <div class="deck__dots" id="deck-dots"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
           </div>
 


### PR DESCRIPTION
## 修改内容
- 更新官网“修改与补录”能力卡片
- 将能力项分组展示并补充响应式样式
- 移除“原库零改动”文案

## 范围
仅修改 `website/` 下 3 个官网文件，不包含消息编辑实现、打包脚本或认证文件。

## 验证
- `node --check website/assets/js/main.js`
- `git diff --check`
- 官网文案断言通过
