### PR TITLE
feat(chat-export): 支持聊天记录增量目录导出与修复

### DIFF
--- a/frontend/components/chat/ChatExportDialog.vue
+++ b/frontend/components/chat/ChatExportDialog.vue
@@ -243,12 +243,30 @@
             <header class="chat-export-panel__header">
               <div>
                 <h3 id="chat-export-output-title">时间与文件</h3>
-                <p>时间范围和文件名可留空，保存目录为必选项。</p>
+                <p>选择一次性 ZIP，或可以重复更新的增量目录。</p>
               </div>
               <span class="chat-export-count" :class="{ 'chat-export-count--warning': !exportHasFolder }">
                 {{ exportHasFolder ? '位置已设置' : '需要目录' }}
               </span>
             </header>
+
+            <fieldset class="chat-export-fieldset chat-export-output-mode">
+              <legend>输出方式</legend>
+              <div class="chat-export-format-grid chat-export-format-grid--two">
+                <label class="chat-export-format-option" :class="{ 'chat-export-format-option--selected': exportOutputMode === 'zip' }">
+                  <input v-model="exportOutputMode" type="radio" value="zip" class="sr-only" />
+                  <span class="chat-export-format-option__code">ZIP 全量</span>
+                  <span class="chat-export-format-option__meta">一次性归档</span>
+                  <span class="chat-export-format-option__check" aria-hidden="true"><svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4"><path d="m4 10 4 4 8-8" /></svg></span>
+                </label>
+                <label class="chat-export-format-option" :class="{ 'chat-export-format-option--selected': exportOutputMode === 'folder' }">
+                  <input v-model="exportOutputMode" type="radio" value="folder" class="sr-only" />
+                  <span class="chat-export-format-option__code">增量目录</span>
+                  <span class="chat-export-format-option__meta">可持续更新</span>
+                  <span class="chat-export-format-option__check" aria-hidden="true"><svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4"><path d="m4 10 4 4 8-8" /></svg></span>
+                </label>
+              </div>
+            </fieldset>
 
             <div class="chat-export-output-section">
               <div class="chat-export-compact-label">
@@ -268,7 +286,7 @@
               </div>
             </div>
 
-            <div class="chat-export-output-section">
+            <div v-if="exportOutputMode === 'zip'" class="chat-export-output-section">
               <div class="chat-export-compact-label">
                 <h4>ZIP 文件名</h4>
                 <span>可选，留空时自动生成</span>
@@ -282,6 +300,36 @@
               />
             </div>
 
+            <div v-else class="chat-export-output-section chat-export-incremental-card">
+              <div class="chat-export-incremental-card__summary">
+                <span class="chat-export-incremental-card__icon" aria-hidden="true">
+                  <i class="fa-solid fa-folder-tree"></i>
+                </span>
+                <div class="chat-export-incremental-card__copy">
+                  <div class="chat-export-incremental-card__heading">
+                    <h4>增量目录</h4>
+                    <span class="chat-export-baseline-status" :data-status="exportBaselineStatus">
+                      {{ exportBaselineStatusLabel }}
+                    </span>
+                  </div>
+                  <strong class="chat-export-incremental-card__folder" :title="exportFolderNamePreview">
+                    {{ exportFolderNamePreview }}
+                  </strong>
+                  <span class="chat-export-incremental-card__hint">未选中的既有会话会继续保留</span>
+                </div>
+              </div>
+              <label class="chat-export-reset-option" :class="{ 'chat-export-reset-option--selected': exportResetBaseline }">
+                <input v-model="exportResetBaseline" type="checkbox" class="sr-only" />
+                <span class="chat-export-checkbox" :class="{ 'chat-export-checkbox--checked': exportResetBaseline }" aria-hidden="true">
+                  <i class="fa-solid fa-check"></i>
+                </span>
+                <span class="chat-export-reset-option__copy">
+                  <strong>重置增量基线</strong>
+                  <small>仅配置发生变化时使用；会完整重建目录内的会话</small>
+                </span>
+              </label>
+            </div>
+
             <div class="chat-export-output-section chat-export-output-section--destination">
               <div class="chat-export-compact-label">
                 <h4>保存目录</h4>
@@ -293,7 +341,7 @@
                 </svg>
                 <div>
                   <strong>{{ exportFolder || '尚未选择保存目录' }}</strong>
-                  <small>{{ exportFolder ? '导出完成后会写入此目录' : '开始导出前需要先完成此项' }}</small>
+                  <small>{{ exportFolder ? (exportOutputMode === 'folder' ? '将创建或更新其中的增量目录' : '导出完成后会写入此目录') : '开始导出前需要先完成此项' }}</small>
                 </div>
                 <button type="button" class="chat-export-secondary-button" @click="chooseExportFolder">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
@@ -341,8 +389,12 @@
                 <strong>{{ exportJob.progress?.mediaCopied || 0 }}</strong>
               </div>
               <div>
-                <span>缺失媒体</span>
-                <strong>{{ exportJob.progress?.mediaMissing || 0 }}</strong>
+                <span>{{ exportJob.options?.outputMode === 'folder' ? '待补媒体（去重）' : '缺失媒体' }}</span>
+                <strong>
+                  {{ exportJob.options?.outputMode === 'folder' && exportJob.status === 'done'
+                    ? (exportJob.unresolvedMedia?.uniqueCount || 0)
+                    : (exportJob.progress?.mediaMissing || 0) }}
+                </strong>
               </div>
             </div>
 
@@ -371,7 +423,106 @@
               <p>{{ exportJob.progress?.currentConversationMessagesExported || 0 }} / {{ exportJob.progress?.currentConversationMessagesTotal || 0 }} 条消息</p>
             </div>
 
-            <div v-if="exportJob.status === 'done'" class="chat-export-result chat-export-result--success">
+            <div
+              v-if="exportJob.status === 'done' && exportJob.options?.outputMode === 'folder'"
+              class="chat-export-folder-result"
+            >
+              <div class="chat-export-folder-result__summary" role="status" aria-live="polite">
+                <span class="chat-export-folder-result__status-icon" aria-hidden="true">
+                  <i class="fa-solid fa-check"></i>
+                </span>
+                <div class="chat-export-folder-result__main">
+                  <strong>增量目录已更新</strong>
+                  <span class="chat-export-folder-result__path">
+                    {{ exportJob.folderPath || exportJob.folderName || exportFolderNamePreview }}
+                  </span>
+                  <div class="chat-export-folder-result__metrics" aria-label="本次增量更新统计">
+                    <span>新增 <strong>{{ exportJob.incremental?.messagesAdded || 0 }}</strong></span>
+                    <span>更新 <strong>{{ exportJob.incremental?.conversationsUpdated || 0 }}</strong></span>
+                    <span>复用 <strong>{{ exportJob.incremental?.conversationsReused || 0 }}</strong></span>
+                    <span v-if="exportJob.incremental?.filesRecovered">
+                      补回 <strong>{{ exportJob.incremental.filesRecovered }}</strong>
+                    </span>
+                    <span v-if="exportJob.incremental?.historyChangesSynced">
+                      同步历史 <strong>{{ exportJob.incremental.historyChangesSynced }}</strong>
+                    </span>
+                  </div>
+                  <span v-if="hasWebExportFolder" class="chat-export-folder-result__save-state">
+                    浏览器目录：{{ exportFolder || '未选择' }}
+                  </span>
+                  <span v-if="exportSaveState === 'saving'" class="chat-export-result__info">{{ exportSaveProgressText }}</span>
+                  <span v-else-if="exportSaveMsg" class="chat-export-result__success">{{ exportSaveMsg }}</span>
+                  <template v-else-if="exportSaveError">
+                    <ErrorNotice :message="exportSaveError" compact class="chat-export-result__error" />
+                    <button
+                      v-if="hasWebExportFolder"
+                      type="button"
+                      class="chat-export-secondary-button chat-export-repair-button"
+                      :disabled="exportSaveBusy"
+                      @click="saveExportToSelectedFolder"
+                    >
+                      重试写入目录
+                    </button>
+                  </template>
+                </div>
+              </div>
+
+              <div
+                v-if="exportJob.repairCandidates?.length || exportJob.unresolvedMedia?.conversations?.length"
+                class="chat-export-folder-result__followups"
+                aria-label="差异与媒体状态"
+              >
+                <div v-if="exportJob.repairCandidates?.length" class="chat-export-followup chat-export-followup--repairable">
+                  <span class="chat-export-followup__icon" aria-hidden="true">
+                    <i class="fa-solid fa-screwdriver-wrench"></i>
+                  </span>
+                  <div class="chat-export-followup__copy">
+                    <strong>{{ exportJob.repairCandidates.length }} 个会话存在可恢复差异</strong>
+                    <span>已确认修复会产生变化，仅重建对应会话。</span>
+                  </div>
+                  <button
+                    type="button"
+                    class="chat-export-followup__action chat-export-followup__action--primary"
+                    :disabled="isExportCreating"
+                    @click="repairIncrementalConversations"
+                  >
+                    修复可恢复差异
+                  </button>
+                </div>
+
+                <div
+                  v-if="exportJob.unresolvedMedia?.conversations?.length"
+                  class="chat-export-followup chat-export-followup--unavailable"
+                >
+                  <span class="chat-export-followup__icon" aria-hidden="true">
+                    <i class="fa-solid fa-photo-film"></i>
+                  </span>
+                  <div class="chat-export-followup__copy">
+                    <strong>{{ exportJob.unresolvedMedia?.uniqueCount || 0 }} 个媒体当前无法获取</strong>
+                    <span>
+                      影响 {{ exportJob.unresolvedMedia?.referenceCount || 0 }} 条消息；源端暂不可用，重复修复不会改变结果。
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    class="chat-export-followup__action"
+                    :disabled="isExportCreating"
+                    title="重新扫描这些会话并重试本地及已启用的远程媒体；源端仍不可用时会继续保留待补状态"
+                    @click="recheckIncrementalMedia"
+                  >
+                    <i class="fa-solid fa-rotate" aria-hidden="true"></i>
+                    重新探测缺失媒体
+                  </button>
+                </div>
+              </div>
+
+              <details v-if="exportJob.warning" class="chat-export-folder-result__details">
+                <summary>查看完整任务说明</summary>
+                <p>{{ exportJob.warning }}</p>
+              </details>
+            </div>
+
+            <div v-else-if="exportJob.status === 'done'" class="chat-export-result chat-export-result--success">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="9" />
                 <path d="m8 12 2.5 2.5L16 9" />
@@ -379,10 +530,22 @@
               <div>
                 <strong>导出已完成</strong>
                 <span>{{ exportBackendZipPath || 'ZIP 文件已生成' }}</span>
+                <span v-if="exportJob.warning" class="chat-export-result__warning">{{ exportJob.warning }}</span>
                 <span v-if="hasWebExportFolder">浏览器目录：{{ exportFolder || '未选择' }}</span>
                 <span v-if="exportSaveState === 'saving'" class="chat-export-result__info">{{ exportSaveProgressText }}</span>
                 <span v-else-if="exportSaveMsg" class="chat-export-result__success">{{ exportSaveMsg }}</span>
-                <ErrorNotice v-else-if="exportSaveError" :message="exportSaveError" compact class="chat-export-result__error" />
+                <template v-else-if="exportSaveError">
+                  <ErrorNotice :message="exportSaveError" compact class="chat-export-result__error" />
+                  <button
+                    v-if="hasWebExportFolder"
+                    type="button"
+                    class="chat-export-secondary-button chat-export-repair-button"
+                    :disabled="exportSaveBusy"
+                    @click="saveExportToSelectedFolder"
+                  >
+                    重试写入目录
+                  </button>
+                </template>
               </div>
               <a
                 v-if="!hasWebExportFolder"
@@ -413,7 +576,7 @@
         <div class="chat-export-summary" aria-live="polite">
           <span><strong>{{ exportSelectedCount }}</strong> 个会话</span>
           <span class="chat-export-summary__separator" aria-hidden="true"></span>
-          <span><strong>{{ exportFormatLabel }}</strong> · {{ exportMessageTypeCount }} 类消息</span>
+          <span><strong>{{ exportFormatLabel }}</strong> · {{ exportOutputModeLabel }} · {{ exportMessageTypeCount }} 类消息</span>
           <span class="chat-export-summary__separator" aria-hidden="true"></span>
           <button
             type="button"
@@ -441,7 +604,7 @@
               <path d="m7.5 10.5 4.5 4.5 4.5-4.5" />
               <path d="M4 19h16" />
             </svg>
-            {{ isExportCreating ? '正在创建' : '开始导出' }}
+            {{ isExportCreating ? '正在创建' : (exportOutputMode === 'folder' ? '开始更新' : '开始导出') }}
           </button>
           <button
             v-else
@@ -500,6 +663,17 @@ export default defineComponent({
       const value = String(stateValue('exportFormat') || 'html').toLowerCase()
       return FORMAT_OPTIONS.find((option) => option.value === value)?.label || value.toUpperCase()
     })
+    const exportOutputModeLabel = computed(() => {
+      return String(stateValue('exportOutputMode') || 'zip') === 'folder' ? '增量目录' : 'ZIP 全量'
+    })
+    const exportBaselineStatusLabel = computed(() => ({
+      ready: '基线已读取',
+      repair: '将补回缺失文件',
+      new: '首次生成',
+      invalid: '基线不可用',
+      auto: '自动检查基线',
+      unknown: '待检查基线',
+    }[String(stateValue('exportBaselineStatus') || 'unknown')] || '待检查基线'))
     const exportHasFolder = computed(() => Boolean(String(stateValue('exportFolder') || '').trim()))
     const exportTimeSummary = computed(() => {
       const start = String(stateValue('exportStartLocal') || '').trim()
@@ -525,6 +699,8 @@ export default defineComponent({
       exportSelectedCount,
       exportMessageTypeCount,
       exportFormatLabel,
+      exportOutputModeLabel,
+      exportBaselineStatusLabel,
       exportHasFolder,
       exportTimeSummary,
       exportJobStatusLabel,
@@ -1153,6 +1329,165 @@ export default defineComponent({
   gap: 6px;
 }
 
+.chat-export-format-grid--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.chat-export-output-mode {
+  padding: 0 0 10px;
+}
+
+.chat-export-incremental-card {
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--app-border);
+  border-radius: 7px;
+  background: var(--app-surface-bg);
+}
+
+.chat-export-incremental-card__summary {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  padding: 10px 11px;
+}
+
+.chat-export-incremental-card__icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border-radius: 6px;
+  background: var(--export-accent-soft);
+  color: var(--export-accent-text);
+  font-size: 13px;
+}
+
+.chat-export-incremental-card__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-export-incremental-card__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.chat-export-incremental-card__heading h4 {
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.chat-export-baseline-status {
+  display: inline-flex;
+  min-height: 22px;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 3px 7px;
+  border: 1px solid var(--export-accent-border);
+  border-radius: 4px;
+  background: var(--export-accent-soft);
+  color: var(--export-accent-text);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.chat-export-baseline-status[data-status='repair'],
+.chat-export-baseline-status[data-status='invalid'] {
+  border-color: var(--export-warning-border);
+  background: var(--export-warning-soft);
+  color: var(--export-warning-text);
+}
+
+.chat-export-incremental-card__folder {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--app-text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-export-incremental-card__hint {
+  color: var(--app-text-muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.chat-export-reset-option {
+  display: grid;
+  min-height: 48px;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  padding: 8px 11px;
+  border-top: 1px solid var(--app-border);
+  background: var(--app-surface-soft);
+  color: var(--app-text-primary);
+  cursor: pointer;
+  transition: background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.chat-export-reset-option:hover {
+  background: var(--app-neutral-btn-hover);
+}
+
+.chat-export-reset-option:focus-within {
+  box-shadow: inset 0 0 0 2px var(--app-accent);
+}
+
+.chat-export-reset-option--selected {
+  background: var(--export-warning-soft);
+}
+
+.chat-export-reset-option--selected:hover {
+  background: var(--export-warning-soft);
+}
+
+.chat-export-reset-option .chat-export-checkbox {
+  width: 17px;
+  height: 17px;
+}
+
+.chat-export-reset-option .chat-export-checkbox i {
+  display: none;
+  font-size: 9px;
+}
+
+.chat-export-reset-option .chat-export-checkbox--checked i {
+  display: block;
+}
+
+.chat-export-reset-option__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-export-reset-option__copy strong {
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.chat-export-reset-option__copy small {
+  color: var(--app-text-muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
 .chat-export-format-option {
   position: relative;
   display: flex;
@@ -1661,6 +1996,221 @@ export default defineComponent({
   color: var(--export-danger-text) !important;
 }
 
+.chat-export-result__warning {
+  color: var(--export-warning-text) !important;
+}
+
+.chat-export-repair-button {
+  width: fit-content;
+  margin-top: 4px;
+}
+
+.chat-export-folder-result {
+  margin-top: 20px;
+  overflow: hidden;
+  border: 1px solid var(--app-border);
+  border-radius: 7px;
+  background: var(--app-surface-bg);
+}
+
+.chat-export-folder-result__summary {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  padding: 13px 14px 12px;
+}
+
+.chat-export-folder-result__status-icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--export-accent-soft);
+  color: var(--export-accent-text);
+  font-size: 13px;
+}
+
+.chat-export-folder-result__main {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.chat-export-folder-result__main > strong {
+  color: var(--app-text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.chat-export-folder-result__path,
+.chat-export-folder-result__save-state {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--app-text-muted);
+  font-size: 11px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-export-folder-result__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 2px;
+}
+
+.chat-export-folder-result__metrics > span {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  background: var(--app-surface-soft);
+  color: var(--app-text-secondary);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.chat-export-folder-result__metrics strong {
+  color: var(--app-text-primary);
+  font-size: inherit;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-export-folder-result__followups {
+  border-top: 1px solid var(--app-border);
+  background: var(--app-surface-soft);
+}
+
+.chat-export-followup {
+  display: grid;
+  min-height: 62px;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 14px;
+}
+
+.chat-export-followup + .chat-export-followup {
+  border-top: 1px solid var(--app-border);
+}
+
+.chat-export-followup__icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 6px;
+  background: var(--app-surface-bg);
+  color: var(--app-text-muted);
+  font-size: 13px;
+}
+
+.chat-export-followup--repairable .chat-export-followup__icon {
+  background: var(--export-warning-soft);
+  color: var(--export-warning-text);
+}
+
+.chat-export-followup__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-export-followup__copy strong {
+  color: var(--app-text-primary);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
+.chat-export-followup__copy span {
+  color: var(--app-text-muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.chat-export-followup__action {
+  display: inline-flex;
+  min-height: 34px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 5px;
+  background: var(--app-surface-bg);
+  color: var(--app-text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease, opacity 160ms ease;
+}
+
+.chat-export-followup__action:hover:not(:disabled) {
+  background: var(--app-neutral-btn-hover);
+  color: var(--app-text-primary);
+}
+
+.chat-export-followup__action--primary {
+  border-color: var(--export-accent-border);
+  background: var(--export-accent-soft);
+  color: var(--export-accent-text);
+}
+
+.chat-export-followup__action--primary:hover:not(:disabled) {
+  border-color: var(--app-accent);
+  background: var(--app-accent);
+  color: #fff;
+}
+
+.chat-export-followup__action:active {
+  transform: translateY(1px);
+}
+
+.chat-export-followup__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.chat-export-folder-result__details {
+  border-top: 1px solid var(--app-border);
+  color: var(--app-text-muted);
+  font-size: 11px;
+}
+
+.chat-export-folder-result__details summary {
+  display: flex;
+  min-height: 34px;
+  align-items: center;
+  width: fit-content;
+  padding: 7px 14px;
+  color: var(--app-text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.chat-export-folder-result__details summary:hover {
+  color: var(--app-text-primary);
+}
+
+.chat-export-folder-result__details p {
+  margin: -2px 14px 10px;
+  color: var(--app-text-muted);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
 .chat-export-footer {
   display: flex;
   min-height: 66px;
@@ -1885,6 +2435,16 @@ html[data-theme='dark'] .chat-export-modal :is(input, select) {
 
   .chat-export-result .chat-export-primary-button {
     grid-column: 2;
+    justify-self: start;
+  }
+
+  .chat-export-followup {
+    grid-template-columns: 28px minmax(0, 1fr);
+  }
+
+  .chat-export-followup__action {
+    grid-column: 2;
+    width: fit-content;
     justify-self: start;
   }
 }

--- a/frontend/composables/chat/useChatExport.js
+++ b/frontend/composables/chat/useChatExport.js
@@ -9,6 +9,9 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
 
   const exportScope = ref('selected')
   const exportFormat = ref('html')
+  const exportOutputMode = ref('zip')
+  const exportResetBaseline = ref(false)
+  const exportBaselineStatus = ref('unknown')
   const exportDownloadRemoteMedia = ref(true)
   const exportHtmlPageSize = ref(1000)
   const exportTranscribeVoice = ref(false)
@@ -50,6 +53,21 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
   const exportSaveBytesTotal = ref(0)
   const exportAutoSavedFor = ref('')
   const exportCancelRequested = ref(false)
+  const privacyAccountToken = (value) => {
+    let hash = 0x811c9dc5
+    const text = String(value || '')
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index)
+      hash = Math.imul(hash, 0x01000193) >>> 0
+    }
+    return hash.toString(16).padStart(8, '0')
+  }
+  const exportFolderNamePreview = computed(() => {
+    const account = String(selectedAccount.value || '账号').trim() || '账号'
+    if (privacyMode.value) return `微信聊天记录_隐私_${privacyAccountToken(account)}`
+    return `微信聊天记录_${account}`.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').slice(0, 96)
+  })
+  const isIncrementalFolderMode = computed(() => exportOutputMode.value === 'folder')
 
   const exportSearchQuery = ref('')
   const exportListTab = ref('all')
@@ -116,6 +134,12 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
   })
   const exportSaveProgressText = computed(() => {
     if (exportSaveState.value !== 'saving') return ''
+    if (String(exportJob.value?.options?.outputMode || '') === 'folder') {
+      const progress = exportSaveBytesTotal.value > 0
+        ? `（${formatBytes(exportSaveBytesWritten.value)} / ${formatBytes(exportSaveBytesTotal.value)}）`
+        : ''
+      return `正在增量更新目录：${exportFolderNamePreview.value}${progress}`
+    }
     const fileName = guessExportZipName(exportJob.value)
     if (exportSaveBytesTotal.value > 0) {
       return `正在保存到浏览器目录：${fileName}（${formatBytes(exportSaveBytesWritten.value)} / ${formatBytes(exportSaveBytesTotal.value)}）`
@@ -377,6 +401,7 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
         if (result && !result.canceled && Array.isArray(result.filePaths) && result.filePaths.length > 0) {
           exportFolder.value = String(result.filePaths[0] || '').trim()
           exportFolderHandle.value = null
+          exportBaselineStatus.value = 'auto'
         }
         return
       }
@@ -386,6 +411,8 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
         if (handle) {
           exportFolderHandle.value = handle
           exportFolder.value = `浏览器目录：${String(handle.name || '已选择')}`
+          const baseline = await readBrowserChatExportBaseline()
+          exportBaselineStatus.value = baseline?.invalid ? 'invalid' : (baseline ? 'ready' : 'new')
         }
         return
       }
@@ -398,6 +425,177 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
       }
       exportError.value = error?.message || '选择导出目录失败'
     }
+  }
+
+  const CHAT_EXPORT_BASELINE_FILE = '.wechat-chat-export.json'
+
+  const normalizeManagedPath = (value) => {
+    const parts = String(value || '').replace(/\\/g, '/').split('/').filter((part) => part && part !== '.')
+    if (!parts.length || parts.some((part) => part === '..')) return ''
+    return parts.join('/')
+  }
+
+  const readBaselineFromRoot = async (root) => {
+    if (!root || typeof root.getFileHandle !== 'function') return { found: false, baseline: null }
+    try {
+      const handle = await root.getFileHandle(CHAT_EXPORT_BASELINE_FILE)
+      const file = await handle.getFile()
+      return { found: true, baseline: JSON.parse(await file.text()) }
+    } catch (error) {
+      if (error?.name === 'NotFoundError') return { found: false, baseline: null }
+      return { found: true, baseline: { invalid: true } }
+    }
+  }
+
+  const browserBaselineMatchesSelection = (baseline) => {
+    if (!baseline || typeof baseline !== 'object' || baseline.invalid) return false
+    const accountMatches = String(baseline.account || '') === String(selectedAccount.value || '')
+      || (!String(baseline.account || '') && Boolean(baseline.accountFingerprint))
+    return accountMatches
+      && String(baseline.folderName || '') === String(exportFolderNamePreview.value || '')
+  }
+
+  const getBrowserChatExportRoot = async ({ create = true } = {}) => {
+    const selected = exportFolderHandle.value
+    if (!selected || typeof selected.getDirectoryHandle !== 'function') return null
+    const direct = await readBaselineFromRoot(selected)
+    if (
+      String(selected.name || '') === String(exportFolderNamePreview.value || '')
+      || (direct.found && browserBaselineMatchesSelection(direct.baseline))
+    ) {
+      return selected
+    }
+    try {
+      return await selected.getDirectoryHandle(exportFolderNamePreview.value, { create: false })
+    } catch (error) {
+      if (error?.name !== 'NotFoundError' || !create) throw error
+      return await selected.getDirectoryHandle(exportFolderNamePreview.value, { create: true })
+    }
+  }
+
+  const readBrowserChatExportBaseline = async () => {
+    try {
+      const root = await getBrowserChatExportRoot({ create: false })
+      if (!root) return null
+      return (await readBaselineFromRoot(root)).baseline
+    } catch (error) {
+      if (error?.name === 'NotFoundError') return null
+      return { invalid: true }
+    }
+  }
+
+  const browserDirectoryHasEntries = async (root) => {
+    if (!root || typeof root.values !== 'function') return false
+    for await (const _entry of root.values()) return true
+    return false
+  }
+
+  const resolveBrowserDirectory = async (root, parts, { create = true } = {}) => {
+    let current = root
+    for (const part of parts) current = await current.getDirectoryHandle(part, { create })
+    return current
+  }
+
+  const findMissingBrowserManagedFiles = async (root, baseline) => {
+    const files = baseline?.files && typeof baseline.files === 'object' ? baseline.files : {}
+    const missing = []
+    for (const [rawPath, metadata] of Object.entries(files)) {
+      const path = normalizeManagedPath(rawPath)
+      if (!path) continue
+      const parts = path.split('/')
+      try {
+        const parent = await resolveBrowserDirectory(root, parts.slice(0, -1), { create: false })
+        const handle = await parent.getFileHandle(parts.at(-1), { create: false })
+        const file = await handle.getFile()
+        const expectedSize = Number(metadata?.size)
+        if (Number.isFinite(expectedSize) && expectedSize >= 0 && Number(file.size) !== expectedSize) missing.push(path)
+      } catch (error) {
+        if (error?.name === 'NotFoundError' || error?.name === 'TypeMismatchError') {
+          missing.push(path)
+          continue
+        }
+        throw error
+      }
+    }
+    return [...new Set(missing)].sort()
+  }
+
+  const writeResponseToBrowserFile = async (root, relativePath, response) => {
+    const path = normalizeManagedPath(relativePath)
+    if (!path) throw new Error('增量文件路径无效')
+    const parts = path.split('/')
+    const parent = await resolveBrowserDirectory(root, parts.slice(0, -1), { create: true })
+    const fileHandle = await parent.getFileHandle(parts.at(-1), { create: true })
+    const writable = await fileHandle.createWritable()
+    try {
+      if (response.body && typeof response.body.getReader === 'function') {
+        const reader = response.body.getReader()
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          if (!value?.byteLength) continue
+          await writable.write(value)
+          exportSaveBytesWritten.value += value.byteLength
+        }
+      } else {
+        const blob = await response.blob()
+        await writable.write(blob)
+        exportSaveBytesWritten.value += asNumber(blob.size)
+      }
+      await writable.close()
+    } catch (error) {
+      try { await writable.abort() } catch {}
+      throw error
+    }
+  }
+
+  const removeBrowserManagedFile = async (root, relativePath) => {
+    const path = normalizeManagedPath(relativePath)
+    if (!path) return
+    const parts = path.split('/')
+    try {
+      const parent = await resolveBrowserDirectory(root, parts.slice(0, -1), { create: false })
+      await parent.removeEntry(parts.at(-1))
+    } catch (error) {
+      if (error?.name !== 'NotFoundError') throw error
+    }
+  }
+
+  const getIncrementalFileUrl = (exportId, fileId) => {
+    return `${apiBase}/chat/exports/${encodeURIComponent(String(exportId || ''))}/files/${encodeURIComponent(String(fileId || ''))}`
+  }
+
+  const saveIncrementalChatExportToBrowser = async (exportId) => {
+    const manifestUrl = `${apiBase}/chat/exports/${encodeURIComponent(String(exportId))}/files`
+    const manifestResponse = await fetch(manifestUrl)
+    if (!manifestResponse.ok) throw new Error(`读取增量文件清单失败（${manifestResponse.status}）`)
+    const payload = await manifestResponse.json()
+    const manifest = payload?.manifest || {}
+    const root = await getBrowserChatExportRoot({ create: true })
+    if (!root) throw new Error('未选择浏览器导出目录')
+    const files = Array.isArray(manifest.files) ? manifest.files : []
+    const stateUnchanged = Boolean(manifest?.state?.unchanged)
+    exportSaveBytesTotal.value = files.reduce(
+      (sum, item) => sum + asNumber(item?.size),
+      stateUnchanged ? 0 : asNumber(manifest?.state?.size)
+    )
+    for (const entry of files) {
+      const response = await fetch(getIncrementalFileUrl(exportId, entry?.fileId))
+      if (!response.ok) throw new Error(`下载增量文件失败（${response.status}）`)
+      await writeResponseToBrowserFile(root, entry?.path, response)
+    }
+    for (const stalePath of Array.isArray(manifest.stale) ? manifest.stale : []) {
+      await removeBrowserManagedFile(root, stalePath)
+    }
+    if (!stateUnchanged) {
+      // 基线必须最后写入，保证中断后仍能依据上一轮状态安全重试。
+      const stateResponse = await fetch(getIncrementalFileUrl(exportId, manifest?.state?.fileId))
+      if (!stateResponse.ok) throw new Error(`下载增量基线失败（${stateResponse.status}）`)
+      await writeResponseToBrowserFile(root, CHAT_EXPORT_BASELINE_FILE, stateResponse)
+    }
+    const commit = await fetch(`${apiBase}/chat/exports/${encodeURIComponent(String(exportId))}/commit`, { method: 'POST' })
+    if (!commit.ok) throw new Error(`提交增量导出状态失败（${commit.status}）`)
+    return manifest
   }
 
   const guessExportZipName = (job) => {
@@ -437,6 +635,15 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
     exportSaveBusy.value = true
     exportSaveState.value = 'saving'
     try {
+      if (String(exportJob.value?.options?.outputMode || '') === 'folder') {
+        const manifest = await saveIncrementalChatExportToBrowser(exportId)
+        const stats = manifest?.stats || {}
+        exportAutoSavedFor.value = String(exportId)
+        exportSaveState.value = 'success'
+        exportBaselineStatus.value = 'ready'
+        exportSaveMsg.value = `增量目录已更新：${manifest?.folderName || exportFolderNamePreview.value}\n新写 ${stats.filesChanged || 0} 个文件，复用 ${stats.filesReused || 0} 个文件。`
+        return
+      }
       const response = await fetch(getExportDownloadUrl(exportId))
       if (!response.ok) {
         await reportServerErrorFromResponse(response, {
@@ -569,6 +776,9 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
     exportMessageTypes.value = exportMessageTypeValues.slice()
     exportAutoSavedFor.value = ''
     exportFormat.value = 'html'
+    exportOutputMode.value = 'zip'
+    exportResetBaseline.value = false
+    exportBaselineStatus.value = exportFolder.value ? 'auto' : 'unknown'
     exportDownloadRemoteMedia.value = true
     exportHtmlPageSize.value = 1000
     exportTranscribeVoice.value = false
@@ -587,6 +797,8 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
   const clearExportFolderSelection = () => {
     exportFolder.value = ''
     exportFolderHandle.value = null
+    exportBaselineStatus.value = 'unknown'
+    exportResetBaseline.value = false
     resetExportSaveFeedback({ resetAutoSavedFor: true })
   }
 
@@ -627,7 +839,7 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
     }
   )
 
-  const startChatExport = async () => {
+  const startChatExport = async (options = {}) => {
     exportError.value = ''
     resetExportSaveFeedback({ resetAutoSavedFor: true })
     exportCancelRequested.value = false
@@ -636,9 +848,20 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
       return
     }
 
-    let scope = exportScope.value
+    const requestedRepairUsernames = Array.isArray(options?.repairUsernames)
+      ? options.repairUsernames.map((item) => String(item || '').trim()).filter(Boolean)
+      : []
+    const requestedMediaRecheckUsernames = Array.isArray(options?.recheckUsernames)
+      ? options.recheckUsernames.map((item) => String(item || '').trim()).filter(Boolean)
+      : []
+    const requestedActionUsernames = requestedRepairUsernames.length
+      ? requestedRepairUsernames
+      : requestedMediaRecheckUsernames
+    let scope = requestedActionUsernames.length ? 'selected' : exportScope.value
     let usernames = []
-    if (scope === 'current') {
+    if (requestedActionUsernames.length) {
+      usernames = [...new Set(requestedActionUsernames)]
+    } else if (scope === 'current') {
       scope = 'selected'
       if (selectedContact.value?.username) {
         usernames = [selectedContact.value.username]
@@ -705,6 +928,21 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
     isExportCreating.value = true
     exportAutoSavedFor.value = ''
     try {
+      let baseline = null
+      let missingFiles = []
+      if (isIncrementalFolderMode.value && !isDesktopExportRuntime()) {
+        baseline = await readBrowserChatExportBaseline()
+        const root = await getBrowserChatExportRoot({ create: false }).catch(() => null)
+        if (!baseline && root && await browserDirectoryHasEntries(root)) {
+          throw new Error('目标增量目录非空但缺少基线，请选择新目录；为保护用户文件，不能在原目录直接重建。')
+        }
+        if (baseline && !baseline.invalid && root) {
+          missingFiles = await findMissingBrowserManagedFiles(root, baseline)
+        }
+        exportBaselineStatus.value = baseline?.invalid
+          ? 'invalid'
+          : (baseline ? (missingFiles.length ? 'repair' : 'ready') : 'new')
+      }
       if (transcribeVoice) {
         const status = await api.getVoiceTranscriptionStatus()
         if (!status?.available) {
@@ -728,8 +966,15 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
         html_page_size: Math.max(0, Math.floor(Number(exportHtmlPageSize.value || 1000))),
         output_dir: isDesktopExportRuntime() ? String(exportFolder.value || '').trim() : null,
         privacy_mode: !!privacyMode.value,
-        file_name: exportFileName.value || null,
-        transcribe_voice: transcribeVoice
+        file_name: isIncrementalFolderMode.value ? null : (exportFileName.value || null),
+        transcribe_voice: transcribeVoice,
+        output_mode: exportOutputMode.value,
+        folder_name: isIncrementalFolderMode.value ? exportFolderNamePreview.value : null,
+        baseline: isIncrementalFolderMode.value ? baseline : null,
+        missing_files: isIncrementalFolderMode.value ? missingFiles : [],
+        reset_baseline: isIncrementalFolderMode.value && !!exportResetBaseline.value,
+        repair_usernames: requestedRepairUsernames,
+        recheck_media: !!options?.recheckMedia
       })
 
       exportJob.value = response?.job || null
@@ -759,12 +1004,38 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
     }
   }
 
+  const repairIncrementalConversations = async () => {
+    const usernames = (Array.isArray(exportJob.value?.repairCandidates) ? exportJob.value.repairCandidates : [])
+      .map((item) => String(item?.username || '').trim())
+      .filter(Boolean)
+    if (!usernames.length) return
+    await startChatExport({ repairUsernames: usernames })
+  }
+
+  const recheckIncrementalMedia = async () => {
+    const usernames = (Array.isArray(exportJob.value?.unresolvedMedia?.conversations)
+      ? exportJob.value.unresolvedMedia.conversations
+      : [])
+      .map((item) => String(item?.username || '').trim())
+      .filter(Boolean)
+    if (!usernames.length) return
+    await startChatExport({
+      recheckMedia: true,
+      recheckUsernames: [...new Set(usernames)]
+    })
+  }
+
   return {
     exportModalOpen,
     isExportCreating,
     exportError,
     exportScope,
     exportFormat,
+    exportOutputMode,
+    exportResetBaseline,
+    exportBaselineStatus,
+    exportFolderNamePreview,
+    isIncrementalFolderMode,
     exportDownloadRemoteMedia,
     exportHtmlPageSize,
     exportTranscribeVoice,
@@ -812,6 +1083,8 @@ export const useChatExport = ({ api, apiBase, contacts, selectedAccount, selecte
     openExportModal,
     closeExportModal,
     startChatExport,
+    repairIncrementalConversations,
+    recheckIncrementalMedia,
     cancelCurrentExport,
     stopExportPolling
   }

--- a/frontend/composables/useApi.js
+++ b/frontend/composables/useApi.js
@@ -650,7 +650,7 @@ export const useApi = () => {
     })
   }
 
-  // 聊天记录导出（离线zip）
+  // 聊天记录导出（ZIP 全量或增量目录）
   const createChatExport = async (data = {}) => {
     return await request('/chat/exports', {
       method: 'POST',
@@ -673,7 +673,14 @@ export const useApi = () => {
         html_page_size: data.html_page_size != null ? Number(data.html_page_size) : 1000,
         privacy_mode: !!data.privacy_mode,
         file_name: data.file_name || null,
-        transcribe_voice: !!data.transcribe_voice
+        transcribe_voice: !!data.transcribe_voice,
+        output_mode: data.output_mode === 'folder' ? 'folder' : 'zip',
+        folder_name: data.folder_name || null,
+        baseline: data.baseline && typeof data.baseline === 'object' ? data.baseline : null,
+        missing_files: Array.isArray(data.missing_files) ? data.missing_files : [],
+        reset_baseline: !!data.reset_baseline,
+        repair_usernames: Array.isArray(data.repair_usernames) ? data.repair_usernames : [],
+        recheck_media: !!data.recheck_media
       }
     })
   }

--- a/src/wechat_decrypt_tool/chat_export_service.py
+++ b/src/wechat_decrypt_tool/chat_export_service.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import heapq
 import html
+import io
 import ipaddress
 import json
 import os
@@ -60,6 +61,17 @@ from .chat_helpers import (
 )
 from .chat_realtime_autosync import CHAT_REALTIME_AUTOSYNC
 from .chat_realtime_reader import count_realtime_message_rows_via_exec, iter_realtime_message_rows
+from .chat_incremental_export import (
+    ChatFolderContext,
+    ChatIncrementalError,
+    allocate_conversation_directory,
+    build_config as build_incremental_config,
+    conversation_key as incremental_conversation_key,
+    materialize_folder_archive,
+    missing_conversation_keys,
+    normalize_pending_media,
+    prepare_folder_context,
+)
 from .logging_config import get_logger
 from .media_helpers import (
     MediaPathIndex,
@@ -113,6 +125,7 @@ ExportFormat = Literal["json", "txt", "html", "excel"]
 ExportScope = Literal["selected", "all", "groups", "singles"]
 ChatSource = Literal["auto", "decrypted", "realtime"]
 ExportStatus = Literal["queued", "running", "done", "error", "cancelled"]
+ExportOutputMode = Literal["zip", "folder"]
 MediaKind = Literal["image", "emoji", "video", "video_thumb", "voice", "file"]
 
 _EXPORT_PROGRESS_LOG_INTERVAL = 1000
@@ -951,6 +964,188 @@ def _html_export_runtime_js(native_integrity: Any) -> str:
     return _native_text(native_integrity, "runtime_js")
 
 
+def _html_export_folder_runtime_js(native_integrity: Any) -> str:
+    """保留 HTML 交互能力，但关闭只适用于不可变 ZIP 的阻断式校验。"""
+
+    wrapped = _html_export_runtime_js(native_integrity)
+    match = re.search(
+        r"const _0=(\[.*?\]),_1=(\[[0-9,\s]+\]);let _2=atob",
+        wrapped,
+        flags=re.DOTALL,
+    )
+    if match is None:
+        raise RuntimeError(_HTML_EXPORT_NATIVE_ERROR)
+    try:
+        chunks = json.loads(match.group(1))
+        key = bytes(int(value) & 0xFF for value in json.loads(match.group(2)))
+        encrypted = base64.b64decode("".join(str(value) for value in chunks), validate=True)
+        source = bytes(value ^ key[index % len(key)] for index, value in enumerate(encrypted)).decode("utf-8")
+    except Exception as exc:
+        raise RuntimeError(_HTML_EXPORT_NATIVE_ERROR) from exc
+
+    startup = "const integrityOk = await initExportIntegrity()"
+    if source.count(startup) != 1:
+        raise RuntimeError(_HTML_EXPORT_NATIVE_ERROR)
+    folder_startup = """const integrityOk = true
+    try {
+      document.documentElement.setAttribute('data-wce-folder-mode', '1')
+      document.documentElement.setAttribute('data-wce-integrity-ok', '1')
+      window.__WCE_VERIFY_FRAGMENT__ = () => true
+    } catch {}"""
+    source = source.replace(startup, folder_startup, 1)
+
+    # 增量目录中的每个会话页可能生成于不同批次。运行时统一读取公共会话清单，
+    # 避免点击会话后左侧目录退回到该页面生成时的旧快照。
+    listener_marker = "  document.addEventListener('DOMContentLoaded', async () => {"
+    search_marker = "    initSessionSearch()"
+    if source.count(listener_marker) != 1 or source.count(search_marker) != 1:
+        raise RuntimeError(_HTML_EXPORT_NATIVE_ERROR)
+    folder_sessions_runtime = r"""  const wceFolderRuntimeSrc = (() => {
+    try {
+      const currentSrc = String((document.currentScript && document.currentScript.src) || '')
+      if (currentSrc) return currentSrc
+      const scripts = Array.from(document.querySelectorAll('script[src]'))
+      const runtimeScript = scripts.find((element) => {
+        const src = String((element && element.src) || '')
+        return /(^|\/)chat-export\.js(?:[?#].*)?$/.test(src)
+      })
+      return String((runtimeScript && runtimeScript.src) || '')
+    } catch {
+      return ''
+    }
+  })()
+
+  async function loadFolderSessionCatalog() {
+    const ready = window.__WCE_FOLDER_SESSIONS__
+    if (ready && Array.isArray(ready.items)) return true
+    if (!wceFolderRuntimeSrc) return false
+
+    return await new Promise((resolve) => {
+      let settled = false
+      const finish = (value) => {
+        if (settled) return
+        settled = true
+        resolve(Boolean(value))
+      }
+      let script = document.querySelector('script[data-wce-folder-sessions="1"]')
+      if (!script) {
+        script = document.createElement('script')
+        script.defer = true
+        script.setAttribute('data-wce-folder-sessions', '1')
+        try {
+          script.src = new URL('chat-sessions.js', wceFolderRuntimeSrc).href
+        } catch {
+          finish(false)
+          return
+        }
+        document.head.appendChild(script)
+      }
+      if (window.__WCE_FOLDER_SESSIONS__ && Array.isArray(window.__WCE_FOLDER_SESSIONS__.items)) {
+        finish(true)
+        return
+      }
+      script.addEventListener('load', () => finish(
+        window.__WCE_FOLDER_SESSIONS__ && Array.isArray(window.__WCE_FOLDER_SESSIONS__.items)
+      ), { once: true })
+      script.addEventListener('error', () => finish(false), { once: true })
+      window.setTimeout(() => finish(false), 3000)
+    })
+  }
+
+  function syncFolderSessionCatalog() {
+    const catalog = window.__WCE_FOLDER_SESSIONS__
+    const container = document.querySelector('[data-wce-session-list="1"]')
+    if (!catalog || !Array.isArray(catalog.items) || !container || !wceFolderRuntimeSrc) return
+
+    let exportRoot
+    try {
+      exportRoot = new URL('../', wceFolderRuntimeSrc)
+    } catch {
+      return
+    }
+    const currentPath = (() => {
+      try { return decodeURIComponent(window.location.pathname || '').replace(/\\/g, '/') }
+      catch { return String(window.location.pathname || '').replace(/\\/g, '/') }
+    })()
+    const fragment = document.createDocumentFragment()
+
+    for (const rawItem of catalog.items) {
+      const convDir = String((rawItem && rawItem.convDir) || '').trim().replace(/\\/g, '/').replace(/^\/+|\/+$/g, '')
+      if (!convDir) continue
+      const displayName = String((rawItem && rawItem.displayName) || '').trim() || '会话'
+      const username = String((rawItem && rawItem.username) || '').trim()
+      const avatarPath = String((rawItem && rawItem.avatarPath) || '').trim().replace(/\\/g, '/').replace(/^\/+/, '')
+      const lastTimeText = String((rawItem && rawItem.lastTimeText) || '').trim()
+      const previewText = String((rawItem && rawItem.previewText) || '').trim()
+      const messageSuffix = `/${convDir}/messages.html`
+      const active = currentPath.endsWith(messageSuffix)
+
+      const link = document.createElement('a')
+      link.href = new URL(`${convDir}/messages.html`, exportRoot).href
+      link.className = 'px-3 cursor-pointer transition-colors duration-150 border-b border-gray-100 h-[calc(80px/var(--dpr))] flex items-center '
+        + (active ? 'bg-[#DEDEDE]' : 'hover:bg-[#F5F5F5]')
+      link.setAttribute('data-wce-session-item', '1')
+      link.setAttribute('data-wce-session-name', displayName)
+      link.setAttribute('data-wce-session-username', username)
+      if (active) link.setAttribute('aria-current', 'page')
+
+      const avatarWrap = document.createElement('div')
+      avatarWrap.className = 'relative'
+      const avatarBox = document.createElement('div')
+      avatarBox.className = 'w-[calc(45px/var(--dpr))] h-[calc(45px/var(--dpr))] rounded-md overflow-hidden bg-gray-300'
+      if (avatarPath) {
+        const image = document.createElement('img')
+        image.src = new URL(avatarPath, exportRoot).href
+        image.alt = displayName
+        image.className = 'w-full h-full object-cover'
+        image.referrerPolicy = 'no-referrer'
+        avatarBox.appendChild(image)
+      } else {
+        const fallback = document.createElement('div')
+        fallback.className = 'w-full h-full flex items-center justify-center text-white text-xs font-bold'
+        fallback.style.backgroundColor = '#4B5563'
+        fallback.textContent = (displayName.slice(0, 1).trim() || '?')
+        avatarBox.appendChild(fallback)
+      }
+      avatarWrap.appendChild(avatarBox)
+      link.appendChild(avatarWrap)
+
+      const content = document.createElement('div')
+      content.className = 'flex-1 min-w-0 ml-3'
+      const heading = document.createElement('div')
+      heading.className = 'flex items-center justify-between'
+      const title = document.createElement('h3')
+      title.className = 'text-sm font-medium text-gray-900 truncate'
+      title.textContent = displayName
+      heading.appendChild(title)
+      const timeWrap = document.createElement('div')
+      timeWrap.className = 'flex items-center flex-shrink-0 ml-2'
+      const time = document.createElement('span')
+      time.className = 'text-xs text-gray-500'
+      time.textContent = lastTimeText
+      timeWrap.appendChild(time)
+      heading.appendChild(timeWrap)
+      content.appendChild(heading)
+      const preview = document.createElement('p')
+      preview.className = 'text-xs text-gray-500 truncate mt-0.5 leading-tight'
+      preview.textContent = previewText
+      content.appendChild(preview)
+      link.appendChild(content)
+      fragment.appendChild(link)
+    }
+
+    container.replaceChildren(fragment)
+    container.setAttribute('data-wce-session-catalog', '1')
+  }"""
+    source = source.replace(listener_marker, folder_sessions_runtime + "\n\n" + listener_marker, 1)
+    source = source.replace(
+        search_marker,
+        "    await loadFolderSessionCatalog()\n    syncFolderSessionCatalog()\n\n" + search_marker,
+        1,
+    )
+    return source
+
+
 def _html_export_asset_paths(export_id: str) -> tuple[str, str, str]:
     values = _native_json_list(
         _load_wce_integrity_native(),
@@ -1021,6 +1216,49 @@ def _zip_arcname(value: Any) -> str:
     while "//" in s:
         s = s.replace("//", "/")
     return s
+
+
+def _html_export_folder_sessions_js(session_items: list[dict[str, Any]]) -> str:
+    """生成增量 HTML 共用的会话目录；字段只取已经过隐私处理的会话摘要。"""
+
+    items: list[dict[str, Any]] = []
+    seen_directories: set[str] = set()
+    for value in session_items:
+        if not isinstance(value, dict):
+            continue
+        conv_dir = _zip_arcname(value.get("convDir")).rstrip("/")
+        conv_parts = [part for part in conv_dir.split("/") if part]
+        if (
+            len(conv_parts) < 2
+            or conv_parts[0] != "conversations"
+            or any(part in {".", ".."} for part in conv_parts)
+            or conv_dir in seen_directories
+        ):
+            continue
+        seen_directories.add(conv_dir)
+
+        avatar_path = _zip_arcname(value.get("avatarPath"))
+        if any(part in {".", ".."} for part in avatar_path.split("/") if part):
+            avatar_path = ""
+        items.append(
+            {
+                "username": str(value.get("username") or "").strip(),
+                "displayName": str(value.get("displayName") or "").strip() or "会话",
+                "isGroup": bool(value.get("isGroup")),
+                "convDir": conv_dir,
+                "avatarPath": avatar_path,
+                "lastTimeText": str(value.get("lastTimeText") or "").strip(),
+                "previewText": str(value.get("previewText") or "").strip(),
+            }
+        )
+
+    payload = json.dumps(
+        {"version": 1, "items": items},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+    return f"window.__WCE_FOLDER_SESSIONS__={payload};\n"
 
 
 class _ZipIntegrityWriter:
@@ -1236,6 +1474,7 @@ class ExportProgress:
     messages_exported: int = 0
     media_copied: int = 0
     media_missing: int = 0
+    media_missing_references: int = 0
 
 
 @dataclass
@@ -1247,7 +1486,16 @@ class ExportJob:
     started_at: Optional[float] = None
     finished_at: Optional[float] = None
     error: str = ""
+    warning: str = ""
+    incremental: dict[str, int] = field(default_factory=dict)
     zip_path: Optional[Path] = None
+    folder_path: Optional[Path] = None
+    staging_dir: Optional[Path] = field(default=None, repr=False)
+    staged_files: dict[str, Path] = field(default_factory=dict, repr=False)
+    change_manifest: dict[str, Any] = field(default_factory=dict)
+    repair_candidates: list[dict[str, Any]] = field(default_factory=list)
+    unresolved_media: dict[str, Any] = field(default_factory=dict)
+    missing_media_keys: set[tuple[str, str]] = field(default_factory=set, repr=False)
     options: dict[str, Any] = field(default_factory=dict)
     progress: ExportProgress = field(default_factory=ExportProgress)
     cancel_requested: bool = False
@@ -1255,6 +1503,11 @@ class ExportJob:
     voice_cache_generation: Optional[int] = field(default=None, repr=False)
 
     def to_public_dict(self) -> dict[str, Any]:
+        public_options = {
+            key: value
+            for key, value in self.options.items()
+            if key not in {"baseline", "missingFiles", "_folderContext", "_folderResourceOwners"}
+        }
         return {
             "exportId": self.export_id,
             "account": self.account,
@@ -1263,9 +1516,16 @@ class ExportJob:
             "startedAt": int(self.started_at) if self.started_at else None,
             "finishedAt": int(self.finished_at) if self.finished_at else None,
             "error": self.error or "",
+            "warning": self.warning or "",
             "zipPath": str(self.zip_path) if self.zip_path else "",
             "zipReady": bool(self.zip_path and self.zip_path.exists()),
-            "options": self.options,
+            "folderPath": str(self.folder_path) if self.folder_path else "",
+            "folderName": str(self.change_manifest.get("folderName") or ""),
+            "filesReady": bool(self.staged_files),
+            "incremental": self.incremental,
+            "repairCandidates": self.repair_candidates,
+            "unresolvedMedia": self.unresolved_media,
+            "options": public_options,
             "progress": {
                 "conversationsTotal": self.progress.conversations_total,
                 "conversationsDone": self.progress.conversations_done,
@@ -1277,6 +1537,7 @@ class ExportJob:
                 "messagesExported": self.progress.messages_exported,
                 "mediaCopied": self.progress.media_copied,
                 "mediaMissing": self.progress.media_missing,
+                "mediaMissingReferences": self.progress.media_missing_references,
             },
         }
 
@@ -1320,6 +1581,7 @@ class ChatExportManager:
                             "messagesExported": job.progress.messages_exported,
                             "mediaCopied": job.progress.media_copied,
                             "mediaMissing": job.progress.media_missing,
+                            "mediaMissingReferences": job.progress.media_missing_references,
                         },
                     }
                 ),
@@ -1329,6 +1591,31 @@ class ChatExportManager:
                 job.finished_at = time.time()
                 logger.info("chat export queued job cancelled export_id=%s", job.export_id)
             return True
+
+    def get_staged_file(self, export_id: str, file_id: str) -> Optional[Path]:
+        with self._lock:
+            job = self._jobs.get(str(export_id or "").strip())
+            if not job or job.status != "done":
+                return None
+            path = job.staged_files.get(str(file_id or "").strip())
+        if path is None or not path.is_file():
+            return None
+        return path
+
+    def commit_staged_files(self, export_id: str) -> bool:
+        with self._lock:
+            job = self._jobs.get(str(export_id or "").strip())
+            if not job:
+                return False
+            staging_dir = job.staging_dir
+            job.staged_files = {}
+            job.staging_dir = None
+        if staging_dir and staging_dir.exists():
+            # 只清理当前聊天导出任务创建的临时目录。
+            import shutil
+
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        return True
 
     def create_job(
         self,
@@ -1354,9 +1641,19 @@ class ChatExportManager:
         encrypt: bool = False,
         content_key: bytearray | None = None,
         transcribe_voice: bool = False,
+        output_mode: ExportOutputMode = "zip",
+        folder_name: Optional[str] = None,
+        baseline: Optional[dict[str, Any]] = None,
+        missing_files: Optional[list[str]] = None,
+        reset_baseline: bool = False,
+        repair_usernames: Optional[list[str]] = None,
+        recheck_media: bool = False,
     ) -> ExportJob:
         if bool(encrypt) != (content_key is not None):
             raise ValueError("encrypted chat export requires one validated content key")
+        output_mode_norm: ExportOutputMode = "folder" if str(output_mode or "zip") == "folder" else "zip"
+        if output_mode_norm == "folder" and bool(encrypt):
+            raise ValueError("增量目录不支持整包加密，请使用 ZIP 全量导出。")
         account_dir = _resolve_account_dir(account)
         source_requested = _normalize_chat_source(source, default="auto")
         source_norm = source_requested
@@ -1385,6 +1682,72 @@ class ChatExportManager:
             retry_after_seconds=retry_after_seconds,
         )
         export_id = uuid.uuid4().hex[:12]
+
+        if output_mode_norm == "folder":
+            normalized_message_types = [
+                str(value or "").strip()
+                for value in (message_types or [])
+                if str(value or "").strip()
+            ]
+            normalized_want = {
+                key
+                for value in normalized_message_types
+                if (key := _normalize_render_type_key(value))
+            }
+            effective_include_media, effective_media_kinds = _resolve_effective_media_kinds(
+                include_media=bool(include_media),
+                media_kinds=list(media_kinds),
+                selected_render_types=normalized_want or None,
+                privacy_mode=bool(privacy_mode),
+            )
+            try:
+                preview_html_page_size = int(html_page_size or 1000)
+            except Exception:
+                preview_html_page_size = 1000
+            if preview_html_page_size < 0:
+                preview_html_page_size = 0
+            preview_config = build_incremental_config(
+                export_format=str(export_format),
+                start_time=int(start_time) if start_time else None,
+                end_time=int(end_time) if end_time else None,
+                message_types=sorted(normalized_want),
+                include_media=effective_include_media,
+                media_kinds=list(effective_media_kinds),
+                download_remote_media=bool(download_remote_media),
+                html_page_size=preview_html_page_size,
+                privacy_mode=bool(privacy_mode),
+                transcribe_voice=bool(transcribe_voice) and not bool(privacy_mode),
+            )
+            preview_folder_context = prepare_folder_context(
+                account=account_dir.name,
+                exports_root=_resolve_export_output_dir(account_dir, output_dir),
+                requested_folder_name=str(folder_name or ""),
+                config=preview_config,
+                privacy_mode=bool(privacy_mode),
+                desktop_output=bool(str(output_dir or "").strip()),
+                supplied_baseline=baseline if isinstance(baseline, dict) else {},
+                missing_files=list(missing_files or []),
+                reset_baseline=bool(reset_baseline),
+            )
+            if bool(reset_baseline) and str(scope or "") == "selected":
+                old_conversations = (
+                    preview_folder_context.old_state.get("conversations")
+                    if isinstance(preview_folder_context.old_state.get("conversations"), dict)
+                    else {}
+                )
+                selected_keys = {
+                    incremental_conversation_key(
+                        salt=preview_folder_context.salt,
+                        username=str(username or "").strip(),
+                    )
+                    for username in (usernames or [])
+                    if str(username or "").strip()
+                }
+                if set(old_conversations) - selected_keys:
+                    raise ChatIncrementalError(
+                        "incremental_reset_incomplete",
+                        "重置基线需要选择该目录内的全部既有会话；无法补齐时请改用新目录。",
+                    )
 
         voice_cache_generation = (
             capture_voice_transcript_cache_generation()
@@ -1416,6 +1779,27 @@ class ChatExportManager:
                 "fileName": str(file_name or "").strip(),
                 "encrypted": bool(encrypt),
                 "transcribeVoice": bool(transcribe_voice),
+                **(
+                    {
+                        "outputMode": "folder",
+                        "folderName": str(folder_name or "").strip(),
+                        "baseline": copy.deepcopy(baseline or {}),
+                        "missingFiles": list(dict.fromkeys([
+                            str(value or "").strip()
+                            for value in (missing_files or [])
+                            if str(value or "").strip()
+                        ])),
+                        "resetBaseline": bool(reset_baseline),
+                        "repairUsernames": list(dict.fromkeys([
+                            str(value or "").strip()
+                            for value in (repair_usernames or [])
+                            if str(value or "").strip()
+                        ])),
+                        "recheckMedia": bool(recheck_media),
+                    }
+                    if output_mode_norm == "folder"
+                    else {}
+                ),
             },
             content_key=content_key,
             voice_cache_generation=voice_cache_generation,
@@ -1647,6 +2031,9 @@ class ChatExportManager:
         if export_format_raw not in {"json", "txt", "html", "excel"}:
             raise ValueError(f"Unsupported export format: {export_format_raw}")
         export_format: ExportFormat = export_format_raw  # type: ignore[assignment]
+        output_mode: ExportOutputMode = "folder" if str(opts.get("outputMode") or "zip") == "folder" else "zip"
+        if output_mode == "folder" and job.content_key is not None:
+            raise ValueError("增量目录不支持整包加密，请使用 ZIP 全量导出。")
         include_hidden = bool(opts.get("includeHidden"))
         include_official = bool(opts.get("includeOfficial"))
         include_media = bool(opts.get("includeMedia"))
@@ -1706,6 +2093,7 @@ class ChatExportManager:
             downloadRemoteMedia=download_remote_media,
             privacyMode=privacy_mode,
             transcribeVoice=transcribe_voice,
+            outputMode=output_mode,
         )
         _raise_if_job_cancelled(job, "options_resolved", trace)
 
@@ -1737,8 +2125,120 @@ class ChatExportManager:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         _safe_trace(trace, "output_dir_resolved", durationMs=_elapsed_ms(phase_started), outputDir=str(exports_root))
 
+        folder_context: Optional[ChatFolderContext] = None
+        folder_missing_owner_keys: set[str] = set()
+        if output_mode == "folder":
+            incremental_config = build_incremental_config(
+                export_format=export_format,
+                start_time=st,
+                end_time=et,
+                message_types=sorted(want_types) if want_types else [],
+                include_media=include_media,
+                media_kinds=list(media_kinds),
+                download_remote_media=download_remote_media,
+                html_page_size=html_page_size,
+                privacy_mode=privacy_mode,
+                transcribe_voice=transcribe_voice,
+            )
+            folder_context = prepare_folder_context(
+                account=account_dir.name,
+                exports_root=exports_root,
+                requested_folder_name=str(opts.get("folderName") or ""),
+                config=incremental_config,
+                privacy_mode=privacy_mode,
+                desktop_output=bool(str(opts.get("outputDir") or "").strip()),
+                supplied_baseline=opts.get("baseline") if isinstance(opts.get("baseline"), dict) else {},
+                missing_files=list(opts.get("missingFiles") or []),
+                reset_baseline=bool(opts.get("resetBaseline")),
+            )
+            preferred_missing_owner_keys = {
+                incremental_conversation_key(salt=folder_context.salt, username=username)
+                for username in target_usernames
+            }
+            folder_missing_owner_keys = missing_conversation_keys(
+                folder_context,
+                preferred_keys=preferred_missing_owner_keys,
+            )
+            if folder_missing_owner_keys:
+                original_target_count = len(target_usernames)
+                username_by_key: dict[str, str] = {}
+                old_conversations = (
+                    folder_context.old_state.get("conversations")
+                    if isinstance(folder_context.old_state.get("conversations"), dict)
+                    else {}
+                )
+                for key, raw_state in old_conversations.items():
+                    if not isinstance(raw_state, dict):
+                        continue
+                    meta = raw_state.get("meta") if isinstance(raw_state.get("meta"), dict) else {}
+                    username = str(meta.get("username") or "").strip()
+                    if username and incremental_conversation_key(
+                        salt=folder_context.salt,
+                        username=username,
+                    ) == str(key or ""):
+                        username_by_key[str(key)] = username
+
+                unresolved_keys = folder_missing_owner_keys - set(username_by_key)
+                if unresolved_keys:
+                    if has_prepared_conversations:
+                        candidates = list(prepared_by_username)
+                    else:
+                        candidates = _resolve_export_targets(
+                            account_dir=account_dir,
+                            scope="all",
+                            usernames=[],
+                            include_hidden=True,
+                            include_official=True,
+                            source=source_norm,
+                            rt_conn=rt_conn,
+                        )
+                    for username in candidates:
+                        key = incremental_conversation_key(
+                            salt=folder_context.salt,
+                            username=username,
+                        )
+                        if key in unresolved_keys:
+                            username_by_key[key] = username
+
+                selected_usernames = set(target_usernames)
+                for key in sorted(folder_missing_owner_keys):
+                    username = username_by_key.get(key, "")
+                    if username and username not in selected_usernames:
+                        target_usernames.append(username)
+                        selected_usernames.add(username)
+                folder_context.unresolved_missing_owner_keys = (
+                    folder_missing_owner_keys - set(username_by_key)
+                )
+                _safe_trace(
+                    trace,
+                    "incremental_missing_files_resolved",
+                    missingFiles=len(folder_context.missing_files),
+                    ownerConversations=len(folder_missing_owner_keys),
+                    autoSelected=max(0, len(target_usernames) - original_target_count),
+                    unresolvedOwners=len(folder_context.unresolved_missing_owner_keys),
+                )
+            if folder_context.reset_baseline:
+                old_conversations = (
+                    folder_context.old_state.get("conversations")
+                    if isinstance(folder_context.old_state.get("conversations"), dict)
+                    else {}
+                )
+                selected_keys = {
+                    incremental_conversation_key(salt=folder_context.salt, username=username)
+                    for username in target_usernames
+                }
+                if set(old_conversations) - selected_keys:
+                    raise ChatIncrementalError(
+                        "incremental_reset_incomplete",
+                        "重置基线需要选择该目录内的全部既有会话；无法补齐时请改用新目录。",
+                    )
+            job.options["_folderRuntimeId"] = folder_context.export_runtime_id
+            job.options["folderName"] = folder_context.folder_name
+
         base_name = str(opts.get("fileName") or "").strip()
-        if not base_name:
+        if output_mode == "folder":
+            base_name = f".chat_incremental_{job.export_id}.zip"
+        elif not base_name:
             if privacy_mode:
                 base_name = f"wechat_chat_export_privacy_{ts}_{job.export_id}.zip"
             else:
@@ -1864,6 +2364,27 @@ class ChatExportManager:
                 return display_name, bool(prepared.get("isGroup")), avatar_username, messages
             row = contact_row_cache.get(username)
             return resolve_display_name(username), bool(username.endswith("@chatroom")), username, None
+
+        def conversation_directory(
+            idx: int,
+            username: str,
+            display_name: str,
+            is_group: bool,
+        ) -> tuple[str, str]:
+            if folder_context is None:
+                return (
+                    _conversation_dir_name(idx, display_name, username, is_group, privacy_mode),
+                    "",
+                )
+            key = incremental_conversation_key(salt=folder_context.salt, username=username)
+            folder_context.selected_keys.add(key)
+            directory = allocate_conversation_directory(
+                old_state=folder_context.old_state,
+                key=key,
+                display_name=display_name,
+                privacy_mode=privacy_mode,
+            )
+            return directory.removeprefix("conversations/"), key
         _safe_trace(
             trace,
             "contacts_preloaded",
@@ -1874,7 +2395,15 @@ class ChatExportManager:
         _raise_if_job_cancelled(job, "contacts_preloaded", trace)
 
         media_index: Optional[MediaPathIndex] = None
-        if include_media and any(kind in {"image", "emoji", "video", "video_thumb", "file"} for kind in media_kinds):
+        media_index_required = bool(
+            include_media
+            and any(kind in {"image", "emoji", "video", "video_thumb", "file"} for kind in media_kinds)
+        )
+
+        def ensure_media_index() -> Optional[MediaPathIndex]:
+            nonlocal media_index
+            if not media_index_required or media_index is not None:
+                return media_index
             phase_started = time.perf_counter()
             media_index = MediaPathIndex.build(
                 account_dir=account_dir,
@@ -1893,6 +2422,11 @@ class ChatExportManager:
                 hardlinkRows=int(media_index.stats.get("hardlinkRows") or 0),
             )
             _raise_if_job_cancelled(job, "media_index_built", trace)
+            return media_index
+
+        # ZIP 仍沿用原先的预构建时机；目录模式等确认确有新增或修复任务后再加载媒体索引。
+        if folder_context is None:
+            ensure_media_index()
 
         media_written: dict[str, str] = {}
         avatar_written: dict[str, str] = {}
@@ -1910,6 +2444,8 @@ class ChatExportManager:
             job.progress.messages_exported = 0
             job.progress.media_copied = 0
             job.progress.media_missing = 0
+            job.progress.media_missing_references = 0
+            job.missing_media_keys.clear()
         _safe_trace(trace, "progress_initialized", conversationCount=len(target_usernames))
 
         encrypted_output_path: Optional[Path] = None
@@ -1922,24 +2458,78 @@ class ChatExportManager:
 
             phase_started = time.perf_counter()
             _safe_trace(trace, "zip_open_start", tmpZip=str(tmp_zip))
-            native_integrity = _load_wce_integrity_native()
+            native_integrity = (
+                _load_wce_integrity_native()
+                if folder_context is None or export_format == "html"
+                else None
+            )
             with zipfile.ZipFile(tmp_zip, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as raw_zf:
-                zf = _ZipIntegrityWriter(raw_zf, native_integrity=native_integrity)
+                zf = _ZipIntegrityWriter(
+                    raw_zf,
+                    native_integrity=None if folder_context is not None else native_integrity,
+                )
                 _safe_trace(trace, "zip_opened", durationMs=_elapsed_ms(phase_started))
                 html_index_items: list[dict[str, Any]] = []
                 excel_index_items: list[dict[str, Any]] = []
                 self_avatar_path = ""
                 session_items: list[dict[str, Any]] = []
+                if folder_context is not None:
+                    old_conversations = (
+                        folder_context.old_state.get("conversations")
+                        if isinstance(folder_context.old_state.get("conversations"), dict)
+                        else {}
+                    )
+                    for old_value in old_conversations.values():
+                        if not isinstance(old_value, dict):
+                            continue
+                        old_session = old_value.get("session")
+                        has_old_session = False
+                        if isinstance(old_session, dict) and str(old_session.get("convDir") or "").strip():
+                            session_items.append(dict(old_session))
+                            has_old_session = True
+                        old_meta = old_value.get("meta")
+                        old_directory = str(old_value.get("directory") or "").strip()
+                        if old_directory and not has_old_session:
+                            meta_value = dict(old_meta) if isinstance(old_meta, dict) else {}
+                            session_items.append(
+                                {
+                                    "username": str(meta_value.get("username") or "").strip(),
+                                    "displayName": (
+                                        str(meta_value.get("displayName") or old_value.get("displayName") or "").strip()
+                                        or "会话"
+                                    ),
+                                    "isGroup": bool(meta_value.get("isGroup", old_value.get("isGroup"))),
+                                    "convDir": old_directory,
+                                    "avatarPath": str(meta_value.get("avatarPath") or "").strip(),
+                                    "lastTimeText": "",
+                                    "previewText": "",
+                                }
+                            )
+                        if isinstance(old_meta, dict) and old_directory:
+                            item = {"convDir": old_directory, "meta": dict(old_meta)}
+                            html_index_items.append(item)
+                            excel_index_items.append(item)
                 remote_written: dict[str, str] = {}
                 remote_download_enabled = bool(download_remote_media) and (export_format == "html") and include_media and (not privacy_mode)
                 if export_format == "html":
                     phase_started = time.perf_counter()
                     _safe_trace(trace, "html_assets_start")
                     ui_public_dir = _resolve_ui_public_dir()
-                    css_asset_path, js_asset_path, integrity_asset_path = _html_export_asset_paths(job.export_id)
-                    manifest_asset_path, signature_asset_path = _html_export_integrity_sidecar_paths(job.export_id)
+                    if folder_context is not None:
+                        css_asset_path = "assets/chat-export.css"
+                        js_asset_path = "assets/chat-export.js"
+                        integrity_asset_path = ""
+                        manifest_asset_path = ""
+                        signature_asset_path = ""
+                    else:
+                        css_asset_path, js_asset_path, integrity_asset_path = _html_export_asset_paths(job.export_id)
+                        manifest_asset_path, signature_asset_path = _html_export_integrity_sidecar_paths(job.export_id)
                     css_payload = _minify_css_for_export(_load_ui_css_bundle(ui_public_dir=ui_public_dir, report=report))
-                    js_payload = _html_export_runtime_js(native_integrity)
+                    js_payload = (
+                        _html_export_folder_runtime_js(native_integrity)
+                        if folder_context is not None
+                        else _html_export_runtime_js(native_integrity)
+                    )
                     job.options["_htmlAssets"] = {
                         "cssPath": css_asset_path,
                         "jsPath": js_asset_path,
@@ -1949,6 +2539,9 @@ class ChatExportManager:
                         "cssIntegrity": _sri_sha384(css_payload),
                         "jsIntegrity": _sri_sha384(js_payload),
                     }
+                    if folder_context is not None:
+                        job.options["_htmlAssets"]["folderMode"] = True
+                        job.options["_htmlAssets"]["sessionCatalogPath"] = "assets/chat-sessions.js"
                     zf.writestr(css_asset_path, css_payload)
                     zf.writestr(js_asset_path, js_payload)
 
@@ -2105,7 +2698,13 @@ class ChatExportManager:
                         prepared_name, prepared_is_group, conv_avatar_username, _prepared_messages = conversation_meta(conv_username)
                         conv_name = prepared_name if not privacy_mode else _pick_display_name(conv_row, conv_username)
                         conv_is_group = prepared_is_group
-                        conv_dir = f"conversations/{_conversation_dir_name(idx, conv_name, conv_username, conv_is_group, privacy_mode)}"
+                        conv_part, conv_key = conversation_directory(
+                            idx,
+                            conv_username,
+                            conv_name,
+                            conv_is_group,
+                        )
+                        conv_dir = f"conversations/{conv_part}"
 
                         conv_avatar_path = ""
                         if not privacy_mode and conv_avatar_username:
@@ -2116,23 +2715,31 @@ class ChatExportManager:
                                 avatar_written=avatar_written,
                             )
 
-                        session_items.append(
-                            {
-                                "username": "" if privacy_mode else conv_username,
-                                "displayName": (f"会话 {idx:04d}" if privacy_mode else conv_name),
-                                "isGroup": bool(conv_is_group),
-                                "convDir": conv_dir,
-                                "avatarPath": "" if privacy_mode else conv_avatar_path,
-                                "lastTimeText": ("" if privacy_mode else _format_session_time(last_ts_by_username.get(conv_username))),
-                                "previewText": ("" if privacy_mode else str(preview_by_username.get(conv_username) or "")),
-                            }
-                        )
+                        session_value = {
+                            "username": "" if privacy_mode else conv_username,
+                            "displayName": (f"会话 {idx:04d}" if privacy_mode else conv_name),
+                            "isGroup": bool(conv_is_group),
+                            "convDir": conv_dir,
+                            "avatarPath": "" if privacy_mode else conv_avatar_path,
+                            "lastTimeText": ("" if privacy_mode else _format_session_time(last_ts_by_username.get(conv_username))),
+                            "previewText": ("" if privacy_mode else str(preview_by_username.get(conv_username) or "")),
+                        }
+                        session_items = [
+                            item for item in session_items
+                            if str(item.get("convDir") or "") != conv_dir
+                        ]
+                        session_items.append(session_value)
                     _safe_trace(
                         trace,
                         "html_session_index_built",
                         durationMs=_elapsed_ms(phase_started),
                         sessionItems=len(session_items),
                     )
+                    if folder_context is not None:
+                        zf.writestr(
+                            "assets/chat-sessions.js",
+                            _html_export_folder_sessions_js(session_items),
+                        )
 
                 for idx, conv_username in enumerate(target_usernames, start=1):
                     _raise_if_job_cancelled(job, "conversation_loop_start", trace, index=idx)
@@ -2143,7 +2750,13 @@ class ChatExportManager:
                     conv_name = prepared_name if not privacy_mode else _pick_display_name(conv_row, conv_username)
                     conv_is_group = prepared_is_group
 
-                    conv_dir = f"conversations/{_conversation_dir_name(idx, conv_name, conv_username, conv_is_group, privacy_mode)}"
+                    conv_part, conv_key = conversation_directory(
+                        idx,
+                        conv_username,
+                        conv_name,
+                        conv_is_group,
+                    )
+                    conv_dir = f"conversations/{conv_part}"
 
                     with self._lock:
                         job.progress.current_conversation_index = idx
@@ -2156,11 +2769,41 @@ class ChatExportManager:
                     if prepared_messages is not None:
                         estimated_total = len(prepared_messages)
                     else:
+                        estimate_start_time = st
+                        if folder_context is not None and conv_key and export_format == "html" and html_page_size > 0:
+                            estimate_old_conversations = (
+                                folder_context.old_state.get("conversations")
+                                if isinstance(folder_context.old_state.get("conversations"), dict)
+                                else {}
+                            )
+                            estimate_old = (
+                                estimate_old_conversations.get(conv_key)
+                                if isinstance(estimate_old_conversations.get(conv_key), dict)
+                                else {}
+                            )
+                            estimate_watermark = _incremental_watermark(estimate_old.get("watermark"))
+                            estimate_repair_requested = bool(
+                                bool(opts.get("resetBaseline"))
+                                or conv_username in set(opts.get("repairUsernames") or [])
+                            )
+                            estimate_managed_missing = conv_key in folder_missing_owner_keys or any(
+                                str(path or "") in folder_context.missing_files
+                                for path in (estimate_old.get("managedFiles") or [])
+                            )
+                            # 正常追加时，进度估算也必须从旧水位开始，避免先统计整段历史。
+                            if (
+                                estimate_watermark is not None
+                                and not estimate_repair_requested
+                                and not estimate_managed_missing
+                            ):
+                                estimate_start_time = int(estimate_watermark[0] or 0)
+                                if st is not None:
+                                    estimate_start_time = max(int(st), estimate_start_time)
                         try:
                             estimated_total = _estimate_conversation_message_count(
                                 account_dir=account_dir,
                                 conv_username=conv_username,
-                                start_time=st,
+                                start_time=estimate_start_time,
                                 end_time=et,
                                 local_types=estimate_local_types,
                                 source=source_norm,
@@ -2199,6 +2842,283 @@ class ChatExportManager:
                     )
                     _raise_if_job_cancelled(job, "conversation_resource_lookup", trace, index=idx, conversation=conv_username)
 
+                    incremental_old: dict[str, Any] = {}
+                    incremental_probe: dict[str, Any] = {}
+                    incremental_should_render = True
+                    incremental_reasons: list[str] = []
+                    incremental_append_mode = False
+                    incremental_append_messages: list[dict[str, Any]] = []
+                    incremental_append_snapshot: Optional[dict[str, Any]] = None
+                    if folder_context is not None and conv_key:
+                        old_conversations = (
+                            folder_context.old_state.get("conversations")
+                            if isinstance(folder_context.old_state.get("conversations"), dict)
+                            else {}
+                        )
+                        incremental_old = (
+                            dict(old_conversations.get(conv_key))
+                            if isinstance(old_conversations.get(conv_key), dict)
+                            else {}
+                        )
+                        repair_requested = bool(
+                            bool(opts.get("resetBaseline"))
+                            or conv_username in set(opts.get("repairUsernames") or [])
+                            or bool(opts.get("recheckMedia"))
+                        )
+                        managed_missing = conv_key in folder_missing_owner_keys or any(
+                            str(path or "") in folder_context.missing_files
+                            for path in (incremental_old.get("managedFiles") or [])
+                        )
+                        append_html_path = (
+                            folder_context.target_root / Path(*f"{conv_dir}/messages.html".split("/"))
+                            if folder_context.target_root is not None
+                            else None
+                        )
+                        if append_html_path is not None and append_html_path.is_file():
+                            incremental_append_snapshot = _html_incremental_snapshot(append_html_path)
+                        append_probe_allowed = bool(
+                            export_format == "html"
+                            and html_page_size > 0
+                            and incremental_old
+                            and _incremental_watermark(incremental_old.get("watermark")) is not None
+                            and incremental_append_snapshot is not None
+                            and not repair_requested
+                            and not managed_missing
+                            and (
+                                privacy_mode
+                                or str(incremental_old.get("displayName") or "") == str(conv_name or "")
+                            )
+                            and (
+                                not transcribe_voice
+                                or incremental_old.get("voiceCacheGeneration") is None
+                                or int(incremental_old.get("voiceCacheGeneration") or 0)
+                                == int(job.voice_cache_generation or 0)
+                            )
+                        )
+                        _safe_trace(
+                            trace,
+                            "incremental_append_eligibility",
+                            conversation=conv_username,
+                            allowed=append_probe_allowed,
+                            format=export_format,
+                            pageSize=html_page_size,
+                            hasBaseline=bool(incremental_old),
+                            hasWatermark=_incremental_watermark(incremental_old.get("watermark")) is not None,
+                            hasHtmlSnapshot=incremental_append_snapshot is not None,
+                            repairRequested=repair_requested,
+                            managedMissing=managed_missing,
+                            profileStable=(
+                                privacy_mode
+                                or str(incremental_old.get("displayName") or "") == str(conv_name or "")
+                            ),
+                        )
+                        if prepared_messages is None:
+                            if append_probe_allowed:
+                                incremental_probe = _probe_incremental_append(
+                                    account_dir=account_dir,
+                                    conv_username=conv_username,
+                                    start_time=st,
+                                    end_time=et,
+                                    source=source_norm,
+                                    rt_conn=rt_conn,
+                                    old_state=incremental_old,
+                                    want_types=want_types,
+                                    is_group=conv_is_group,
+                                    checkpoint=lambda: _raise_if_job_cancelled(
+                                        job,
+                                        "incremental_append_probe",
+                                        trace,
+                                        conversation=conv_username,
+                                    ),
+                                )
+                                incremental_append_messages = list(
+                                    incremental_probe.get("preparedMessages") or []
+                                )
+                                if len(incremental_append_messages) > int(html_page_size):
+                                    incremental_probe = {}
+                                    incremental_append_messages = []
+                            if not incremental_probe:
+                                incremental_probe = _probe_incremental_conversation(
+                                    account_dir=account_dir,
+                                    conv_username=conv_username,
+                                    start_time=st,
+                                    end_time=et,
+                                    source=source_norm,
+                                    rt_conn=rt_conn,
+                                    old_state=incremental_old,
+                                    want_types=want_types,
+                                    is_group=conv_is_group,
+                                    privacy_mode=privacy_mode,
+                                    checkpoint=lambda: _raise_if_job_cancelled(
+                                        job,
+                                        "incremental_probe",
+                                        trace,
+                                        conversation=conv_username,
+                                    ),
+                                )
+                        else:
+                            incremental_probe = {
+                                "messageCount": len(prepared_messages),
+                                "newMessageCount": len(prepared_messages),
+                                "watermark": [],
+                                "historyFingerprint": hashlib.sha256(
+                                    json.dumps(prepared_messages, ensure_ascii=False, sort_keys=True, default=str).encode("utf-8")
+                                ).hexdigest(),
+                                "historyChanged": False,
+                            }
+
+                        has_new_messages = int(incremental_probe.get("newMessageCount") or 0) > 0
+                        content_history_changed = bool(incremental_probe.get("historyChanged"))
+                        history_changed = content_history_changed
+                        profile_changed = False
+                        transcript_changed = False
+                        if (
+                            incremental_old
+                            and not privacy_mode
+                            and str(incremental_old.get("displayName") or "") != str(conv_name or "")
+                        ):
+                            profile_changed = True
+                            history_changed = True
+                            incremental_reasons.append("profile_changed")
+                        if (
+                            transcribe_voice
+                            and incremental_old
+                            and incremental_old.get("voiceCacheGeneration") is not None
+                            and int(incremental_old.get("voiceCacheGeneration") or 0)
+                            != int(job.voice_cache_generation or 0)
+                        ):
+                            transcript_changed = True
+                            history_changed = True
+                            incremental_reasons.append("transcript_changed")
+                        pending_media = normalize_pending_media(incremental_old.get("pendingMedia") or [])
+                        repairable_pending: list[dict[str, Any]] = []
+                        if pending_media:
+                            pending_media, pending_changed = _classify_pending_media(
+                                account_dir=account_dir,
+                                conv_username=conv_username,
+                                values=pending_media,
+                                media_index=ensure_media_index(),
+                            )
+                            incremental_old["pendingMedia"] = pending_media
+                            folder_context.metadata_changed = bool(folder_context.metadata_changed or pending_changed)
+                            repairable_pending = [
+                                item for item in pending_media if bool(item.get("repairable"))
+                            ]
+                            unavailable_pending = [
+                                item for item in pending_media if not bool(item.get("repairable"))
+                            ]
+                            if repairable_pending:
+                                incremental_reasons.append("media_recoverable")
+                            if unavailable_pending:
+                                folder_context.unresolved_media_conversations.append(
+                                    {
+                                        "username": "" if privacy_mode else conv_username,
+                                        "conversationKey": conv_key,
+                                        "displayName": "" if privacy_mode else conv_name,
+                                        "uniqueCount": len(unavailable_pending),
+                                        "referenceCount": sum(
+                                            max(1, int(item.get("occurrenceCount") or 1))
+                                            for item in unavailable_pending
+                                        ),
+                                    }
+                                )
+
+                        if managed_missing:
+                            incremental_reasons.append("managed_file_missing")
+
+                        incremental_append_mode = bool(
+                            incremental_probe.get("appendProbe")
+                            and has_new_messages
+                            and not history_changed
+                            and incremental_append_snapshot is not None
+                            and incremental_append_messages
+                        )
+                        if incremental_probe.get("appendProbe"):
+                            with self._lock:
+                                append_total = int(incremental_probe.get("newMessageCount") or 0)
+                                job.progress.current_conversation_messages_total = append_total
+                                job.progress.current_conversation_messages_exported = 0
+
+                        if not incremental_old:
+                            incremental_should_render = True
+                        elif repair_requested or managed_missing:
+                            incremental_should_render = True
+                        elif profile_changed and not content_history_changed and not transcript_changed:
+                            # 资料变化可以直接同步，不需要用户再确认一次“修复”。
+                            incremental_should_render = True
+                        elif history_changed and not has_new_messages:
+                            incremental_should_render = False
+                            reasons = list(dict.fromkeys(["history_changed", *incremental_reasons]))
+                            folder_context.repair_candidates.append(
+                                {
+                                    "username": conv_username,
+                                    "conversationKey": conv_key,
+                                    "displayName": "" if privacy_mode else conv_name,
+                                    "reasons": reasons,
+                                    "newMessageCount": 0,
+                                }
+                            )
+                        elif repairable_pending and not has_new_messages:
+                            incremental_should_render = False
+                            folder_context.repair_candidates.append(
+                                {
+                                    "username": conv_username,
+                                    "conversationKey": conv_key,
+                                    "displayName": "" if privacy_mode else conv_name,
+                                    "reasons": ["media_recoverable"],
+                                    "newMessageCount": 0,
+                                }
+                            )
+                        else:
+                            incremental_should_render = has_new_messages or history_changed
+
+                        if history_changed and has_new_messages:
+                            folder_context.history_synced.append(
+                                {
+                                    "username": conv_username,
+                                    "conversationKey": conv_key,
+                                    "displayName": "" if privacy_mode else conv_name,
+                                    "reasons": list(dict.fromkeys(["history_changed", *incremental_reasons])),
+                                    "newMessageCount": int(incremental_probe.get("newMessageCount") or 0),
+                                }
+                            )
+                        elif repairable_pending and incremental_append_mode:
+                            # 新消息仍按真正增量追加；旧媒体确认可恢复后再由用户明确重建。
+                            folder_context.repair_candidates.append(
+                                {
+                                    "username": conv_username,
+                                    "conversationKey": conv_key,
+                                    "displayName": "" if privacy_mode else conv_name,
+                                    "reasons": ["media_recoverable"],
+                                    "newMessageCount": int(incremental_probe.get("newMessageCount") or 0),
+                                }
+                            )
+                        if incremental_old and not incremental_should_render:
+                            reused_count = int(incremental_old.get("messageCount") or 0)
+                            reused_state = dict(incremental_old)
+                            reused_state["rendered"] = False
+                            reused_state["newMessageCount"] = 0
+                            folder_context.current_conversations[conv_key] = reused_state
+                            with self._lock:
+                                reused_progress = (
+                                    0 if incremental_probe.get("appendProbe") else reused_count
+                                )
+                                job.progress.current_conversation_messages_exported = reused_progress
+                                job.progress.current_conversation_messages_total = reused_progress
+                                job.progress.conversations_done += 1
+                            _safe_trace(
+                                trace,
+                                "conversation_reused",
+                                index=idx,
+                                conversation=conv_username,
+                                durationMs=_elapsed_ms(conv_started),
+                                exportedCount=reused_count,
+                                conversationsDone=job.progress.conversations_done,
+                            )
+                            continue
+
+                    if folder_context is not None:
+                        ensure_media_index()
                     conv_avatar_path = ""
                     if not privacy_mode and conv_avatar_username:
                         phase_started = time.perf_counter()
@@ -2284,9 +3204,7 @@ class ChatExportManager:
                             prepared_messages=prepared_messages,
                         )
                     elif export_format == "html":
-                        exported_count = _write_conversation_html(
-                            zf=zf,
-                            conv_dir=conv_dir,
+                        html_writer_options = dict(
                             account_dir=account_dir,
                             conv_username=conv_username,
                             conv_name=conv_name,
@@ -2318,8 +3236,24 @@ class ChatExportManager:
                             media_index=media_index,
                             job=job,
                             lock=self._lock,
-                            prepared_messages=prepared_messages,
                         )
+                        if incremental_append_mode and incremental_append_snapshot is not None:
+                            exported_count = _write_conversation_html_append(
+                                zf=zf,
+                                conv_dir=conv_dir,
+                                existing_snapshot=incremental_append_snapshot,
+                                old_state=incremental_old,
+                                new_messages=incremental_append_messages,
+                                runtime_id=(folder_context.export_runtime_id if folder_context is not None else ""),
+                                writer_options=html_writer_options,
+                            )
+                        else:
+                            exported_count = _write_conversation_html(
+                                zf=zf,
+                                conv_dir=conv_dir,
+                                prepared_messages=prepared_messages,
+                                **html_writer_options,
+                            )
                     else:
                         exported_count = _write_conversation_json(
                             zf=zf,
@@ -2378,14 +3312,111 @@ class ChatExportManager:
                         "messageCount": int(exported_count),
                     }
                     zf.writestr(f"{conv_dir}/meta.json", json.dumps(meta, ensure_ascii=False, indent=2))
+                    effective_meta = meta
+                    if folder_context is not None and not incremental_should_render:
+                        old_meta = incremental_old.get("meta")
+                        if isinstance(old_meta, dict):
+                            effective_meta = dict(old_meta)
                     if export_format == "html":
-                        html_index_items.append({"convDir": conv_dir, "meta": meta})
+                        html_index_items = [
+                            item for item in html_index_items
+                            if str(item.get("convDir") or "") != conv_dir
+                        ]
+                        html_index_items.append({"convDir": conv_dir, "meta": effective_meta})
                     elif export_format == "excel":
-                        excel_index_items.append({"convDir": conv_dir, "meta": meta})
+                        excel_index_items = [
+                            item for item in excel_index_items
+                            if str(item.get("convDir") or "") != conv_dir
+                        ]
+                        excel_index_items.append({"convDir": conv_dir, "meta": effective_meta})
+
+                    if folder_context is not None and conv_key:
+                        previous_state = dict(incremental_old)
+                        if incremental_should_render:
+                            session_value = next(
+                                (
+                                    dict(item)
+                                    for item in session_items
+                                    if str(item.get("convDir") or "") == conv_dir
+                                ),
+                                {},
+                            )
+                            pending_media = normalize_pending_media(
+                                [
+                                    {
+                                        "kind": str(item.get("kind") or ""),
+                                        "id": str(item.get("id") or ""),
+                                        "messageId": str(item.get("messageId") or ""),
+                                    }
+                                    for item in (report.get("missingMedia") or [])
+                                    if isinstance(item, dict)
+                                    and str(item.get("conversation") or "") == conv_username
+                                ],
+                                default_state="source_unavailable",
+                                default_reason="SOURCE_NOT_FOUND",
+                            )
+                            if incremental_append_mode:
+                                pending_media = normalize_pending_media(
+                                    [
+                                        *list(incremental_old.get("pendingMedia") or []),
+                                        *pending_media,
+                                    ],
+                                    default_state="source_unavailable",
+                                    default_reason="SOURCE_NOT_FOUND",
+                                )
+                            current_state = {
+                                "directory": conv_dir,
+                                "displayName": "" if privacy_mode else conv_name,
+                                "isGroup": bool(conv_is_group),
+                                "sourceRowCount": int(incremental_probe.get("messageCount") or 0),
+                                "messageCount": int(exported_count),
+                                "watermark": list(incremental_probe.get("watermark") or []),
+                                "historyFingerprint": str(incremental_probe.get("historyFingerprint") or ""),
+                                "voiceCacheGeneration": int(job.voice_cache_generation or 0) if transcribe_voice else None,
+                                "pendingMedia": pending_media,
+                                "session": session_value,
+                                "meta": effective_meta,
+                                "rendered": True,
+                                "appendOnly": bool(incremental_append_mode),
+                                "newMessageCount": int(incremental_probe.get("newMessageCount") or 0),
+                            }
+                        else:
+                            current_state = previous_state
+                            current_state["rendered"] = False
+                            current_state["newMessageCount"] = 0
+                        folder_context.current_conversations[conv_key] = current_state
+                        unresolved_items = [
+                            item
+                            for item in normalize_pending_media(current_state.get("pendingMedia") or [])
+                            if not bool(item.get("repairable"))
+                        ]
+                        folder_context.unresolved_media_conversations = [
+                            item
+                            for item in folder_context.unresolved_media_conversations
+                            if str(item.get("conversationKey") or "") != conv_key
+                        ]
+                        if unresolved_items:
+                            folder_context.unresolved_media_conversations.append(
+                                {
+                                    "username": "" if privacy_mode else conv_username,
+                                    "conversationKey": conv_key,
+                                    "displayName": "" if privacy_mode else conv_name,
+                                    "uniqueCount": len(unresolved_items),
+                                    "referenceCount": sum(
+                                        max(1, int(item.get("occurrenceCount") or 1))
+                                        for item in unresolved_items
+                                    ),
+                                }
+                            )
 
                     with self._lock:
-                        job.progress.current_conversation_messages_exported = int(exported_count)
-                        job.progress.current_conversation_messages_total = int(exported_count)
+                        progress_count = (
+                            int(incremental_probe.get("newMessageCount") or 0)
+                            if incremental_append_mode
+                            else int(exported_count)
+                        )
+                        job.progress.current_conversation_messages_exported = progress_count
+                        job.progress.current_conversation_messages_total = progress_count
                         job.progress.conversations_done += 1
                     _safe_trace(
                         trace,
@@ -2417,21 +3448,31 @@ class ChatExportManager:
                     html_assets = dict(job.options.get("_htmlAssets") or {})
                     css_asset_path = str(html_assets.get("cssPath") or _html_export_asset_paths(job.export_id)[0])
                     js_asset_path = str(html_assets.get("jsPath") or _html_export_asset_paths(job.export_id)[1])
+                    session_catalog_path = str(html_assets.get("sessionCatalogPath") or "assets/chat-sessions.js")
                     integrity_asset_path = str(html_assets.get("integrityPath") or _html_export_asset_paths(job.export_id)[2])
                     css_integrity = str(html_assets.get("cssIntegrity") or "")
                     js_integrity = str(html_assets.get("jsIntegrity") or "")
-                    parts.append(_html_export_gate_style())
-                    # Do not use native `integrity=` here: Chrome blocks SRI on file://
-                    # because it cannot enforce CORS. Keep hashes in inert data attrs
-                    # and let the export integrity checker verify them instead.
-                    parts.append(f'  <link id="wceStyle" rel="stylesheet" href="{esc_attr(css_asset_path)}" data-wce-sri="{esc_attr(css_integrity)}" />\n')
-                    parts.append(_html_export_integrity_script_tag(src=integrity_asset_path))
-                    parts.append(f'  <script defer src="{esc_attr(js_asset_path)}" data-wce-sri="{esc_attr(js_integrity)}"></script>\n')
+                    if folder_context is not None:
+                        parts.append(f'  <link id="wceStyle" rel="stylesheet" href="{esc_attr(css_asset_path)}" />\n')
+                        parts.append(
+                            f'  <script defer src="{esc_attr(session_catalog_path)}" data-wce-folder-sessions="1"></script>\n'
+                        )
+                        parts.append(f'  <script defer src="{esc_attr(js_asset_path)}"></script>\n')
+                    else:
+                        parts.append(_html_export_gate_style())
+                        # file:// 下由导出运行时核对 data-wce-sri，不能使用浏览器原生 SRI。
+                        parts.append(f'  <link id="wceStyle" rel="stylesheet" href="{esc_attr(css_asset_path)}" data-wce-sri="{esc_attr(css_integrity)}" />\n')
+                        parts.append(_html_export_integrity_script_tag(src=integrity_asset_path))
+                        parts.append(f'  <script defer src="{esc_attr(js_asset_path)}" data-wce-sri="{esc_attr(js_integrity)}"></script>\n')
                     parts.append("</head>\n")
                     parts.append("<body>\n")
                     parts.append(
                         '  <div id="wceJsMissing" style="position:fixed;top:0;left:0;right:0;z-index:9999;background:#FEF3C7;color:#92400E;border-bottom:1px solid #F59E0B;padding:8px 12px;font-size:12px;line-height:1.4">'
-                        "提示：此页面需要 JavaScript 才能使用“合并聊天记录”等交互功能。若该提示一直存在，请确认已完整解压导出目录，并检查 assets/_wce/ 下的运行时文件是否完整。</div>\n"
+                        + (
+                            "提示：此页面需要 JavaScript 才能使用“合并聊天记录”等交互功能。若该提示一直存在，请确认导出目录中的运行时文件完整。</div>\n"
+                            if folder_context is not None
+                            else "提示：此页面需要 JavaScript 才能使用“合并聊天记录”等交互功能。若该提示一直存在，请确认已完整解压导出目录，并检查 assets/_wce/ 下的运行时文件是否完整。</div>\n"
+                        )
                     )
                     parts.append('<div class="wce-index">\n')
                     parts.append('  <div class="wce-index-container">\n')
@@ -2545,7 +3586,10 @@ class ChatExportManager:
                 }
                 zf.writestr("manifest.json", json.dumps(manifest, ensure_ascii=False, indent=2))
                 zf.writestr("report.json", json.dumps(report, ensure_ascii=False, indent=2))
-                if export_format == "html":
+                if folder_context is not None:
+                    # 可持续目录由基线保存逐文件摘要；不可变 ZIP 的阻断式完整性链不适用于原地更新。
+                    pass
+                elif export_format == "html":
                     try:
                         html_assets = dict(job.options.get("_htmlAssets") or {})
                         write_active_html_zip_integrity(zf, job.export_id, html_assets)
@@ -2569,7 +3613,39 @@ class ChatExportManager:
             _raise_if_job_cancelled(job, "before_finalize", trace)
 
             phase_started = time.perf_counter()
-            if job.content_key is not None:
+            if folder_context is not None:
+                final_out = materialize_folder_archive(
+                    job=job,
+                    archive_path=tmp_zip,
+                    context=folder_context,
+                )
+                tmp_zip.unlink(missing_ok=True)
+                warning_parts: list[str] = []
+                if folder_context.reset_baseline:
+                    warning_parts.append("已重置基线并完整重建本次选择的会话。")
+                recovered_files = int(job.incremental.get("filesRecovered") or 0)
+                if recovered_files:
+                    warning_parts.append(f"已补回 {recovered_files} 个缺失或异常的受管理文件。")
+                if folder_context.repair_candidates:
+                    warning_parts.append(
+                        f"发现 {len(folder_context.repair_candidates)} 个会话存在可恢复差异。"
+                    )
+                unresolved_unique = int(job.unresolved_media.get("uniqueCount") or 0)
+                unresolved_references = int(job.unresolved_media.get("referenceCount") or 0)
+                if unresolved_unique:
+                    warning_parts.append(
+                        f"有 {unresolved_unique} 个媒体当前在源端不可用，影响 {unresolved_references} 条消息；重复修复不会产生变化。"
+                    )
+                if folder_context.history_synced:
+                    warning_parts.append(
+                        f"已在追加新消息时同步 {len(folder_context.history_synced)} 个会话的历史变化。"
+                    )
+                if folder_context.unresolved_missing_owner_keys:
+                    warning_parts.append(
+                        f"有 {len(folder_context.unresolved_missing_owner_keys)} 个缺失文件所属会话已不在当前数据源中，将在后续更新时继续尝试补回。"
+                    )
+                job.warning = " ".join(warning_parts)
+            elif job.content_key is not None:
                 final_out = final_zip.with_name(final_zip.name + ".wec")
                 if final_out.exists():
                     final_out = final_out.with_name(
@@ -2591,13 +3667,14 @@ class ChatExportManager:
 
             with self._lock:
                 job.status = "done"
-                job.zip_path = final_out
+                job.zip_path = final_out if folder_context is None else None
                 job.finished_at = time.time()
             _safe_trace(
                 trace,
                 "job_done",
                 durationMs=round(((job.finished_at or time.time()) - (job.started_at or job.created_at)) * 1000.0, 1),
-                finalZip=str(final_out),
+                finalZip=str(final_out) if folder_context is None else "",
+                folderPath=str(final_out) if folder_context is not None else "",
                 messagesExported=job.progress.messages_exported,
                 mediaCopied=job.progress.media_copied,
                 mediaMissing=job.progress.media_missing,
@@ -2622,10 +3699,16 @@ class ChatExportManager:
                 mediaMissing=job.progress.media_missing,
             )
         except Exception:
-            if job.content_key is not None:
+            if job.content_key is not None or folder_context is not None:
                 tmp_zip.unlink(missing_ok=True)
                 if encrypted_output_path is not None:
                     encrypted_output_path.unlink(missing_ok=True)
+                if job.staging_dir is not None and job.staging_dir.exists():
+                    import shutil
+
+                    shutil.rmtree(job.staging_dir, ignore_errors=True)
+                    job.staging_dir = None
+                    job.staged_files = {}
             raise
         finally:
             if realtime_paused:
@@ -3490,6 +4573,207 @@ def _iter_rows_for_conversation(
     return heapq.merge(*streams, key=sort_key)
 
 
+def _incremental_row_key(row: _Row) -> tuple[int, int, int, int, str, str]:
+    return (
+        int(row.create_time or 0),
+        int(row.sort_seq or 0),
+        int(row.local_id or 0),
+        int(row.server_id or 0),
+        str(row.db_stem or ""),
+        str(row.table_name or ""),
+    )
+
+
+def _incremental_row_payload(row: _Row, message: dict[str, Any]) -> bytes:
+    normalized_message = {
+        key: value
+        for key, value in message.items()
+        if key not in {"createTimeText", "conversationUsername", "_mediaUsername"}
+    }
+    value = {
+        "key": list(_incremental_row_key(row)),
+        "message": normalized_message,
+    }
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+
+
+def _incremental_watermark(value: Any) -> tuple[int, int, int, int, str, str] | None:
+    raw = value if isinstance(value, list) else []
+    if len(raw) < 6:
+        return None
+    try:
+        return (
+            int(raw[0] or 0),
+            int(raw[1] or 0),
+            int(raw[2] or 0),
+            int(raw[3] or 0),
+            str(raw[4] or ""),
+            str(raw[5] or ""),
+        )
+    except Exception:
+        return None
+
+
+def _probe_incremental_append(
+    *,
+    account_dir: Path,
+    conv_username: str,
+    start_time: Optional[int],
+    end_time: Optional[int],
+    source: str,
+    rt_conn: Any | None,
+    old_state: dict[str, Any],
+    want_types: Optional[set[str]] = None,
+    is_group: bool = False,
+    checkpoint: Optional[Callable[[], None]] = None,
+) -> dict[str, Any]:
+    """只读取旧水位之后的消息，供可分页格式执行真正的追加更新。"""
+
+    old_watermark = _incremental_watermark(old_state.get("watermark"))
+    if old_watermark is None:
+        raise ValueError("incremental append requires one valid watermark")
+
+    lower_bound = int(old_watermark[0] or 0)
+    if start_time is not None:
+        lower_bound = max(lower_bound, int(start_time))
+    prepared_messages: list[dict[str, Any]] = []
+    new_payloads: list[bytes] = []
+    watermark = old_watermark
+    rows = _iter_rows_for_conversation(
+        account_dir=account_dir,
+        conv_username=conv_username,
+        start_time=lower_bound,
+        end_time=end_time,
+        local_types=None,
+        source=source,
+        rt_conn=rt_conn,
+        checkpoint=checkpoint,
+    )
+    for row in rows:
+        key = _incremental_row_key(row)
+        if key <= old_watermark:
+            continue
+        watermark = max(watermark, key)
+        parsed = _parse_message_for_export(
+            row=row,
+            conv_username=conv_username,
+            is_group=is_group,
+            resource_conn=None,
+            resource_chat_id=None,
+        )
+        if not _is_render_type_selected(parsed.get("renderType"), want_types):
+            continue
+        prepared_messages.append(parsed)
+        new_payloads.append(_incremental_row_payload(row, parsed))
+
+    old_count = int(old_state.get("sourceRowCount") or old_state.get("messageCount") or 0)
+    chained_hash = hashlib.sha256()
+    chained_hash.update(b"wce-incremental-append-v1\0")
+    chained_hash.update(str(old_state.get("historyFingerprint") or "").encode("ascii", errors="ignore"))
+    for payload in new_payloads:
+        chained_hash.update(len(payload).to_bytes(4, "big"))
+        chained_hash.update(payload)
+    return {
+        "messageCount": old_count + len(prepared_messages),
+        "newMessageCount": len(prepared_messages),
+        "watermark": list(watermark),
+        "historyFingerprint": (
+            chained_hash.hexdigest()
+            if prepared_messages
+            else str(old_state.get("historyFingerprint") or "")
+        ),
+        "historyChanged": False,
+        "preparedMessages": prepared_messages,
+        "appendProbe": True,
+    }
+
+
+def _probe_incremental_conversation(
+    *,
+    account_dir: Path,
+    conv_username: str,
+    start_time: Optional[int],
+    end_time: Optional[int],
+    source: str,
+    rt_conn: Any | None,
+    old_state: dict[str, Any],
+    want_types: Optional[set[str]] = None,
+    is_group: bool = False,
+    privacy_mode: bool = False,
+    checkpoint: Optional[Callable[[], None]] = None,
+) -> dict[str, Any]:
+    """流式计算旧水位前的历史指纹和当前会话水位。"""
+
+    old_watermark = _incremental_watermark(old_state.get("watermark"))
+
+    full_hash = hashlib.sha256()
+    prefix_hash = hashlib.sha256()
+    count = 0
+    prefix_count = 0
+    new_count = 0
+    watermark: tuple[int, int, int, int, str, str] | None = None
+    privacy_sender_alias_map: dict[str, int] = {}
+    rows = _iter_rows_for_conversation(
+        account_dir=account_dir,
+        conv_username=conv_username,
+        start_time=start_time,
+        end_time=end_time,
+        local_types=None,
+        source=source,
+        rt_conn=rt_conn,
+        checkpoint=checkpoint,
+    )
+    for row in rows:
+        parsed = _parse_message_for_export(
+            row=row,
+            conv_username=conv_username,
+            is_group=is_group,
+            resource_conn=None,
+            resource_chat_id=None,
+        )
+        if not _is_render_type_selected(parsed.get("renderType"), want_types):
+            continue
+        if privacy_mode:
+            _privacy_scrub_message(
+                parsed,
+                conv_is_group=is_group,
+                sender_alias_map=privacy_sender_alias_map,
+            )
+        payload = _incremental_row_payload(row, parsed)
+        key = _incremental_row_key(row)
+        full_hash.update(len(payload).to_bytes(4, "big"))
+        full_hash.update(payload)
+        count += 1
+        watermark = key
+        if old_watermark is not None and key <= old_watermark:
+            prefix_hash.update(len(payload).to_bytes(4, "big"))
+            prefix_hash.update(payload)
+            prefix_count += 1
+        elif old_watermark is not None:
+            new_count += 1
+
+    old_exists = bool(old_state)
+    if not old_exists or old_watermark is None:
+        new_count = count
+    old_count = int(old_state.get("sourceRowCount") or old_state.get("messageCount") or 0)
+    old_fingerprint = str(old_state.get("historyFingerprint") or "")
+    history_changed = bool(
+        old_exists
+        and old_watermark is not None
+        and (
+            prefix_count != old_count
+            or prefix_hash.hexdigest() != old_fingerprint
+        )
+    )
+    return {
+        "messageCount": count,
+        "newMessageCount": max(0, new_count),
+        "watermark": list(watermark) if watermark is not None else [],
+        "historyFingerprint": full_hash.hexdigest(),
+        "historyChanged": history_changed,
+    }
+
+
 def _parse_message_for_export(
     *,
     row: _Row,
@@ -4189,6 +5473,7 @@ def _write_conversation_json(
                         zf=zf,
                         account_dir=account_dir,
                         conv_username=media_conv_username,
+                        owner_username=conv_username,
                         msg=msg,
                         media_written=media_written,
                         report=report,
@@ -4551,6 +5836,7 @@ def _write_conversation_txt(
                         zf=zf,
                         account_dir=account_dir,
                         conv_username=media_conv_username,
+                        owner_username=conv_username,
                         msg=msg,
                         media_written=media_written,
                         report=report,
@@ -4609,6 +5895,85 @@ def _write_conversation_txt(
 
     _safe_trace(trace, "writer_done", exported=exported)
     return exported
+
+
+def _html_incremental_snapshot_text(text: str) -> Optional[dict[str, Any]]:
+    """读取 HTML 的最后一页和分页元数据；结构不匹配时安全回退全量生成。"""
+
+    marker = '<div id="wceMessageList">\n'
+    marker_at = text.find(marker)
+    if marker_at < 0:
+        return None
+    content_start = marker_at + len(marker)
+    page_pattern = re.compile(
+        r'<script type="application/json" id="wcePageMeta">(.*?)</script>',
+        flags=re.DOTALL,
+    )
+    page_match = page_pattern.search(text, content_start)
+    brand_at = text.find('<div id="wceBrandAttribution"', content_start)
+    boundary = page_match.start() if page_match is not None else brand_at
+    if boundary < 0:
+        return None
+    close_marker = "\n          </div>\n        </div>\n"
+    content_end = text.rfind(close_marker, content_start, boundary)
+    if content_end < content_start:
+        return None
+
+    page_meta: dict[str, Any] = {}
+    page_span: tuple[int, int] | None = None
+    if page_match is not None:
+        try:
+            value = json.loads(page_match.group(1))
+            if not isinstance(value, dict):
+                return None
+            page_meta = value
+            page_span = (page_match.start(), page_match.end())
+        except Exception:
+            return None
+
+    media_pattern = re.compile(
+        r'<script type="application/json" id="wceMediaIndex">(.*?)</script>',
+        flags=re.DOTALL,
+    )
+    media_match = media_pattern.search(text, boundary)
+    media_index: dict[str, Any] = {}
+    if media_match is not None:
+        try:
+            value = json.loads(media_match.group(1))
+            if isinstance(value, dict):
+                media_index = value
+        except Exception:
+            media_index = {}
+
+    return {
+        "text": text,
+        "contentStart": content_start,
+        "contentEnd": content_end,
+        "closeMarker": close_marker,
+        "fragment": text[content_start:content_end],
+        "pageMeta": page_meta,
+        "pageSpan": page_span,
+        "mediaIndex": media_index,
+    }
+
+
+def _html_incremental_snapshot(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        return _html_incremental_snapshot_text(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _merge_html_media_index(old_value: Any, new_value: Any) -> Any:
+    if not isinstance(old_value, dict) or not isinstance(new_value, dict):
+        return copy.deepcopy(new_value if new_value not in ({}, None) else old_value)
+    merged = copy.deepcopy(old_value)
+    for key, value in new_value.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _merge_html_media_index(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
 
 
 def _write_conversation_html(
@@ -4675,12 +6040,15 @@ def _write_conversation_html(
     html_assets = dict(getattr(job, "options", {}).get("_htmlAssets") or {})
     css_asset_path = str(html_assets.get("cssPath") or _html_export_asset_paths(job.export_id)[0])
     js_asset_path = str(html_assets.get("jsPath") or _html_export_asset_paths(job.export_id)[1])
+    session_catalog_path = str(html_assets.get("sessionCatalogPath") or "assets/chat-sessions.js")
     integrity_asset_path = str(html_assets.get("integrityPath") or _html_export_asset_paths(job.export_id)[2])
     css_integrity = str(html_assets.get("cssIntegrity") or "")
     js_integrity = str(html_assets.get("jsIntegrity") or "")
+    folder_mode = bool(html_assets.get("folderMode"))
     css_href = rel_root + css_asset_path
     integrity_src = rel_root + integrity_asset_path
     js_src = rel_root + js_asset_path
+    session_catalog_src = rel_root + session_catalog_path
 
     def esc_text(v: Any) -> str:
         return html.escape(str(v or ""), quote=False)
@@ -5114,17 +6482,27 @@ def _write_conversation_html(
             tw.write('  <meta charset="utf-8" />\n')
             tw.write('  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />\n')
             tw.write(f"  <title>{esc_text(page_title)}</title>\n")
-            tw.write(_html_export_gate_style())
-            # Do not use native `integrity=` for offline file:// exports; Chrome blocks
-            # those resources before our runtime can show the page.
-            tw.write(f'  <link id="wceStyle" rel="stylesheet" href="{esc_attr(css_href)}" data-wce-sri="{esc_attr(css_integrity)}" />\n')
-            tw.write(_html_export_integrity_script_tag(src=integrity_src))
-            tw.write(f'  <script defer src="{esc_attr(js_src)}" data-wce-sri="{esc_attr(js_integrity)}"></script>\n')
+            if folder_mode:
+                tw.write(f'  <link id="wceStyle" rel="stylesheet" href="{esc_attr(css_href)}" />\n')
+                tw.write(
+                    f'  <script defer src="{esc_attr(session_catalog_src)}" data-wce-folder-sessions="1"></script>\n'
+                )
+                tw.write(f'  <script defer src="{esc_attr(js_src)}"></script>\n')
+            else:
+                tw.write(_html_export_gate_style())
+                # file:// 下由导出运行时核对 data-wce-sri，不能使用浏览器原生 SRI。
+                tw.write(f'  <link id="wceStyle" rel="stylesheet" href="{esc_attr(css_href)}" data-wce-sri="{esc_attr(css_integrity)}" />\n')
+                tw.write(_html_export_integrity_script_tag(src=integrity_src))
+                tw.write(f'  <script defer src="{esc_attr(js_src)}" data-wce-sri="{esc_attr(js_integrity)}"></script>\n')
             tw.write("</head>\n")
             tw.write("<body>\n")
             tw.write(
                 '  <div id="wceJsMissing" style="position:fixed;top:0;left:0;right:0;z-index:9999;background:#FEF3C7;color:#92400E;border-bottom:1px solid #F59E0B;padding:8px 12px;font-size:12px;line-height:1.4">'
-                "提示：此页面需要 JavaScript 才能使用“合并聊天记录”等交互功能。若该提示一直存在，请确认已完整解压导出目录，并检查 assets/_wce/ 下的运行时文件是否完整。</div>\n"
+                + (
+                    "提示：此页面需要 JavaScript 才能使用“合并聊天记录”等交互功能。若该提示一直存在，请确认导出目录中的运行时文件完整。</div>\n"
+                    if folder_mode
+                    else "提示：此页面需要 JavaScript 才能使用“合并聊天记录”等交互功能。若该提示一直存在，请确认已完整解压导出目录，并检查 assets/_wce/ 下的运行时文件是否完整。</div>\n"
+                )
             )
 
             # Root
@@ -5468,6 +6846,7 @@ def _write_conversation_html(
                         zf=zf,
                         account_dir=account_dir,
                         conv_username=media_conv_username,
+                        owner_username=conv_username,
                         msg=msg,
                         media_written=media_written,
                         report=report,
@@ -5475,6 +6854,7 @@ def _write_conversation_html(
                         allow_process_key_extract=allow_process_key_extract,
                         media_db_path=media_db_path,
                         media_index=media_index,
+                        remote_written=remote_written,
                         lock=lock,
                         job=job,
                     )
@@ -6304,7 +7684,11 @@ def _write_conversation_html(
                 num = str(page_no).zfill(int(paged_pad_width or 4))
                 arc_js = f"{conv_dir}/pages/page-{num}.js"
                 js_payload = _html_export_page_fragment_js(
-                    export_id=str(getattr(job, "export_id", "") or ""),
+                    export_id=str(
+                        (getattr(job, "options", {}) or {}).get("_folderRuntimeId")
+                        or getattr(job, "export_id", "")
+                        or ""
+                    ),
                     arc_js=arc_js,
                     page_no=int(page_no),
                     fragment_html=frag_text,
@@ -6319,6 +7703,121 @@ def _write_conversation_html(
 
     _safe_trace(trace, "writer_done", exported=exported)
     return exported
+
+
+def _write_conversation_html_append(
+    *,
+    zf: _ZipIntegrityWriter,
+    conv_dir: str,
+    existing_snapshot: dict[str, Any],
+    old_state: dict[str, Any],
+    new_messages: list[dict[str, Any]],
+    runtime_id: str,
+    writer_options: dict[str, Any],
+) -> int:
+    """把旧内联末页转为历史分页，仅渲染并内联本轮新增消息。"""
+
+    old_count = int(old_state.get("messageCount") or 0)
+    if old_count <= 0 or not str(existing_snapshot.get("fragment") or "").strip():
+        return _write_conversation_html(
+            zf=zf,
+            conv_dir=conv_dir,
+            prepared_messages=new_messages,
+            **writer_options,
+        )
+
+    temp_buffer = io.BytesIO()
+    with zipfile.ZipFile(temp_buffer, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as temp_archive:
+        temp_writer = _ZipIntegrityWriter(temp_archive, native_integrity=None)
+        added_count = _write_conversation_html(
+            zf=temp_writer,
+            conv_dir=conv_dir,
+            prepared_messages=new_messages,
+            **writer_options,
+        )
+    if added_count <= 0:
+        return old_count
+
+    temp_buffer.seek(0)
+    with zipfile.ZipFile(temp_buffer, mode="r") as temp_archive:
+        temp_html = temp_archive.read(f"{conv_dir}/messages.html").decode("utf-8")
+        delta_snapshot = _html_incremental_snapshot_text(temp_html)
+        if delta_snapshot is None or not str(delta_snapshot.get("fragment") or "").strip():
+            raise RuntimeError("新增 HTML 分页生成失败，无法安全追加。")
+        for name in temp_archive.namelist():
+            normalized = _zip_arcname(name)
+            if not normalized or normalized.startswith(f"{conv_dir}/"):
+                continue
+            zf.writestr(normalized, temp_archive.read(name))
+
+    old_text = str(existing_snapshot.get("text") or "")
+    content_start = int(existing_snapshot.get("contentStart") or 0)
+    content_end = int(existing_snapshot.get("contentEnd") or 0)
+    close_marker = str(existing_snapshot.get("closeMarker") or "")
+    old_fragment = str(existing_snapshot.get("fragment") or "")
+    new_fragment = str(delta_snapshot.get("fragment") or "")
+    old_page_meta = dict(existing_snapshot.get("pageMeta") or {})
+    old_total_pages = max(1, int(old_page_meta.get("totalPages") or 1))
+    new_total_pages = old_total_pages + 1
+    pad_width = max(4, int(old_page_meta.get("padWidth") or 4), len(str(new_total_pages)))
+
+    old_page_number = str(old_total_pages).zfill(pad_width)
+    old_page_arc = f"{conv_dir}/pages/page-{old_page_number}.js"
+    zf.writestr(
+        old_page_arc,
+        _html_export_page_fragment_js(
+            export_id=str(runtime_id or ""),
+            arc_js=old_page_arc,
+            page_no=old_total_pages,
+            fragment_html=_minify_html_for_export(old_fragment),
+        ),
+    )
+
+    merged_html = old_text[:content_start] + new_fragment + old_text[content_end:]
+    page_meta = {
+        "schemaVersion": 1,
+        "pageSize": int(old_page_meta.get("pageSize") or writer_options.get("html_page_size") or 1000),
+        "totalPages": new_total_pages,
+        "initialPage": new_total_pages,
+        "totalMessages": old_count + added_count,
+        "padWidth": pad_width,
+        "pageFilePrefix": "pages/page-",
+        "pageFileSuffix": ".js",
+        "inlinedPages": [new_total_pages],
+    }
+    page_script = (
+        '<script type="application/json" id="wcePageMeta">'
+        + json.dumps(page_meta, ensure_ascii=False).replace("</", "<\\/")
+        + "</script>"
+    )
+    page_pattern = re.compile(
+        r'<script type="application/json" id="wcePageMeta">.*?</script>',
+        flags=re.DOTALL,
+    )
+    if page_pattern.search(merged_html):
+        merged_html = page_pattern.sub(lambda _match: page_script, merged_html, count=1)
+    else:
+        inserted_at = content_start + len(new_fragment) + len(close_marker)
+        merged_html = merged_html[:inserted_at] + page_script + "\n" + merged_html[inserted_at:]
+
+    merged_media = _merge_html_media_index(
+        existing_snapshot.get("mediaIndex") or {},
+        delta_snapshot.get("mediaIndex") or {},
+    )
+    media_script = (
+        '<script type="application/json" id="wceMediaIndex">'
+        + json.dumps(merged_media, ensure_ascii=False).replace("</", "<\\/")
+        + "</script>"
+    )
+    media_pattern = re.compile(
+        r'<script type="application/json" id="wceMediaIndex">.*?</script>',
+        flags=re.DOTALL,
+    )
+    if media_pattern.search(merged_html):
+        merged_html = media_pattern.sub(lambda _match: media_script, merged_html, count=1)
+
+    zf.writestr(f"{conv_dir}/messages.html", merged_html)
+    return old_count + added_count
 
 
 def _format_message_line_txt(*, msg: dict[str, Any]) -> str:
@@ -6552,11 +8051,109 @@ def _attach_voice_transcript(
         stats["failed"] = int(stats.get("failed") or 0) + 1
 
 
+def _pending_media_local_repairability(
+    *,
+    account_dir: Path,
+    conv_username: str,
+    item: dict[str, Any],
+    media_index: Optional[MediaPathIndex],
+) -> tuple[bool, str]:
+    """只在确认本地资源能生成有效产物时，才允许进入媒体修复流程。"""
+
+    kind = str(item.get("kind") or "").strip().lower()
+    ident = str(item.get("id") or "").strip()
+    if not kind or not ident:
+        return False, "SOURCE_ID_MISSING"
+    md5 = ident.lower() if _is_md5(ident.lower()) else ""
+    file_id = "" if md5 else ident
+    source: Optional[Path] = None
+    if md5:
+        try:
+            source = _try_find_decrypted_resource(account_dir, md5)
+        except Exception:
+            source = None
+    if source is None and media_index is not None:
+        try:
+            source = media_index.resolve(
+                kind=kind,
+                md5=md5,
+                file_id=file_id,
+                username=str(conv_username or "").strip(),
+            )
+        except Exception:
+            source = None
+    if source is None and md5:
+        try:
+            source = _resolve_media_path_for_kind(
+                account_dir,
+                kind=kind,
+                md5=md5,
+                username=conv_username,
+                allow_fallback_scan=False,
+            )
+        except Exception:
+            source = None
+    try:
+        if source is None or not source.is_file():
+            return False, "SOURCE_NOT_FOUND"
+    except Exception:
+        return False, "SOURCE_NOT_FOUND"
+
+    if kind == "file":
+        return True, "LOCAL_SOURCE_READY"
+    if kind == "voice":
+        # 语音需要按 server_id 从媒体库读取，不能只凭待补标识判断可恢复。
+        return False, "SOURCE_NOT_FOUND"
+    try:
+        data, media_type = _read_and_maybe_decrypt_media(source, account_dir=account_dir)
+    except Exception:
+        return False, "SOURCE_DECRYPT_FAILED"
+    media_type = str(media_type or "").strip().lower()
+    if kind in {"image", "emoji", "video_thumb"}:
+        return (
+            (True, "LOCAL_SOURCE_READY")
+            if media_type.startswith("image/") and bool(data)
+            else (False, "SOURCE_DECRYPT_FAILED")
+        )
+    if kind == "video":
+        return (
+            (True, "LOCAL_SOURCE_READY")
+            if media_type == "video/mp4" and bool(data)
+            else (False, "SOURCE_DECRYPT_FAILED")
+        )
+    return False, "SOURCE_FORMAT_UNSUPPORTED"
+
+
+def _classify_pending_media(
+    *,
+    account_dir: Path,
+    conv_username: str,
+    values: Any,
+    media_index: Optional[MediaPathIndex],
+) -> tuple[list[dict[str, Any]], bool]:
+    normalized = normalize_pending_media(values)
+    classified: list[dict[str, Any]] = []
+    for raw in normalized:
+        item = dict(raw)
+        repairable, reason_code = _pending_media_local_repairability(
+            account_dir=account_dir,
+            conv_username=conv_username,
+            item=item,
+            media_index=media_index,
+        )
+        item["repairable"] = repairable
+        item["state"] = "recoverable_local" if repairable else "source_unavailable"
+        item["reasonCode"] = reason_code
+        classified.append(item)
+    return classified, classified != normalized
+
+
 def _attach_offline_media(
     *,
     zf: zipfile.ZipFile,
     account_dir: Path,
     conv_username: str,
+    owner_username: str,
     msg: dict[str, Any],
     media_written: dict[str, str],
     report: dict[str, Any],
@@ -6564,6 +8161,7 @@ def _attach_offline_media(
     allow_process_key_extract: bool,
     media_db_path: Path,
     media_index: Optional[MediaPathIndex],
+    remote_written: Optional[dict[str, str]] = None,
     lock: threading.Lock,
     job: ExportJob,
 ) -> None:
@@ -6582,7 +8180,15 @@ def _attach_offline_media(
 
     def record_missing(kind: str, ident: str) -> None:
         with lock:
-            job.progress.media_missing += 1
+            job.progress.media_missing_references += 1
+            if str(job.options.get("outputMode") or "zip") == "folder":
+                key = (str(kind or ""), str(ident or ""))
+                if key not in job.missing_media_keys:
+                    job.missing_media_keys.add(key)
+                    job.progress.media_missing += 1
+            else:
+                # ZIP 全量保留原有按消息引用计数的行为。
+                job.progress.media_missing += 1
         try:
             report["missingMedia"].append(
                 {
@@ -6594,6 +8200,31 @@ def _attach_offline_media(
             )
         except Exception:
             pass
+
+    def try_remote_image(kind: str, ident: str, url: Any) -> tuple[str, bool]:
+        if (
+            str(job.options.get("outputMode") or "zip") != "folder"
+            or remote_written is None
+            or not bool(job.options.get("downloadRemoteMedia"))
+        ):
+            return "", False
+        raw = str(url or "").strip()
+        try:
+            parsed = urlparse(raw)
+        except Exception:
+            parsed = None
+        if parsed is None or parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return "", False
+        was_known = raw in remote_written
+        arc = _download_remote_image_to_zip(
+            zf=zf,
+            url=raw,
+            remote_written=remote_written,
+            report=report,
+        )
+        if arc and ident:
+            media_written[f"{kind}:{ident}"] = arc
+        return arc, bool(arc and not was_known)
 
     offline: list[dict[str, Any]] = []
 
@@ -6666,6 +8297,16 @@ def _attach_offline_media(
                     used_file_id = file_id
                     break
 
+        if not arc:
+            arc, is_new = try_remote_image(
+                "image",
+                primary_md5 or primary_file_id,
+                msg.get("imageUrl"),
+            )
+            if arc:
+                used_md5 = primary_md5
+                used_file_id = primary_file_id
+
         if arc:
             # Keep primary fields in sync with what actually resolved.
             try:
@@ -6697,6 +8338,8 @@ def _attach_offline_media(
             suggested_name="",
             media_index=media_index,
         )
+        if not arc:
+            arc, is_new = try_remote_image("emoji", md5 or file_id, msg.get("emojiUrl"))
         if arc:
             offline.append({"kind": "emoji", "path": arc, "md5": md5, "fileId": file_id})
             if is_new:
@@ -6792,6 +8435,17 @@ def _attach_offline_media(
 
     if offline:
         msg["offlineMedia"] = offline
+        if str(job.options.get("outputMode") or "") == "folder":
+            owners_by_path = job.options.setdefault("_folderResourceOwners", {})
+            owner = str(owner_username or "").strip()
+            if isinstance(owners_by_path, dict) and owner:
+                for item in offline:
+                    path = str(item.get("path") or "").strip()
+                    if not path:
+                        continue
+                    owners = owners_by_path.setdefault(path, [])
+                    if isinstance(owners, list) and owner not in owners:
+                        owners.append(owner)
 
 
 def _materialize_avatar(

--- a/src/wechat_decrypt_tool/chat_incremental_export.py
+++ b/src/wechat_decrypt_tool/chat_incremental_export.py
@@ -1,0 +1,922 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import tempfile
+import uuid
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+
+STATE_FILE_NAME = ".wechat-chat-export.json"
+SCHEMA_VERSION = 1
+ARTIFACT_TYPE = "wechat-chat-incremental-folder"
+PENDING_MEDIA_STATES = {
+    "unclassified",
+    "recoverable_local",
+    "recoverable_remote",
+    "retryable",
+    "source_unavailable",
+    "decrypt_blocked",
+    "unsupported",
+}
+
+
+class ChatIncrementalError(ValueError):
+    """聊天增量目录无法安全继续更新。"""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = str(code or "incremental_error")
+
+
+def _safe_component(value: Any, *, fallback: str) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"[<>:\"/\\|?*\x00-\x1f]", "_", text)
+    text = re.sub(r"\s+", " ", text).strip(" .")
+    if not text:
+        text = fallback
+    return text[:96].rstrip(" .") or fallback
+
+
+def normalize_relative_path(value: Any) -> str:
+    text = str(value or "").replace("\\", "/").lstrip("/")
+    parts = [part for part in text.split("/") if part not in {"", "."}]
+    if not parts or any(part == ".." for part in parts):
+        return ""
+    return "/".join(parts)
+
+
+def _require_managed_path(value: Any) -> str:
+    raw = str(value or "").strip().replace("\\", "/")
+    normalized = normalize_relative_path(raw)
+    if (
+        not normalized
+        or raw.startswith("/")
+        or raw != normalized
+        or ":" in normalized.split("/", 1)[0]
+        or "\x00" in raw
+    ):
+        raise ChatIncrementalError("incremental_unsafe_path", "增量基线包含不安全的文件路径。")
+    return normalized
+
+
+def _validate_baseline_paths(value: dict[str, Any]) -> None:
+    files = value.get("files") if isinstance(value.get("files"), dict) else {}
+    for path, metadata in files.items():
+        _require_managed_path(path)
+        if not isinstance(metadata, dict):
+            raise ChatIncrementalError("incremental_baseline_invalid", "增量基线文件摘要损坏，请选择新目录。")
+        digest = str(metadata.get("sha256") or "")
+        try:
+            size = int(metadata.get("size"))
+        except Exception as exc:
+            raise ChatIncrementalError("incremental_baseline_invalid", "增量基线文件摘要损坏，请选择新目录。") from exc
+        if size < 0 or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ChatIncrementalError("incremental_baseline_invalid", "增量基线文件摘要损坏，请选择新目录。")
+    conversations = value.get("conversations") if isinstance(value.get("conversations"), dict) else {}
+    for state in conversations.values():
+        if not isinstance(state, dict):
+            raise ChatIncrementalError("incremental_baseline_invalid", "增量基线会话信息损坏，请选择新目录。")
+        directory = _require_managed_path(state.get("directory"))
+        if not directory.startswith("conversations/"):
+            raise ChatIncrementalError("incremental_unsafe_path", "增量基线包含不安全的会话目录。")
+        managed_files = state.get("managedFiles") or []
+        if not isinstance(managed_files, list):
+            raise ChatIncrementalError("incremental_baseline_invalid", "增量基线会话信息损坏，请选择新目录。")
+        for path in managed_files:
+            _require_managed_path(path)
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def build_config(
+    *,
+    export_format: str,
+    start_time: Optional[int],
+    end_time: Optional[int],
+    message_types: list[str],
+    include_media: bool,
+    media_kinds: list[str],
+    download_remote_media: bool,
+    html_page_size: int,
+    privacy_mode: bool,
+    transcribe_voice: bool,
+) -> dict[str, Any]:
+    return {
+        "format": str(export_format or "").strip().lower(),
+        "startTime": int(start_time) if start_time is not None else None,
+        "endTime": int(end_time) if end_time is not None else None,
+        "messageTypes": sorted({str(item or "").strip() for item in message_types if str(item or "").strip()}),
+        "includeMedia": bool(include_media),
+        "mediaKinds": sorted({str(item or "").strip() for item in media_kinds if str(item or "").strip()}),
+        "downloadRemoteMedia": bool(download_remote_media),
+        "htmlPageSize": int(html_page_size) if str(export_format or "").lower() == "html" else None,
+        "privacyMode": bool(privacy_mode),
+        "transcribeVoice": bool(transcribe_voice),
+    }
+
+
+def config_fingerprint(config: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(config)).hexdigest()
+
+
+def conversation_key(*, salt: str, username: str) -> str:
+    payload = f"{str(salt or '')}\0{str(username or '')}".encode("utf-8", errors="replace")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def account_fingerprint(account: str) -> str:
+    return hashlib.sha256(str(account or "").encode("utf-8", errors="replace")).hexdigest()
+
+
+def privacy_account_token(account: str) -> str:
+    """生成与浏览器端一致的短标识，避免隐私目录名包含账号明文。"""
+
+    value = 0x811C9DC5
+    raw = str(account or "").encode("utf-16-le", errors="surrogatepass")
+    for index in range(0, len(raw), 2):
+        unit = raw[index] | (raw[index + 1] << 8)
+        value ^= unit
+        value = (value * 0x01000193) & 0xFFFFFFFF
+    return f"{value:08x}"
+
+
+def allocate_conversation_directory(
+    *,
+    old_state: dict[str, Any],
+    key: str,
+    display_name: str,
+    privacy_mode: bool,
+) -> str:
+    conversations = old_state.get("conversations") if isinstance(old_state.get("conversations"), dict) else {}
+    old = conversations.get(key) if isinstance(conversations.get(key), dict) else {}
+    existing = normalize_relative_path(old.get("directory"))
+    if existing and existing.startswith("conversations/"):
+        return existing
+    stem = "conversation" if privacy_mode else _safe_component(display_name, fallback="conversation")
+    return f"conversations/{stem}_{key[:10]}"
+
+
+def normalize_pending_media(
+    values: Any,
+    *,
+    default_state: str = "unclassified",
+    default_reason: str = "",
+) -> list[dict[str, Any]]:
+    """按媒体唯一标识合并待补项，同时保留受影响消息引用数。"""
+
+    state_default = str(default_state or "unclassified").strip()
+    if state_default not in PENDING_MEDIA_STATES:
+        state_default = "unclassified"
+    grouped: dict[tuple[str, str], dict[str, Any]] = {}
+    for raw in values if isinstance(values, list) else []:
+        if not isinstance(raw, dict):
+            continue
+        kind = str(raw.get("kind") or "").strip().lower()
+        ident = str(raw.get("id") or "").strip()
+        if not kind or not ident:
+            continue
+        key = (kind, ident)
+        try:
+            occurrences = max(1, int(raw.get("occurrenceCount") or 1))
+        except Exception:
+            occurrences = 1
+        state = str(raw.get("state") or state_default).strip()
+        if state not in PENDING_MEDIA_STATES:
+            state = state_default
+        repairable = bool(raw.get("repairable")) or state in {"recoverable_local", "recoverable_remote"}
+        reason_code = str(raw.get("reasonCode") or default_reason or "").strip()
+        existing = grouped.get(key)
+        if existing is None:
+            existing = {
+                "kind": kind,
+                "id": ident,
+                "occurrenceCount": occurrences,
+                "state": state,
+                "reasonCode": reason_code,
+                "repairable": repairable,
+            }
+            message_id = str(raw.get("messageId") or "").strip()
+            if message_id:
+                existing["messageId"] = message_id
+            grouped[key] = existing
+            continue
+        existing["occurrenceCount"] = int(existing.get("occurrenceCount") or 0) + occurrences
+        # 只要任一来源已确认可恢复，就不能被另一个旧的不可用记录覆盖。
+        if repairable and not bool(existing.get("repairable")):
+            existing["state"] = state
+            existing["reasonCode"] = reason_code
+            existing["repairable"] = True
+    return [grouped[key] for key in sorted(grouped)]
+
+
+def summarize_pending_media(conversations: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """汇总唯一缺失媒体和消息引用数，避免把重复表情误报成多个文件。"""
+
+    unique: dict[tuple[str, str], dict[str, Any]] = {}
+    by_kind: dict[str, dict[str, int]] = {}
+    for state in conversations.values():
+        if not isinstance(state, dict):
+            continue
+        for item in normalize_pending_media(state.get("pendingMedia") or []):
+            if bool(item.get("repairable")):
+                continue
+            kind = str(item.get("kind") or "")
+            ident = str(item.get("id") or "")
+            key = (kind, ident)
+            references = max(1, int(item.get("occurrenceCount") or 1))
+            bucket = by_kind.setdefault(kind, {"uniqueCount": 0, "referenceCount": 0})
+            bucket["referenceCount"] += references
+            if key not in unique:
+                unique[key] = dict(item)
+                bucket["uniqueCount"] += 1
+            else:
+                unique[key]["occurrenceCount"] = int(unique[key].get("occurrenceCount") or 0) + references
+    return {
+        "uniqueCount": len(unique),
+        "referenceCount": sum(int(item.get("occurrenceCount") or 0) for item in unique.values()),
+        "byKind": by_kind,
+    }
+
+
+@dataclass
+class ChatFolderContext:
+    account: str
+    folder_name: str
+    config: dict[str, Any]
+    config_hash: str
+    privacy_mode: bool
+    desktop_output: bool
+    exports_root: Path
+    target_root: Optional[Path]
+    old_state: dict[str, Any]
+    salt: str
+    missing_files: set[str] = field(default_factory=set)
+    reset_baseline: bool = False
+    selected_keys: set[str] = field(default_factory=set)
+    current_conversations: dict[str, dict[str, Any]] = field(default_factory=dict)
+    repair_candidates: list[dict[str, Any]] = field(default_factory=list)
+    history_synced: list[dict[str, Any]] = field(default_factory=list)
+    unresolved_media_conversations: list[dict[str, Any]] = field(default_factory=list)
+    unresolved_missing_owner_keys: set[str] = field(default_factory=set)
+    metadata_changed: bool = False
+
+    @property
+    def export_runtime_id(self) -> str:
+        return str(self.old_state.get("runtimeId") or hashlib.sha256(self.salt.encode("utf-8")).hexdigest()[:12])
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ChatIncrementalError("incremental_baseline_invalid", "增量基线损坏，请选择新目录。") from exc
+    if not isinstance(value, dict):
+        raise ChatIncrementalError("incremental_baseline_invalid", "增量基线损坏，请选择新目录。")
+    return value
+
+
+def _baseline_is_owned(value: dict[str, Any]) -> bool:
+    return (
+        int(value.get("schemaVersion") or 0) == SCHEMA_VERSION
+        and str(value.get("artifactType") or "") == ARTIFACT_TYPE
+        and isinstance(value.get("conversations"), dict)
+        and isinstance(value.get("files"), dict)
+    )
+
+
+def _directory_has_user_files(path: Path) -> bool:
+    try:
+        return path.is_dir() and any(path.iterdir())
+    except Exception:
+        # 无法检查时按非空处理，避免在未知目录中覆盖用户文件。
+        return True
+
+
+def prepare_folder_context(
+    *,
+    account: str,
+    exports_root: Path,
+    requested_folder_name: str,
+    config: dict[str, Any],
+    privacy_mode: bool,
+    desktop_output: bool,
+    supplied_baseline: Optional[dict[str, Any]],
+    missing_files: list[str],
+    reset_baseline: bool,
+) -> ChatFolderContext:
+    folder_name = _safe_component(
+        requested_folder_name or f"微信聊天记录_{account}",
+        fallback="微信聊天记录",
+    )
+    if privacy_mode:
+        folder_name = f"微信聊天记录_隐私_{privacy_account_token(account)}"
+    exports_root = Path(exports_root).resolve()
+    nested_root = (exports_root / folder_name).resolve()
+    direct_state_path = exports_root / STATE_FILE_NAME
+    direct_state: dict[str, Any] = {}
+    if desktop_output and direct_state_path.is_file():
+        direct_state = _read_json_file(direct_state_path)
+
+    direct_matches = bool(
+        exports_root.name == folder_name
+        or (
+            direct_state
+            and str(direct_state.get("artifactType") or "") == ARTIFACT_TYPE
+            and (
+                str(direct_state.get("account") or "") == str(account or "")
+                or str(direct_state.get("accountFingerprint") or "") == account_fingerprint(account)
+            )
+        )
+    )
+    target_root = exports_root if desktop_output and direct_matches else (nested_root if desktop_output else None)
+
+    old_state: dict[str, Any] = {}
+    if desktop_output and target_root is not None:
+        disk_state_path = target_root / STATE_FILE_NAME
+        if disk_state_path.is_file():
+            old_state = direct_state if disk_state_path == direct_state_path and direct_state else _read_json_file(disk_state_path)
+    elif isinstance(supplied_baseline, dict):
+        old_state = dict(supplied_baseline)
+
+    owned = bool(old_state and _baseline_is_owned(old_state))
+    if old_state and not owned:
+        raise ChatIncrementalError("incremental_baseline_invalid", "增量基线损坏或不属于聊天导出，请选择新目录。")
+    if owned:
+        _validate_baseline_paths(old_state)
+
+    desired_hash = config_fingerprint(config)
+    if owned:
+        baseline_account = str(old_state.get("account") or "")
+        baseline_account_fingerprint = str(old_state.get("accountFingerprint") or "")
+        account_matches = (
+            baseline_account == str(account or "")
+            if baseline_account
+            else baseline_account_fingerprint == account_fingerprint(account)
+        )
+        if not account_matches:
+            raise ChatIncrementalError("incremental_account_mismatch", "该增量目录属于其他微信账号，请选择新目录。")
+        if str(old_state.get("configFingerprint") or "") != desired_hash and not reset_baseline:
+            raise ChatIncrementalError(
+                "incremental_config_mismatch",
+                "导出格式或筛选配置与该增量目录不一致，请选择新目录或重置后完整重建。",
+            )
+
+    if reset_baseline:
+        if old_state and not owned:
+            raise ChatIncrementalError("incremental_baseline_invalid", "无法安全重置损坏的增量目录，请选择空目录。")
+        if not owned and desktop_output and target_root is not None and _directory_has_user_files(target_root):
+            raise ChatIncrementalError(
+                "incremental_directory_not_empty",
+                "无法重置来源不明的非空目录，请选择新目录。",
+            )
+        old_state = {} if not owned else old_state
+    elif not old_state and desktop_output and target_root is not None and _directory_has_user_files(target_root):
+        raise ChatIncrementalError(
+            "incremental_directory_not_empty",
+            "所选目录非空且没有可识别的聊天增量基线，请选择其父目录或一个空目录。",
+        )
+
+    salt = str(old_state.get("conversationSalt") or uuid.uuid4().hex)
+    missing = {_require_managed_path(raw) for raw in missing_files}
+    if owned and desktop_output and target_root is not None:
+        managed_files = old_state.get("files") if isinstance(old_state.get("files"), dict) else {}
+        for raw_path, metadata in managed_files.items():
+            path = _require_managed_path(raw_path)
+            destination = (target_root / Path(*path.split("/"))).resolve()
+            if target_root not in destination.parents or not destination.is_file():
+                missing.add(path)
+                continue
+            try:
+                expected_size = int((metadata or {}).get("size"))
+            except Exception:
+                expected_size = -1
+            if expected_size >= 0 and destination.stat().st_size != expected_size:
+                missing.add(path)
+    return ChatFolderContext(
+        account=str(account or ""),
+        folder_name=str(old_state.get("folderName") or folder_name),
+        config=dict(config),
+        config_hash=desired_hash,
+        privacy_mode=bool(privacy_mode),
+        desktop_output=bool(desktop_output),
+        exports_root=exports_root,
+        target_root=target_root,
+        old_state=old_state,
+        salt=salt,
+        missing_files=missing,
+        reset_baseline=bool(reset_baseline),
+    )
+
+
+def missing_conversation_keys(
+    context: ChatFolderContext,
+    *,
+    preferred_keys: Optional[set[str]] = None,
+) -> set[str]:
+    """把全部缺失受管理文件反向映射到需要重建的会话。"""
+
+    missing = set(context.missing_files)
+    if not missing:
+        return set()
+
+    conversations = (
+        context.old_state.get("conversations")
+        if isinstance(context.old_state.get("conversations"), dict)
+        else {}
+    )
+    files = (
+        context.old_state.get("files")
+        if isinstance(context.old_state.get("files"), dict)
+        else {}
+    )
+    result: set[str] = set()
+    preferred = {str(key or "") for key in (preferred_keys or set())}
+
+    for raw_key, raw_state in conversations.items():
+        if not isinstance(raw_state, dict):
+            continue
+        key = str(raw_key or "")
+        managed = {
+            normalize_relative_path(path)
+            for path in (raw_state.get("managedFiles") or [])
+        }
+        directory = normalize_relative_path(raw_state.get("directory"))
+        if managed & missing or any(
+            directory and (path == directory or path.startswith(directory + "/"))
+            for path in missing
+        ):
+            result.add(key)
+
+    known_keys = {str(key or "") for key in conversations}
+    for path in missing:
+        if not _is_owned_resource_path(path):
+            continue
+        metadata = files.get(path) if isinstance(files.get(path), dict) else {}
+        owners = {
+            str(owner or "")
+            for owner in (metadata.get("owners") or [])
+            if str(owner or "") in known_keys
+        }
+        if owners:
+            # 共享资源只需一个所有者重新物化；优先复用已经需要重建或本次已选择的会话。
+            candidates = owners & result
+            if not candidates:
+                candidates = owners & preferred
+            result.add(sorted(candidates or owners)[0])
+        else:
+            # 老基线若没有资源归属信息，保守重建全部会话，避免缺失媒体永久无法补回。
+            result.update(known_keys)
+    return result
+
+
+def _safe_archive_infos(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
+    result: dict[str, zipfile.ZipInfo] = {}
+    for info in archive.infolist():
+        if info.is_dir():
+            continue
+        path = normalize_relative_path(info.filename)
+        if path:
+            result[path] = info
+    return result
+
+
+def _file_meta(payload: bytes, *, owners: Optional[list[str]] = None) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size": len(payload),
+    }
+    if owners:
+        result["owners"] = sorted(set(owners))
+    return result
+
+
+def _resource_search_payload(payload: bytes, path: str) -> bytes:
+    """Excel 文件本身是 ZIP，需要展开 XML 后才能识别其中的资源引用。"""
+
+    if not str(path or "").lower().endswith(".xlsx"):
+        return payload
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload), "r") as workbook:
+            return b"\n".join(
+                workbook.read(info)
+                for info in workbook.infolist()
+                if not info.is_dir() and info.filename.lower().endswith((".xml", ".rels"))
+            )
+    except Exception:
+        return payload
+
+
+def _is_owned_resource_path(path: str) -> bool:
+    return str(path or "").startswith(("media/", "avatars/"))
+
+
+def _is_conversation_path(path: str) -> bool:
+    return str(path or "").startswith("conversations/")
+
+
+def _conversation_owner(path: str, conversations: dict[str, dict[str, Any]]) -> str:
+    for key, state in conversations.items():
+        directory = normalize_relative_path(state.get("directory"))
+        if directory and (path == directory or path.startswith(directory + "/")):
+            return key
+    return ""
+
+
+def _write_staged_file(staging_dir: Path, relative: str, payload: bytes) -> Path:
+    destination = (staging_dir / Path(*relative.split("/"))).resolve()
+    if staging_dir not in destination.parents:
+        raise ChatIncrementalError("incremental_unsafe_path", "增量文件路径不安全。")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(payload)
+    return destination
+
+
+def materialize_folder_archive(
+    *,
+    job: Any,
+    archive_path: Path,
+    context: ChatFolderContext,
+) -> Path:
+    staging_dir = Path(
+        tempfile.mkdtemp(
+            prefix=f".chat-folder-{job.export_id}-",
+            dir=str(context.exports_root),
+        )
+    ).resolve()
+    job.staging_dir = staging_dir
+
+    old_files = context.old_state.get("files") if isinstance(context.old_state.get("files"), dict) else {}
+    old_conversations = context.old_state.get("conversations") if isinstance(context.old_state.get("conversations"), dict) else {}
+    conversations: dict[str, dict[str, Any]] = {} if context.reset_baseline else {
+        str(key): dict(value)
+        for key, value in old_conversations.items()
+        if isinstance(value, dict)
+    }
+    conversations.update({str(key): dict(value) for key, value in context.current_conversations.items()})
+
+    current_files: dict[str, Any] = {} if context.reset_baseline else {
+        str(path): dict(meta)
+        for path, meta in old_files.items()
+        if normalize_relative_path(path) == str(path) and isinstance(meta, dict)
+    }
+    selected_old_managed: set[str] = set()
+    rendered_keys = {
+        key for key, state in context.current_conversations.items() if bool(state.get("rendered"))
+    }
+    append_keys = {
+        key for key, state in context.current_conversations.items()
+        if bool(state.get("rendered")) and bool(state.get("appendOnly"))
+    }
+    replaced_keys = rendered_keys - append_keys
+    for key in replaced_keys:
+        old = old_conversations.get(key) if isinstance(old_conversations.get(key), dict) else {}
+        selected_old_managed.update(
+            path
+            for raw in (old.get("managedFiles") or [])
+            if (path := normalize_relative_path(raw))
+        )
+    for path in selected_old_managed:
+        current_files.pop(path, None)
+
+    # 先撤销本轮重建会话对旧共享资源的引用；稍后再按新产物重新建立归属。
+    for path, meta in list(current_files.items()):
+        if not _is_owned_resource_path(path) or not isinstance(meta.get("owners"), list):
+            continue
+        meta["owners"] = sorted({str(owner) for owner in meta.get("owners") or []} - replaced_keys)
+
+    quiet_noop = bool(
+        context.old_state
+        and not context.reset_baseline
+        and not rendered_keys
+        and not context.repair_candidates
+        and not context.history_synced
+        and not context.missing_files
+        and not context.metadata_changed
+    )
+    preserve_dynamic_indexes = bool(
+        context.old_state
+        and not context.reset_baseline
+        and not rendered_keys
+        and not context.missing_files
+    )
+    staged_entries: list[dict[str, Any]] = []
+    staged_payloads: dict[str, bytes] = {}
+    new_managed: dict[str, set[str]] = {
+        key: {
+            path
+            for raw in (
+                (old_conversations.get(key) or {}).get("managedFiles")
+                if isinstance(old_conversations.get(key), dict)
+                else []
+            ) or []
+            if (path := normalize_relative_path(raw))
+        }
+        if key in append_keys
+        else set()
+        for key in rendered_keys
+    }
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        infos = _safe_archive_infos(archive)
+        owner_search_payloads: dict[str, list[bytes]] = {key: [] for key in rendered_keys}
+        for path, info in infos.items():
+            if not _is_conversation_path(path):
+                continue
+            owner = _conversation_owner(path, context.current_conversations)
+            if not owner or owner not in rendered_keys:
+                continue
+            payload = archive.read(info)
+            owner_search_payloads.setdefault(owner, []).append(_resource_search_payload(payload, path))
+
+        for path, info in infos.items():
+            if path in {"manifest.json", "report.json"} or path.startswith("_integrity/"):
+                continue
+            owner = _conversation_owner(path, context.current_conversations)
+            if _is_conversation_path(path):
+                if not owner or owner not in rendered_keys:
+                    continue
+                new_managed.setdefault(owner, set()).add(path)
+            payload = archive.read(info)
+            if _is_owned_resource_path(path):
+                path_bytes = path.encode("utf-8", errors="replace")
+                referenced_by = {
+                    key
+                    for key, search_payloads in owner_search_payloads.items()
+                    if any(path_bytes in search_payload for search_payload in search_payloads)
+                }
+                explicit_owners = (getattr(job, "options", {}) or {}).get("_folderResourceOwners") or {}
+                for username in explicit_owners.get(path, []) if isinstance(explicit_owners, dict) else []:
+                    key = conversation_key(salt=context.salt, username=str(username or ""))
+                    if key in rendered_keys:
+                        referenced_by.add(key)
+                previous_current = current_files.get(path) if isinstance(current_files.get(path), dict) else {}
+                owners = sorted(
+                    {
+                        str(value)
+                        for value in (previous_current.get("owners") or [])
+                        if str(value or "")
+                    }
+                    | referenced_by
+                )
+            else:
+                owners = [owner] if owner else []
+            meta = _file_meta(payload, owners=owners)
+            previous = old_files.get(path) if isinstance(old_files.get(path), dict) else {}
+            current_files[path] = meta
+            missing = path in context.missing_files
+            if preserve_dynamic_indexes and not missing and path in {"index.html", "index.xlsx"} and path in old_files:
+                current_files[path] = dict(previous)
+                continue
+            if (
+                not context.reset_baseline
+                and not missing
+                and str(previous.get("sha256") or "") == meta["sha256"]
+                and int(previous.get("size") or -1) == meta["size"]
+                and (
+                    context.target_root is None
+                    or (context.target_root / Path(*path.split("/"))).is_file()
+                )
+            ):
+                continue
+            staged_payloads[path] = payload
+
+    # 只有旧基线明确记录过归属的资源，才会在最后一个会话解除引用后被清理。
+    for path, meta in list(current_files.items()):
+        previous = old_files.get(path) if isinstance(old_files.get(path), dict) else {}
+        if (
+            _is_owned_resource_path(path)
+            and isinstance(previous.get("owners"), list)
+            and not list(meta.get("owners") or [])
+        ):
+            current_files.pop(path, None)
+            staged_payloads.pop(path, None)
+
+    for key in rendered_keys:
+        state = conversations.get(key) or {}
+        state["managedFiles"] = sorted(new_managed.get(key) or [])
+        conversations[key] = state
+
+    generated_at = datetime.now().isoformat(timespec="seconds")
+    unresolved_media = summarize_pending_media(conversations)
+    unresolved_conversations: list[dict[str, Any]] = []
+    for raw in context.unresolved_media_conversations:
+        key = str(raw.get("conversationKey") or "")
+        state = conversations.get(key) if isinstance(conversations.get(key), dict) else {}
+        pending = [
+            item
+            for item in normalize_pending_media(state.get("pendingMedia") or [])
+            if not bool(item.get("repairable"))
+        ]
+        if not pending:
+            continue
+        unresolved_conversations.append(
+            {
+                **dict(raw),
+                "uniqueCount": len(pending),
+                "referenceCount": sum(
+                    max(1, int(item.get("occurrenceCount") or 1)) for item in pending
+                ),
+            }
+        )
+    manifest = {
+        "schemaVersion": 1,
+        "artifactType": ARTIFACT_TYPE,
+        "account": "hidden" if context.privacy_mode else context.account,
+        "format": context.config.get("format"),
+        "folderName": context.folder_name,
+        "updatedAt": generated_at,
+        "stats": {
+            "conversations": len(conversations),
+            "repairPending": len(context.repair_candidates),
+            "unresolvedMedia": int(unresolved_media.get("uniqueCount") or 0),
+            "unresolvedMediaReferences": int(unresolved_media.get("referenceCount") or 0),
+        },
+    }
+    persisted_repairs = [dict(item) for item in context.repair_candidates]
+    persisted_history = [dict(item) for item in context.history_synced]
+    if context.privacy_mode:
+        for item in [*persisted_repairs, *persisted_history]:
+            item["username"] = ""
+            item["displayName"] = ""
+    report = {
+        "schemaVersion": 1,
+        "updatedAt": manifest["updatedAt"],
+        "repairCandidates": persisted_repairs,
+        "historyChangesSynced": persisted_history,
+        "unresolvedMedia": unresolved_media,
+    }
+    for path, payload in {
+        "manifest.json": json.dumps(manifest, ensure_ascii=False, indent=2).encode("utf-8"),
+        "report.json": json.dumps(report, ensure_ascii=False, indent=2).encode("utf-8"),
+    }.items():
+        if quiet_noop and path in old_files:
+            current_files[path] = dict(old_files[path])
+            continue
+        meta = _file_meta(payload)
+        previous = old_files.get(path) if isinstance(old_files.get(path), dict) else {}
+        current_files[path] = meta
+        if (
+            context.reset_baseline
+            or str(previous.get("sha256") or "") != meta["sha256"]
+            or int(previous.get("size") or -1) != meta["size"]
+            or context.target_root is None
+            or not (context.target_root / path).is_file()
+        ):
+            staged_payloads[path] = payload
+
+    old_managed = set(old_files)
+    stale = sorted(
+        path
+        for path in old_managed - set(current_files)
+        if normalize_relative_path(path) == path
+    )
+    # 全局运行时升级也属于真实变更，必须最后更新基线，避免下次重复迁移。
+    quiet_noop = quiet_noop and not staged_payloads and not stale
+
+    for path, payload in sorted(staged_payloads.items()):
+        staged_path = _write_staged_file(staging_dir, path, payload)
+        file_id = uuid.uuid4().hex
+        job.staged_files[file_id] = staged_path
+        meta = current_files[path]
+        staged_entries.append(
+            {
+                "fileId": file_id,
+                "path": path,
+                "size": int(meta.get("size") or 0),
+                "sha256": str(meta.get("sha256") or ""),
+            }
+        )
+
+    persisted_conversations: dict[str, dict[str, Any]] = {}
+    for key, value in conversations.items():
+        cleaned = {
+            field_name: field_value
+            for field_name, field_value in value.items()
+            if field_name not in {"rendered", "appendOnly", "newMessageCount"}
+        }
+        persisted_conversations[key] = cleaned
+
+    state = {
+        "schemaVersion": SCHEMA_VERSION,
+        "artifactType": ARTIFACT_TYPE,
+        "account": "" if context.privacy_mode else context.account,
+        "accountFingerprint": account_fingerprint(context.account),
+        "folderName": context.folder_name,
+        "runtimeId": context.export_runtime_id,
+        "conversationSalt": context.salt,
+        "config": context.config,
+        "configFingerprint": context.config_hash,
+        "updatedAt": (
+            str(context.old_state.get("updatedAt") or generated_at)
+            if quiet_noop
+            else generated_at
+        ),
+        "conversations": persisted_conversations,
+        "files": current_files,
+    }
+    state_bytes = json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8")
+    state_path = _write_staged_file(staging_dir, STATE_FILE_NAME, state_bytes)
+    state_file_id = uuid.uuid4().hex
+    job.staged_files[state_file_id] = state_path
+
+    updated_count = len(rendered_keys)
+    reused_count = max(0, len(context.selected_keys) - updated_count)
+    appended = sum(max(0, int(item.get("newMessageCount") or 0)) for item in context.current_conversations.values())
+    recovered_count = sum(1 for entry in staged_entries if str(entry.get("path") or "") in context.missing_files)
+    job.incremental = {
+        "messagesAdded": appended,
+        "conversationsUpdated": updated_count,
+        "conversationsReused": reused_count,
+        "conversationsRepairPending": len(context.repair_candidates),
+        "historyChangesSynced": len(context.history_synced),
+        "filesChanged": len(staged_entries),
+        "filesReused": max(0, len(current_files) - len(staged_entries)),
+        "filesRemoved": len(stale),
+        "filesRecovered": recovered_count,
+    }
+    job.repair_candidates = list(context.repair_candidates)
+    job.unresolved_media = {
+        **unresolved_media,
+        "conversations": unresolved_conversations,
+    }
+    job.change_manifest = {
+        "folderName": context.folder_name,
+        "files": staged_entries,
+        "stale": stale,
+        "state": {
+            "fileId": state_file_id,
+            "path": STATE_FILE_NAME,
+            "size": len(state_bytes),
+            "sha256": hashlib.sha256(state_bytes).hexdigest(),
+            "unchanged": quiet_noop,
+        },
+        "stats": dict(job.incremental),
+    }
+
+    if not context.desktop_output:
+        return staging_dir
+
+    target_root = context.target_root
+    if target_root is None:
+        raise ChatIncrementalError("incremental_target_missing", "增量目录不可用。")
+    target_root.mkdir(parents=True, exist_ok=True)
+    for entry in staged_entries:
+        source = job.staged_files[str(entry["fileId"])]
+        relative = normalize_relative_path(entry["path"])
+        destination = (target_root / Path(*relative.split("/"))).resolve()
+        if target_root not in destination.parents:
+            raise ChatIncrementalError("incremental_unsafe_path", "增量文件路径不安全。")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(source, destination)
+
+    # 只清理由旧基线明确管理、且本轮已经失效的文件。
+    for relative in stale:
+        destination = (target_root / Path(*relative.split("/"))).resolve()
+        if target_root not in destination.parents or not destination.is_file():
+            continue
+        destination.unlink(missing_ok=True)
+
+    state_destination = target_root / STATE_FILE_NAME
+    if not quiet_noop or not state_destination.is_file():
+        os.replace(state_path, state_destination)
+    job.folder_path = target_root
+    job.staged_files = {}
+    shutil.rmtree(staging_dir, ignore_errors=True)
+    job.staging_dir = None
+    return target_root
+
+
+__all__ = [
+    "ARTIFACT_TYPE",
+    "ChatFolderContext",
+    "ChatIncrementalError",
+    "SCHEMA_VERSION",
+    "STATE_FILE_NAME",
+    "account_fingerprint",
+    "allocate_conversation_directory",
+    "build_config",
+    "config_fingerprint",
+    "conversation_key",
+    "materialize_folder_archive",
+    "missing_conversation_keys",
+    "normalize_pending_media",
+    "normalize_relative_path",
+    "prepare_folder_context",
+    "privacy_account_token",
+    "summarize_pending_media",
+]

--- a/src/wechat_decrypt_tool/routers/chat_export.py
+++ b/src/wechat_decrypt_tool/routers/chat_export.py
@@ -1,13 +1,14 @@
 import asyncio
 import json
 import time
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel, Field, SecretStr
 
 from ..chat_export_service import CHAT_EXPORT_MANAGER, get_chat_export_targets_preview
+from ..chat_incremental_export import ChatIncrementalError
 from ..native_core_export import decode_export_content_key, erase_export_content_key
 from ..path_fix import PathFixRoute
 from ..voice_transcription import VoiceTranscriptionError, get_voice_transcription_service
@@ -16,6 +17,7 @@ router = APIRouter(route_class=PathFixRoute)
 
 ExportFormat = Literal["json", "txt", "html", "excel"]
 ExportScope = Literal["selected", "all", "groups", "singles"]
+ExportOutputMode = Literal["zip", "folder"]
 ChatSource = Literal["auto", "decrypted", "realtime"]
 MediaKind = Literal["image", "emoji", "video", "video_thumb", "voice", "file"]
 MessageType = Literal[
@@ -78,10 +80,25 @@ class ChatExportCreateRequest(BaseModel):
         description="WEC1 的 32 字节 Base64 内容密钥；仅 encrypt=true 时使用",
     )
     transcribe_voice: bool = Field(False, description="使用本地 Whisper 将语音消息转成中文并写入导出文件")
+    output_mode: ExportOutputMode = Field("zip", description="输出方式：zip=全量压缩包；folder=可持续更新目录")
+    folder_name: Optional[str] = Field(None, description="增量导出根目录名")
+    baseline: Optional[dict[str, Any]] = Field(None, description="浏览器端读取的上轮聊天增量基线")
+    missing_files: list[str] = Field(default_factory=list, description="浏览器端发现缺失的受管理文件")
+    reset_baseline: bool = Field(False, description="明确重置基线并完整重建")
+    repair_usernames: list[str] = Field(default_factory=list, description="需要重建的可恢复差异会话")
+    recheck_media: bool = Field(False, description="明确重新探测待补媒体；不会把源端不可用项当成可修复差异")
 
 
-@router.post("/api/chat/exports", summary="创建聊天记录导出任务（离线 zip）")
+@router.post("/api/chat/exports", summary="创建聊天记录导出任务（ZIP 全量或增量目录）")
 async def create_chat_export(req: ChatExportCreateRequest):
+    if req.baseline is not None:
+        baseline_size = len(json.dumps(req.baseline, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+        if baseline_size > 128 * 1024 * 1024:
+            raise HTTPException(status_code=413, detail={"code": "incremental_baseline_too_large", "message": "增量基线过大。"})
+    if len(req.missing_files) > 100_000:
+        raise HTTPException(status_code=413, detail={"code": "incremental_missing_files_too_many", "message": "缺失文件清单过大。"})
+    if req.output_mode == "folder" and req.encrypt:
+        raise HTTPException(status_code=400, detail={"code": "incremental_encryption_unsupported", "message": "增量目录不支持整包加密，请使用 ZIP 全量导出。"})
     if req.transcribe_voice and not req.privacy_mode:
         try:
             await asyncio.to_thread(get_voice_transcription_service().ensure_available)
@@ -120,7 +137,17 @@ async def create_chat_export(req: ChatExportCreateRequest):
             encrypt=bool(req.encrypt),
             content_key=content_key,
             transcribe_voice=req.transcribe_voice,
+            output_mode=req.output_mode,
+            folder_name=req.folder_name,
+            baseline=req.baseline,
+            missing_files=req.missing_files,
+            reset_baseline=bool(req.reset_baseline),
+            repair_usernames=req.repair_usernames,
+            recheck_media=bool(req.recheck_media),
         )
+    except ChatIncrementalError as e:
+        erase_export_content_key(content_key)
+        raise HTTPException(status_code=409, detail={"code": e.code, "message": str(e)}) from e
     except ValueError as e:
         erase_export_content_key(content_key)
         raise HTTPException(status_code=400, detail=str(e))
@@ -178,6 +205,34 @@ async def download_chat_export(export_id: str):
         media_type="application/octet-stream" if job.zip_path.suffix.lower() == ".wec" else "application/zip",
         filename=job.zip_path.name,
     )
+
+
+@router.get("/api/chat/exports/{export_id}/files", summary="获取聊天增量目录变化文件清单")
+async def list_chat_export_files(export_id: str):
+    job = CHAT_EXPORT_MANAGER.get_job(str(export_id or "").strip())
+    if not job:
+        raise HTTPException(status_code=404, detail="Export not found.")
+    if job.status != "done" or not job.change_manifest or not job.staged_files:
+        raise HTTPException(status_code=409, detail="Incremental export not ready.")
+    return {"status": "success", "manifest": job.change_manifest}
+
+
+@router.get("/api/chat/exports/{export_id}/files/{file_id}", summary="下载单个聊天增量变化文件")
+async def download_chat_export_file(export_id: str, file_id: str):
+    path = CHAT_EXPORT_MANAGER.get_staged_file(
+        str(export_id or "").strip(),
+        str(file_id or "").strip(),
+    )
+    if path is None:
+        raise HTTPException(status_code=404, detail="Export file not found.")
+    return FileResponse(str(path), media_type="application/octet-stream", filename=path.name)
+
+
+@router.post("/api/chat/exports/{export_id}/commit", summary="确认浏览器已完成聊天增量目录写入")
+async def commit_chat_export_files(export_id: str):
+    if not CHAT_EXPORT_MANAGER.commit_staged_files(str(export_id or "").strip()):
+        raise HTTPException(status_code=404, detail="Export not found.")
+    return {"status": "success"}
 
 
 @router.get("/api/chat/exports/{export_id}/events", summary="导出任务进度 SSE")

--- a/tests/test_chat_export_panel_frontend.py
+++ b/tests/test_chat_export_panel_frontend.py
@@ -33,6 +33,55 @@ class TestChatExportPanelFrontend(unittest.TestCase):
         self.assertIn("min-width: 88px", dialog)
         self.assertIn("white-space: nowrap", dialog)
 
+    def test_incremental_folder_mode_keeps_zip_as_default_and_writes_baseline_last(self):
+        dialog = (ROOT / "frontend" / "components" / "chat" / "ChatExportDialog.vue").read_text(encoding="utf-8")
+        export_state = (ROOT / "frontend" / "composables" / "chat" / "useChatExport.js").read_text(encoding="utf-8")
+        api_state = (ROOT / "frontend" / "composables" / "useApi.js").read_text(encoding="utf-8")
+
+        self.assertIn("const exportOutputMode = ref('zip')", export_state)
+        self.assertIn("ZIP 全量", dialog)
+        self.assertIn("增量目录", dialog)
+        self.assertIn("output_mode: exportOutputMode.value", export_state)
+        self.assertIn("folder_name:", export_state)
+        self.assertIn("repair_usernames:", export_state)
+        self.assertIn("recheck_media:", export_state)
+        self.assertIn("重新探测缺失媒体", dialog)
+        self.assertIn("修复可恢复差异", dialog)
+        self.assertIn("微信聊天记录_隐私_${privacyAccountToken(account)}", export_state)
+        self.assertIn("output_mode: data.output_mode === 'folder' ? 'folder' : 'zip'", api_state)
+        self.assertIn("baseline: data.baseline && typeof data.baseline === 'object'", api_state)
+        self.assertIn("repair_usernames: Array.isArray(data.repair_usernames)", api_state)
+        self.assertIn("recheck_media: !!data.recheck_media", api_state)
+        file_loop = export_state.index("for (const entry of files)")
+        stale_loop = export_state.index("for (const stalePath")
+        state_write = export_state.index("writeResponseToBrowserFile(root, CHAT_EXPORT_BASELINE_FILE")
+        commit = export_state.index("/commit`, { method: 'POST' }")
+        self.assertLess(file_loop, stale_loop)
+        self.assertLess(stale_loop, state_write)
+        self.assertLess(state_write, commit)
+
+    def test_incremental_result_separates_success_repair_and_unavailable_media(self):
+        dialog = (ROOT / "frontend" / "components" / "chat" / "ChatExportDialog.vue").read_text(encoding="utf-8")
+
+        summary = dialog.index('class="chat-export-folder-result__summary"')
+        followups = dialog.index('class="chat-export-folder-result__followups"')
+        details = dialog.index('class="chat-export-folder-result__details"')
+        self.assertLess(summary, followups)
+        self.assertLess(followups, details)
+        self.assertIn("已确认修复会产生变化，仅重建对应会话。", dialog)
+        self.assertIn("源端暂不可用，重复修复不会改变结果。", dialog)
+        self.assertIn("查看完整任务说明", dialog)
+
+    def test_incremental_baseline_card_uses_compact_status_and_custom_checkbox(self):
+        dialog = (ROOT / "frontend" / "components" / "chat" / "ChatExportDialog.vue").read_text(encoding="utf-8")
+
+        self.assertIn('class="chat-export-incremental-card__folder"', dialog)
+        self.assertIn('class="chat-export-baseline-status"', dialog)
+        self.assertIn(':data-status="exportBaselineStatus"', dialog)
+        self.assertIn("auto: '自动检查基线'", dialog)
+        self.assertIn('type="checkbox" class="sr-only"', dialog)
+        self.assertIn(".chat-export-reset-option:focus-within", dialog)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_chat_incremental_export.py
+++ b/tests/test_chat_incremental_export.py
@@ -1,0 +1,1295 @@
+import hashlib
+import io
+import json
+import os
+import sqlite3
+import threading
+import time
+import unittest
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from test_chat_export_message_types_semantics import TestChatExportMessageTypesSemantics as _BaseChatExportTest
+
+
+class TestChatIncrementalExport(unittest.TestCase):
+    _prepare_account = _BaseChatExportTest._prepare_account
+    _reload_export_modules = _BaseChatExportTest._reload_export_modules
+    _seed_contact_db = _BaseChatExportTest._seed_contact_db
+    _seed_session_db = _BaseChatExportTest._seed_session_db
+    _seed_message_db = _BaseChatExportTest._seed_message_db
+    _seed_media_files = _BaseChatExportTest._seed_media_files
+    _seed_wxid_media_files = _BaseChatExportTest._seed_wxid_media_files
+    _seed_source_info = _BaseChatExportTest._seed_source_info
+
+    def _wait_for_job(self, manager, export_id: str):
+        for _ in range(400):
+            job = manager.get_job(export_id)
+            if job and job.status in {"done", "error", "cancelled"}:
+                return job
+            time.sleep(0.05)
+        self.fail("incremental export job did not finish in time")
+
+    def _create_folder_job(
+        self,
+        manager,
+        *,
+        account: str,
+        username: str | None = None,
+        usernames=None,
+        output_dir: Path,
+        export_format: str = "json",
+        privacy_mode: bool = False,
+        reset_baseline: bool = False,
+        repair_usernames=None,
+        message_types=None,
+        include_media: bool = False,
+        missing_files=None,
+        baseline=None,
+    ):
+        selected_usernames = list(usernames or ([username] if username else []))
+        job = manager.create_job(
+            account=account,
+            source="decrypted",
+            scope="selected",
+            usernames=selected_usernames,
+            export_format=export_format,
+            start_time=None,
+            end_time=None,
+            include_hidden=False,
+            include_official=False,
+            include_media=include_media,
+            media_kinds=["image", "emoji", "video", "video_thumb", "voice", "file"] if include_media else [],
+            message_types=list(message_types or ["text"]),
+            output_dir=str(output_dir) if output_dir is not None else None,
+            allow_process_key_extract=False,
+            download_remote_media=False,
+            html_page_size=1000,
+            privacy_mode=privacy_mode,
+            file_name=None,
+            output_mode="folder",
+            folder_name="聊天增量测试",
+            reset_baseline=reset_baseline,
+            repair_usernames=list(repair_usernames or []),
+            missing_files=list(missing_files or []),
+            baseline=baseline,
+        )
+        return self._wait_for_job(manager, job.export_id)
+
+    @staticmethod
+    def _message_table(username: str) -> str:
+        return f"msg_{hashlib.md5(username.encode('utf-8')).hexdigest()}"
+
+    def _add_conversation(self, account_dir: Path, *, username: str, display_name: str, local_id: int = 20) -> None:
+        connection = sqlite3.connect(str(account_dir / "contact.db"))
+        try:
+            connection.execute(
+                "INSERT INTO contact VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (username, "", display_name, "", 1, 0, "", ""),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        connection = sqlite3.connect(str(account_dir / "session.db"))
+        try:
+            connection.execute("INSERT INTO SessionTable VALUES (?, ?, ?)", (username, 0, 1735689700))
+            connection.commit()
+        finally:
+            connection.close()
+
+        table = self._message_table(username)
+        connection = sqlite3.connect(str(account_dir / "message_0.db"))
+        try:
+            connection.execute("INSERT INTO Name2Id(rowid, user_name) VALUES (?, ?)", (local_id, username))
+            connection.execute(
+                f"""
+                CREATE TABLE {table} (
+                    local_id INTEGER,
+                    server_id INTEGER,
+                    local_type INTEGER,
+                    sort_seq INTEGER,
+                    real_sender_id INTEGER,
+                    create_time INTEGER,
+                    message_content TEXT,
+                    compress_content BLOB
+                )
+                """
+            )
+            connection.execute(
+                f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (1, 2001, 1, 1, local_id, 1735689701, f"{display_name}的文本", None),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _managed_message_file(folder: Path, suffix: str) -> Path:
+        matches = list((folder / "conversations").glob(f"*/messages.{suffix}"))
+        assert len(matches) == 1
+        return matches[0]
+
+    def test_unavailable_pending_media_is_deduplicated_without_repair_prompt(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_pending_account"
+            username = "wxid_pending_friend"
+            self._prepare_account(root, account=account, username=username)
+            output_dir = root / "exports"
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                state_path = first.folder_path / ".wechat-chat-export.json"
+                baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                conversation = next(iter(baseline["conversations"].values()))
+                missing_id = "f" * 32
+                conversation["pendingMedia"] = [
+                    {"kind": "emoji", "id": missing_id, "messageId": "1"},
+                    {"kind": "emoji", "id": missing_id, "messageId": "2"},
+                    {"kind": "emoji", "id": missing_id, "messageId": "3"},
+                ]
+                state_path.write_text(json.dumps(baseline, ensure_ascii=False, indent=2), encoding="utf-8")
+
+                checked = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(checked.status, "done", msg=checked.error)
+                self.assertFalse(checked.repair_candidates)
+                self.assertEqual(checked.unresolved_media.get("uniqueCount"), 1)
+                self.assertEqual(checked.unresolved_media.get("referenceCount"), 3)
+                self.assertIn("重复修复不会产生变化", checked.warning)
+
+                migrated = json.loads(state_path.read_text(encoding="utf-8"))
+                pending = next(iter(migrated["conversations"].values()))["pendingMedia"]
+                self.assertEqual(len(pending), 1)
+                self.assertEqual(pending[0].get("occurrenceCount"), 3)
+                self.assertEqual(pending[0].get("state"), "source_unavailable")
+                self.assertFalse(pending[0].get("repairable"))
+
+                before_repeat = (state_path.stat().st_mtime_ns, state_path.read_bytes())
+                repeated = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(repeated.status, "done", msg=repeated.error)
+                self.assertFalse(repeated.repair_candidates)
+                self.assertEqual(repeated.unresolved_media.get("uniqueCount"), 1)
+                self.assertEqual((state_path.stat().st_mtime_ns, state_path.read_bytes()), before_repeat)
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_html_direct_emoji_uses_remote_download_before_marking_missing(self):
+        with TemporaryDirectory() as td:
+            account_dir = Path(td) / "wxid_remote_emoji"
+            account_dir.mkdir(parents=True)
+            service = self._reload_export_modules()
+            job = service.ExportJob(
+                export_id="remote-emoji",
+                account=account_dir.name,
+                options={"outputMode": "folder", "downloadRemoteMedia": True},
+            )
+            message = {
+                "id": "1",
+                "renderType": "emoji",
+                "emojiMd5": "f" * 32,
+                "emojiUrl": "https://example.com/emoji.png",
+            }
+            report = {"missingMedia": [], "errors": []}
+            with io.BytesIO() as buffer, zipfile.ZipFile(buffer, "w") as archive:
+                with mock.patch.object(
+                    service,
+                    "_download_remote_image_to_zip",
+                    return_value="media/remote/emoji.png",
+                ) as downloader:
+                    service._attach_offline_media(
+                        zf=archive,
+                        account_dir=account_dir,
+                        conv_username="wxid_friend",
+                        owner_username="wxid_friend",
+                        msg=message,
+                        media_written={},
+                        report=report,
+                        media_kinds=["emoji"],
+                        allow_process_key_extract=False,
+                        media_db_path=account_dir / "media.db",
+                        media_index=None,
+                        remote_written={},
+                        lock=threading.Lock(),
+                        job=job,
+                    )
+            downloader.assert_called_once()
+            self.assertEqual(message["offlineMedia"][0]["path"], "media/remote/emoji.png")
+            self.assertEqual(job.progress.media_copied, 1)
+            self.assertEqual(job.progress.media_missing, 0)
+            self.assertFalse(report["missingMedia"])
+
+    def test_repair_prompt_only_appears_after_pending_media_becomes_recoverable(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_recoverable_account"
+            username = "wxid_recoverable_friend"
+            self._prepare_account(root, account=account, username=username)
+            output_dir = root / "exports"
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    include_media=True,
+                    message_types=["text", "image"],
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                state_path = first.folder_path / ".wechat-chat-export.json"
+                baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                conversation = next(iter(baseline["conversations"].values()))
+                conversation["pendingMedia"] = [
+                    {"kind": "image", "id": "a" * 32, "messageId": "2"},
+                ]
+                state_path.write_text(json.dumps(baseline, ensure_ascii=False, indent=2), encoding="utf-8")
+
+                checked = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    include_media=True,
+                    message_types=["text", "image"],
+                )
+                self.assertEqual(checked.status, "done", msg=checked.error)
+                self.assertEqual(len(checked.repair_candidates), 1)
+                self.assertEqual(checked.repair_candidates[0].get("reasons"), ["media_recoverable"])
+                self.assertEqual(checked.unresolved_media.get("uniqueCount"), 0)
+
+                repaired = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    include_media=True,
+                    message_types=["text", "image"],
+                    repair_usernames=[username],
+                )
+                self.assertEqual(repaired.status, "done", msg=repaired.error)
+                self.assertFalse(repaired.repair_candidates)
+                repaired_state = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertFalse(next(iter(repaired_state["conversations"].values()))["pendingMedia"])
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_folder_missing_progress_is_unique_but_zip_keeps_legacy_reference_count(self):
+        with TemporaryDirectory() as td:
+            account_dir = Path(td) / "wxid_missing_counts"
+            account_dir.mkdir(parents=True)
+            service = self._reload_export_modules()
+            for output_mode, expected_missing in (("folder", 1), ("zip", 2)):
+                with self.subTest(output_mode=output_mode):
+                    job = service.ExportJob(
+                        export_id=f"missing-{output_mode}",
+                        account=account_dir.name,
+                        options={"outputMode": output_mode, "downloadRemoteMedia": False},
+                    )
+                    report = {"missingMedia": [], "errors": []}
+                    media_written = {}
+                    with io.BytesIO() as buffer, zipfile.ZipFile(buffer, "w") as archive:
+                        for message_id in ("1", "2"):
+                            service._attach_offline_media(
+                                zf=archive,
+                                account_dir=account_dir,
+                                conv_username="wxid_friend",
+                                owner_username="wxid_friend",
+                                msg={
+                                    "id": message_id,
+                                    "renderType": "emoji",
+                                    "emojiMd5": "f" * 32,
+                                },
+                                media_written=media_written,
+                                report=report,
+                                media_kinds=["emoji"],
+                                allow_process_key_extract=False,
+                                media_db_path=account_dir / "media.db",
+                                media_index=None,
+                                lock=threading.Lock(),
+                                job=job,
+                            )
+                    self.assertEqual(job.progress.media_missing, expected_missing)
+                    self.assertEqual(job.progress.media_missing_references, 2)
+                    self.assertEqual(len(report["missingMedia"]), 2)
+
+    def test_first_run_and_no_change_reuse_all_formats(self):
+        for export_format, suffix in (("html", "html"), ("json", "json"), ("txt", "txt"), ("excel", "xlsx")):
+            with self.subTest(export_format=export_format), TemporaryDirectory() as td:
+                root = Path(td)
+                account = "wxid_incremental"
+                username = "wxid_friend"
+                self._prepare_account(root, account=account, username=username)
+                output_dir = root / "exports"
+
+                previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+                try:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                    service = self._reload_export_modules()
+                    first = self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=output_dir,
+                        export_format=export_format,
+                    )
+                    self.assertEqual(first.status, "done", msg=first.error)
+                    folder = output_dir / "聊天增量测试"
+                    message_file = self._managed_message_file(folder, suffix)
+                    before = (message_file.stat().st_mtime_ns, message_file.read_bytes())
+
+                    second = self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=output_dir,
+                        export_format=export_format,
+                    )
+                    self.assertEqual(second.status, "done", msg=second.error)
+                    after = (message_file.stat().st_mtime_ns, message_file.read_bytes())
+                    self.assertEqual(before, after)
+                    self.assertEqual(second.incremental.get("filesChanged"), 0)
+                    self.assertEqual(second.incremental.get("conversationsUpdated"), 0)
+                    self.assertEqual(second.incremental.get("conversationsReused"), 1)
+
+                    if export_format == "json":
+                        json.loads(message_file.read_text(encoding="utf-8"))
+                    elif export_format == "txt":
+                        message_file.read_text(encoding="utf-8")
+                    elif export_format == "excel":
+                        import zipfile
+
+                        self.assertTrue(zipfile.is_zipfile(message_file))
+                    else:
+                        html_text = message_file.read_text(encoding="utf-8").lower()
+                        self.assertIn("<!doctype html>", html_text)
+                        self.assertNotIn("data-wce-sri", html_text)
+                        self.assertTrue((folder / "assets" / "chat-export.css").is_file())
+                        self.assertTrue((folder / "assets" / "chat-export.js").is_file())
+                        self.assertFalse((folder / "_integrity").exists())
+                finally:
+                    if previous is None:
+                        os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                    else:
+                        os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_html_folder_runtime_disables_zip_integrity_and_migrates_old_asset(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            username = "wxid_friend"
+            self._prepare_account(root, account=account, username=username)
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    export_format="html",
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                folder = output_dir / "聊天增量测试"
+                runtime_path = folder / "assets" / "chat-export.js"
+                folder_runtime = runtime_path.read_text(encoding="utf-8")
+                self.assertIn("data-wce-folder-mode", folder_runtime)
+                self.assertIn("window.__WCE_VERIFY_FRAGMENT__ = () => true", folder_runtime)
+                self.assertNotIn("const integrityOk = await initExportIntegrity()", folder_runtime)
+
+                html_files = [folder / "index.html", self._managed_message_file(folder, "html")]
+                for html_file in html_files:
+                    html_text = html_file.read_text(encoding="utf-8")
+                    self.assertNotIn("data-wce-sri", html_text)
+                    self.assertNotIn("data-wce-integrity-bundle", html_text)
+                message_before = (html_files[1].stat().st_mtime_ns, html_files[1].read_bytes())
+
+                # 模拟已经导出的旧版目录：文件存在且基线摘要也匹配，但运行时仍会阻断目录页。
+                old_runtime = service._html_export_runtime_js(service._load_wce_integrity_native())
+                old_runtime_bytes = old_runtime.encode("utf-8")
+                runtime_path.write_bytes(old_runtime_bytes)
+                state_path = folder / ".wechat-chat-export.json"
+                baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                baseline["files"]["assets/chat-export.js"] = {
+                    "sha256": hashlib.sha256(old_runtime_bytes).hexdigest(),
+                    "size": len(old_runtime_bytes),
+                }
+                state_path.write_text(
+                    json.dumps(baseline, ensure_ascii=False, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+
+                migrated = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    export_format="html",
+                )
+                self.assertEqual(migrated.status, "done", msg=migrated.error)
+                self.assertEqual(runtime_path.read_text(encoding="utf-8"), folder_runtime)
+                self.assertEqual((html_files[1].stat().st_mtime_ns, html_files[1].read_bytes()), message_before)
+                self.assertEqual(migrated.incremental.get("filesChanged"), 1)
+                migrated_baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    migrated_baseline["files"]["assets/chat-export.js"]["sha256"],
+                    hashlib.sha256(runtime_path.read_bytes()).hexdigest(),
+                )
+
+                no_change = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    export_format="html",
+                )
+                self.assertEqual(no_change.status, "done", msg=no_change.error)
+                self.assertEqual(no_change.incremental.get("filesChanged"), 0)
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_html_folder_uses_one_shared_session_catalog_across_incremental_pages(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            first_username = "wxid_friend"
+            second_username = "wxid_second_friend"
+            account_dir = self._prepare_account(root, account=account, username=first_username)
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=first_username,
+                    output_dir=output_dir,
+                    export_format="html",
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                folder = output_dir / "聊天增量测试"
+                first_page = self._managed_message_file(folder, "html")
+
+                # 模拟旧版增量页：聊天正文仍受基线管理，但页面本身还没有公共目录脚本标签。
+                legacy_text = first_page.read_text(encoding="utf-8").replace(
+                    '  <script defer src="../../assets/chat-sessions.js" data-wce-folder-sessions="1"></script>\n',
+                    "",
+                )
+                self.assertNotIn("data-wce-folder-sessions", legacy_text)
+                first_page.write_text(legacy_text, encoding="utf-8")
+                state_path = folder / ".wechat-chat-export.json"
+                baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                first_page_relative = first_page.relative_to(folder).as_posix()
+                first_page_bytes = first_page.read_bytes()
+                baseline["files"][first_page_relative] = {
+                    "sha256": hashlib.sha256(first_page_bytes).hexdigest(),
+                    "size": len(first_page_bytes),
+                }
+                state_path.write_text(
+                    json.dumps(baseline, ensure_ascii=False, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                legacy_before = (first_page.stat().st_mtime_ns, first_page_bytes)
+
+                self._add_conversation(
+                    account_dir,
+                    username=second_username,
+                    display_name="第二个联系人",
+                )
+                updated = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=second_username,
+                    output_dir=output_dir,
+                    export_format="html",
+                )
+                self.assertEqual(updated.status, "done", msg=updated.error)
+                self.assertEqual((first_page.stat().st_mtime_ns, first_page.read_bytes()), legacy_before)
+
+                catalog_path = folder / "assets" / "chat-sessions.js"
+                catalog_text = catalog_path.read_text(encoding="utf-8")
+                prefix = "window.__WCE_FOLDER_SESSIONS__="
+                self.assertTrue(catalog_text.startswith(prefix))
+                catalog = json.loads(catalog_text[len(prefix):].rstrip(";\r\n"))
+                self.assertEqual(len(catalog.get("items") or []), 2)
+                catalog_directories = {
+                    str(item.get("convDir") or "")
+                    for item in catalog.get("items") or []
+                }
+                current_baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    catalog_directories,
+                    {
+                        str(value.get("directory") or "")
+                        for value in current_baseline.get("conversations", {}).values()
+                    },
+                )
+
+                runtime_text = (folder / "assets" / "chat-export.js").read_text(encoding="utf-8")
+                self.assertIn("loadFolderSessionCatalog", runtime_text)
+                self.assertIn("syncFolderSessionCatalog", runtime_text)
+                self.assertIn("new URL('chat-sessions.js', wceFolderRuntimeSrc)", runtime_text)
+
+                second_page = next(
+                    page
+                    for page in (folder / "conversations").glob("*/messages.html")
+                    if page != first_page
+                )
+                self.assertIn("data-wce-folder-sessions", second_page.read_text(encoding="utf-8"))
+
+                no_change = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=second_username,
+                    output_dir=output_dir,
+                    export_format="html",
+                )
+                self.assertEqual(no_change.status, "done", msg=no_change.error)
+                self.assertEqual(no_change.incremental.get("filesChanged"), 0)
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_html_folder_shared_session_catalog_respects_privacy_mode(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_private_account"
+            username = "wxid_private_friend"
+            self._prepare_account(root, account=account, username=username)
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                job = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    export_format="html",
+                    privacy_mode=True,
+                )
+                self.assertEqual(job.status, "done", msg=job.error)
+                catalog_text = (job.folder_path / "assets" / "chat-sessions.js").read_text(encoding="utf-8")
+                self.assertNotIn(account, catalog_text)
+                self.assertNotIn(username, catalog_text)
+                self.assertNotIn("测试好友", catalog_text)
+                self.assertNotIn("普通文本消息", catalog_text)
+                catalog = json.loads(
+                    catalog_text.removeprefix("window.__WCE_FOLDER_SESSIONS__=").rstrip(";\r\n")
+                )
+                self.assertEqual(len(catalog.get("items") or []), 1)
+                item = catalog["items"][0]
+                self.assertEqual(item.get("username"), "")
+                self.assertEqual(item.get("avatarPath"), "")
+                self.assertEqual(item.get("previewText"), "")
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_html_existing_conversation_reads_and_renders_only_new_messages(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            username = "wxid_friend"
+            account_dir = self._prepare_account(root, account=account, username=username)
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    export_format="html",
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                folder = output_dir / "聊天增量测试"
+                message_file = self._managed_message_file(folder, "html")
+                self.assertIn("普通文本消息", message_file.read_text(encoding="utf-8"))
+                first_baseline = json.loads((folder / ".wechat-chat-export.json").read_text(encoding="utf-8"))
+                first_conversation = next(iter(first_baseline["conversations"].values()))
+                first_watermark_time = int(first_conversation["watermark"][0])
+
+                table = self._message_table(username)
+                connection = sqlite3.connect(str(account_dir / "message_0.db"))
+                try:
+                    connection.execute(
+                        f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        (8, 1008, 1, 8, 2, 1735689608, "只渲染这一条增量消息", None),
+                    )
+                    connection.commit()
+                finally:
+                    connection.close()
+
+                original_full_probe = service._probe_incremental_conversation
+                original_estimator = service._estimate_conversation_message_count
+                estimate_start_times = []
+
+                def reject_full_probe(**_kwargs):
+                    raise AssertionError("已有分页会话不应重新扫描完整历史")
+
+                def track_incremental_estimate(**kwargs):
+                    estimate_start_times.append(kwargs.get("start_time"))
+                    return original_estimator(**kwargs)
+
+                service._probe_incremental_conversation = reject_full_probe
+                service._estimate_conversation_message_count = track_incremental_estimate
+                try:
+                    appended = self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=output_dir,
+                        export_format="html",
+                    )
+                    self.assertEqual(appended.status, "done", msg=appended.error)
+                    self.assertEqual(appended.incremental.get("messagesAdded"), 1)
+                    self.assertEqual(appended.progress.messages_exported, 1)
+                    self.assertEqual(appended.progress.current_conversation_messages_total, 1)
+                    self.assertTrue(estimate_start_times)
+                    self.assertEqual(estimate_start_times[0], first_watermark_time)
+
+                    current_html = message_file.read_text(encoding="utf-8")
+                    self.assertIn("只渲染这一条增量消息", current_html)
+                    self.assertNotIn("普通文本消息", current_html)
+                    page_file = message_file.parent / "pages" / "page-0001.js"
+                    self.assertTrue(page_file.is_file())
+                    self.assertIn("普通文本消息", page_file.read_text(encoding="utf-8"))
+                    self.assertIn('"totalPages": 2', current_html)
+
+                    before_noop = (message_file.stat().st_mtime_ns, message_file.read_bytes())
+                    no_change = self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=output_dir,
+                        export_format="html",
+                    )
+                    self.assertEqual(no_change.status, "done", msg=no_change.error)
+                    self.assertEqual(no_change.incremental.get("filesChanged"), 0)
+                    self.assertEqual((message_file.stat().st_mtime_ns, message_file.read_bytes()), before_noop)
+                finally:
+                    service._probe_incremental_conversation = original_full_probe
+                    service._estimate_conversation_message_count = original_estimator
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_new_message_then_history_repair(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            username = "wxid_friend"
+            account_dir = self._prepare_account(root, account=account, username=username)
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                message_file = self._managed_message_file(output_dir / "聊天增量测试", "json")
+
+                table = self._message_table(username)
+                connection = sqlite3.connect(str(account_dir / "message_0.db"))
+                try:
+                    connection.execute(
+                        f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        (8, 1008, 1, 8, 2, 1735689608, "增量新增消息", None),
+                    )
+                    connection.commit()
+                finally:
+                    connection.close()
+
+                appended = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(appended.status, "done", msg=appended.error)
+                self.assertEqual(appended.incremental.get("messagesAdded"), 1)
+                payload = json.loads(message_file.read_text(encoding="utf-8"))
+                contents = [str(item.get("content") or "") for item in payload.get("messages", [])]
+                self.assertEqual(contents.count("增量新增消息"), 1)
+
+                before_repair = message_file.read_bytes()
+                connection = sqlite3.connect(str(account_dir / "message_0.db"))
+                try:
+                    connection.execute(
+                        f"UPDATE {table} SET message_content = ? WHERE local_id = 4",
+                        ("历史消息已修改",),
+                    )
+                    connection.commit()
+                finally:
+                    connection.close()
+
+                detected = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(detected.status, "done", msg=detected.error)
+                self.assertEqual(message_file.read_bytes(), before_repair)
+                self.assertEqual(len(detected.repair_candidates), 1)
+
+                repaired = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    repair_usernames=[username],
+                )
+                self.assertEqual(repaired.status, "done", msg=repaired.error)
+                payload = json.loads(message_file.read_text(encoding="utf-8"))
+                contents = [str(item.get("content") or "") for item in payload.get("messages", [])]
+                self.assertIn("历史消息已修改", contents)
+
+                connection = sqlite3.connect(str(account_dir / "message_0.db"))
+                try:
+                    connection.execute(
+                        f"UPDATE {table} SET message_content = ? WHERE local_id = 4",
+                        ("历史消息再次修改",),
+                    )
+                    connection.execute(
+                        f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        (9, 1009, 1, 9, 2, 1735689609, "历史变化并存的新消息", None),
+                    )
+                    connection.commit()
+                finally:
+                    connection.close()
+                synchronized = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(synchronized.status, "done", msg=synchronized.error)
+                self.assertEqual(synchronized.incremental.get("messagesAdded"), 1)
+                self.assertEqual(synchronized.incremental.get("historyChangesSynced"), 1)
+                self.assertFalse(synchronized.repair_candidates)
+                payload = json.loads(message_file.read_text(encoding="utf-8"))
+                contents = [str(item.get("content") or "") for item in payload.get("messages", [])]
+                self.assertIn("历史消息再次修改", contents)
+                self.assertEqual(contents.count("历史变化并存的新消息"), 1)
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+    def test_config_conflict_and_privacy_baseline(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_private_account"
+            username = "wxid_private_friend"
+            self._prepare_account(root, account=account, username=username)
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    privacy_mode=True,
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                baseline_text = (first.folder_path / ".wechat-chat-export.json").read_text(encoding="utf-8")
+                self.assertNotIn(account, baseline_text)
+                self.assertNotIn(username, baseline_text)
+                self.assertNotIn("测试好友", baseline_text)
+                self.assertNotIn("普通文本消息", baseline_text)
+                user_file = first.folder_path / "用户保留文件.txt"
+                user_file.write_text("不要删除", encoding="utf-8")
+
+                with self.assertRaises(service.ChatIncrementalError) as captured:
+                    self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=output_dir,
+                        privacy_mode=True,
+                        message_types=["text", "system"],
+                    )
+                self.assertEqual(captured.exception.code, "incremental_config_mismatch")
+                rebuilt = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=output_dir,
+                    privacy_mode=True,
+                    message_types=["text", "system"],
+                    reset_baseline=True,
+                )
+                self.assertEqual(rebuilt.status, "done", msg=rebuilt.error)
+                self.assertEqual(user_file.read_text(encoding="utf-8"), "不要删除")
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_unselected_conversation_is_preserved_and_missing_file_is_restored(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            first_username = "wxid_friend"
+            second_username = "wxid_friend_two"
+            account_dir = self._prepare_account(root, account=account, username=first_username)
+            self._add_conversation(account_dir, username=second_username, display_name="第二位好友")
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    usernames=[first_username, second_username],
+                    output_dir=output_dir,
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                folder = output_dir / "聊天增量测试"
+                baseline = json.loads((folder / ".wechat-chat-export.json").read_text(encoding="utf-8"))
+                self.assertEqual(len(baseline["conversations"]), 2)
+                with self.assertRaises(service.ChatIncrementalError) as incomplete_reset:
+                    self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=first_username,
+                        output_dir=output_dir,
+                        reset_baseline=True,
+                    )
+                self.assertEqual(incomplete_reset.exception.code, "incremental_reset_incomplete")
+
+                second_state = next(
+                    state
+                    for state in baseline["conversations"].values()
+                    if state.get("displayName") == "第二位好友"
+                )
+                second_message = folder / Path(second_state["directory"]) / "messages.json"
+                second_before = (second_message.stat().st_mtime_ns, second_message.read_bytes())
+                user_file = folder / "我的说明.txt"
+                user_file.write_text("不能删除", encoding="utf-8")
+
+                table = self._message_table(first_username)
+                connection = sqlite3.connect(str(account_dir / "message_0.db"))
+                try:
+                    connection.execute(
+                        f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        (8, 1008, 1, 8, 2, 1735689800, "只更新第一个会话", None),
+                    )
+                    connection.commit()
+                finally:
+                    connection.close()
+
+                updated = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=first_username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(updated.status, "done", msg=updated.error)
+                self.assertEqual((second_message.stat().st_mtime_ns, second_message.read_bytes()), second_before)
+                self.assertEqual(user_file.read_text(encoding="utf-8"), "不能删除")
+
+                current_baseline = json.loads((folder / ".wechat-chat-export.json").read_text(encoding="utf-8"))
+                first_state = next(
+                    state
+                    for state in current_baseline["conversations"].values()
+                    if state.get("displayName") == "测试好友"
+                )
+                first_message = folder / Path(first_state["directory"]) / "messages.json"
+                first_message.unlink()
+
+                restored = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=second_username,
+                    output_dir=folder,
+                )
+                self.assertEqual(restored.status, "done", msg=restored.error)
+                self.assertTrue(first_message.is_file())
+                self.assertEqual((second_message.stat().st_mtime_ns, second_message.read_bytes()), second_before)
+                self.assertEqual(restored.incremental.get("filesRecovered"), 1)
+                self.assertFalse((folder / "聊天增量测试").exists())
+                self.assertTrue(user_file.is_file())
+
+                connection = sqlite3.connect(str(account_dir / "contact.db"))
+                try:
+                    connection.execute(
+                        "UPDATE contact SET nick_name = ? WHERE username = ?",
+                        ("改名后的好友", first_username),
+                    )
+                    connection.commit()
+                finally:
+                    connection.close()
+                renamed = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=first_username,
+                    output_dir=output_dir,
+                )
+                self.assertEqual(renamed.status, "done", msg=renamed.error)
+                self.assertFalse(renamed.repair_candidates)
+                renamed_baseline = json.loads((folder / ".wechat-chat-export.json").read_text(encoding="utf-8"))
+                renamed_state = next(
+                    state
+                    for state in renamed_baseline["conversations"].values()
+                    if state.get("displayName") == "改名后的好友"
+                )
+                self.assertEqual(renamed_state.get("directory"), first_state.get("directory"))
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_missing_chat_and_media_are_restored_for_all_formats(self):
+        format_suffixes = (
+            ("html", "html"),
+            ("json", "json"),
+            ("txt", "txt"),
+            ("excel", "xlsx"),
+        )
+        for export_format, suffix in format_suffixes:
+            with self.subTest(export_format=export_format), TemporaryDirectory() as td:
+                root = Path(td)
+                account = "wxid_incremental"
+                first_username = "wxid_friend"
+                second_username = "wxid_friend_two"
+                account_dir = self._prepare_account(root, account=account, username=first_username)
+                self._add_conversation(account_dir, username=second_username, display_name="第二位好友")
+                output_dir = root / "exports"
+
+                previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+                try:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                    service = self._reload_export_modules()
+                    initial = self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        usernames=[first_username, second_username],
+                        output_dir=output_dir,
+                        export_format=export_format,
+                        message_types=["text", "image"],
+                        include_media=True,
+                    )
+                    self.assertEqual(initial.status, "done", msg=initial.error)
+
+                    folder = output_dir / "聊天增量测试"
+                    baseline = json.loads((folder / ".wechat-chat-export.json").read_text(encoding="utf-8"))
+                    first_state = next(
+                        state
+                        for state in baseline["conversations"].values()
+                        if state.get("displayName") == "测试好友"
+                    )
+                    second_state = next(
+                        state
+                        for state in baseline["conversations"].values()
+                        if state.get("displayName") == "第二位好友"
+                    )
+                    first_message = folder / Path(first_state["directory"]) / f"messages.{suffix}"
+                    second_message = folder / Path(second_state["directory"]) / f"messages.{suffix}"
+                    second_before = (second_message.stat().st_mtime_ns, second_message.read_bytes())
+                    media_paths = [
+                        path for path in baseline["files"]
+                        if path.startswith("media/images/")
+                    ]
+                    self.assertTrue(media_paths)
+
+                    first_message.unlink()
+                    for media_path in media_paths:
+                        (folder / Path(media_path)).unlink()
+
+                    restored = self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=second_username,
+                        output_dir=output_dir,
+                        export_format=export_format,
+                        message_types=["text", "image"],
+                        include_media=True,
+                    )
+                    self.assertEqual(restored.status, "done", msg=restored.error)
+                    self.assertTrue(first_message.is_file())
+                    for media_path in media_paths:
+                        self.assertTrue((folder / Path(media_path)).is_file())
+                    self.assertEqual(
+                        (second_message.stat().st_mtime_ns, second_message.read_bytes()),
+                        second_before,
+                    )
+                    self.assertEqual(
+                        restored.incremental.get("filesRecovered"),
+                        1 + len(media_paths),
+                    )
+                    self.assertEqual(
+                        restored.incremental.get("conversationsUpdated"),
+                        1,
+                        msg=export_format,
+                    )
+                    self.assertEqual(restored.incremental.get("conversationsReused"), 1)
+                finally:
+                    if previous is None:
+                        os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                    else:
+                        os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_shared_media_is_removed_only_after_last_owner_is_rebuilt(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            first_username = "wxid_friend"
+            second_username = "wxid_friend_two"
+            account_dir = self._prepare_account(root, account=account, username=first_username)
+            self._add_conversation(account_dir, username=second_username, display_name="第二位好友")
+            table_two = self._message_table(second_username)
+            image_xml = '<msg><img md5="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" cdnthumburl="img_file_id_1" /></msg>'
+            connection = sqlite3.connect(str(account_dir / "message_0.db"))
+            try:
+                connection.execute(
+                    f"INSERT INTO {table_two} VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (2, 2002, 3, 2, 20, 1735689702, image_xml, None),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+            output_dir = root / "exports"
+
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                first = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    usernames=[first_username, second_username],
+                    output_dir=output_dir,
+                    message_types=["image"],
+                    include_media=True,
+                )
+                self.assertEqual(first.status, "done", msg=first.error)
+                folder = output_dir / "聊天增量测试"
+                state_path = folder / ".wechat-chat-export.json"
+                baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                media_paths = [path for path in baseline["files"] if path.startswith("media/images/")]
+                self.assertEqual(len(media_paths), 1)
+                media_path = media_paths[0]
+                self.assertEqual(len(baseline["files"][media_path].get("owners") or []), 2)
+
+                media_file = folder / Path(media_path)
+                media_file.unlink()
+                restored = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=second_username,
+                    output_dir=output_dir,
+                    message_types=["image"],
+                    include_media=True,
+                )
+                self.assertEqual(restored.status, "done", msg=restored.error)
+                self.assertTrue(media_file.is_file())
+                self.assertEqual(restored.incremental.get("filesRecovered"), 1)
+                self.assertEqual(restored.incremental.get("conversationsUpdated"), 1)
+
+                for username in (first_username, second_username):
+                    table = self._message_table(username)
+                    connection = sqlite3.connect(str(account_dir / "message_0.db"))
+                    try:
+                        connection.execute(f"DELETE FROM {table} WHERE local_type = 3")
+                        connection.commit()
+                    finally:
+                        connection.close()
+                    repaired = self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=output_dir,
+                        message_types=["image"],
+                        include_media=True,
+                        repair_usernames=[username],
+                    )
+                    self.assertEqual(repaired.status, "done", msg=repaired.error)
+                    if username == first_username:
+                        self.assertTrue(media_file.is_file())
+                        baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                        self.assertEqual(len(baseline["files"][media_path].get("owners") or []), 1)
+                    else:
+                        self.assertFalse(media_file.exists())
+                        baseline = json.loads(state_path.read_text(encoding="utf-8"))
+                        self.assertNotIn(media_path, baseline["files"])
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_nonempty_unknown_corrupt_and_unsafe_baselines_are_rejected(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            username = "wxid_friend"
+            self._prepare_account(root, account=account, username=username)
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                direct = root / "聊天增量测试"
+                direct.mkdir()
+                (direct / "用户文件.txt").write_text("保留", encoding="utf-8")
+                with self.assertRaises(service.ChatIncrementalError) as unknown:
+                    self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=direct,
+                    )
+                self.assertEqual(unknown.exception.code, "incremental_directory_not_empty")
+                with self.assertRaises(service.ChatIncrementalError) as unsafe_reset:
+                    self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=direct,
+                        reset_baseline=True,
+                    )
+                self.assertEqual(unsafe_reset.exception.code, "incremental_directory_not_empty")
+
+                (direct / ".wechat-chat-export.json").write_text("{broken", encoding="utf-8")
+                with self.assertRaises(service.ChatIncrementalError) as corrupt:
+                    self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=direct,
+                        reset_baseline=True,
+                    )
+                self.assertEqual(corrupt.exception.code, "incremental_baseline_invalid")
+
+                malicious = {
+                    "schemaVersion": 1,
+                    "artifactType": "wechat-chat-incremental-folder",
+                    "account": account,
+                    "folderName": "聊天增量测试",
+                    "configFingerprint": "unused",
+                    "conversations": {},
+                    "files": {"../outside.txt": {"size": 1, "sha256": "x"}},
+                }
+                with self.assertRaises(service.ChatIncrementalError) as unsafe:
+                    self._create_folder_job(
+                        service.CHAT_EXPORT_MANAGER,
+                        account=account,
+                        username=username,
+                        output_dir=None,
+                        baseline=malicious,
+                    )
+                self.assertEqual(unsafe.exception.code, "incremental_unsafe_path")
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+    def test_browser_patch_manifest_keeps_state_last_and_commit_cleans_staging(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            account = "wxid_incremental"
+            username = "wxid_friend"
+            self._prepare_account(root, account=account, username=username)
+            previous = os.environ.get("WECHAT_TOOL_DATA_DIR")
+            try:
+                os.environ["WECHAT_TOOL_DATA_DIR"] = str(root)
+                service = self._reload_export_modules()
+                job = self._create_folder_job(
+                    service.CHAT_EXPORT_MANAGER,
+                    account=account,
+                    username=username,
+                    output_dir=None,
+                )
+                self.assertEqual(job.status, "done", msg=job.error)
+                self.assertIsNone(job.folder_path)
+                self.assertTrue(job.staged_files)
+                manifest = job.change_manifest
+                self.assertTrue(manifest.get("files"))
+                self.assertEqual(manifest.get("state", {}).get("path"), ".wechat-chat-export.json")
+                self.assertFalse(manifest.get("state", {}).get("unchanged"))
+                for entry in manifest["files"]:
+                    self.assertNotIn("..", str(entry.get("path") or "").split("/"))
+                    self.assertTrue(service.CHAT_EXPORT_MANAGER.get_staged_file(job.export_id, entry["fileId"]).is_file())
+                state_file = service.CHAT_EXPORT_MANAGER.get_staged_file(
+                    job.export_id,
+                    manifest["state"]["fileId"],
+                )
+                state = json.loads(state_file.read_text(encoding="utf-8"))
+                self.assertEqual(state.get("artifactType"), "wechat-chat-incremental-folder")
+                staging_dir = job.staging_dir
+                self.assertTrue(service.CHAT_EXPORT_MANAGER.commit_staged_files(job.export_id))
+                self.assertFalse(staging_dir.exists())
+                self.assertFalse(job.staged_files)
+            finally:
+                if previous is None:
+                    os.environ.pop("WECHAT_TOOL_DATA_DIR", None)
+                else:
+                    os.environ["WECHAT_TOOL_DATA_DIR"] = previous
+
+
+# 仅借用既有测试的数据构造方法，避免 pytest 重复收集原测试类。
+del _BaseChatExportTest


### PR DESCRIPTION
## 功能说明

在原有完整 ZIP 导出的基础上，新增聊天记录“增量目录”导出模式。

再次导出到同一目录时，会根据基线文件识别发生变化的会话，复用未变化的文件，只更新需要同步或修复的内容，减少重复导出大量聊天记录和媒体文件的开销。

## 主要改动

### 增量导出

- 新增完整 ZIP、增量目录两种输出模式
- 在导出目录中维护 `.wechat-chat-export.json` 基线文件
- 根据消息水位、历史指纹及会话信息判断会话是否发生变化
- 复用未变化会话，仅重新导出需要更新的会话
- 保留本次未选择但已存在于导出目录中的会话

### HTML 增量更新

- 满足条件时仅查询并渲染新增消息
- 合并原有分页、媒体索引和会话目录
- 历史消息发生变化时生成修复候选，由用户确认后重建
- 无法安全追加时自动回退为当前会话完整重建

JSON、TXT、Excel 格式同样支持增量判断，变化的会话会重新生成，未变化的会话继续复用。

### 文件与媒体修复

- 检测导出目录中丢失或大小异常的受管文件
- 支持重新探测缺失媒体并恢复可修复内容
- 记录共享媒体的会话归属，避免删除仍被其他会话使用的资源
- 对无法从本地恢复的媒体进行区分，避免重复提示无效修复

### 安全与兼容性

- 校验基线所属账号及导出配置，避免误用其他导出目录
- 拒绝不安全路径、损坏基线及来源不明的非空目录
- 桌面端通过临时目录和原子替换更新文件
- 浏览器端在全部文件写入完成后再提交基线及清理旧文件
- 隐私模式下不在基线和报告中记录明文账号或会话名称
- 保留原有行为，不影响现有使用方式
- 增量目录模式暂不支持加密导出

### 前端与接口

- 增加增量目录模式选择及目录状态展示
- 展示新增消息、更新会话、复用会话和恢复文件数量
- 增加历史变化修复和缺失媒体重新探测入口
- 增加浏览器端文件清单、文件下载和提交清理接口
- 增加浏览器写入进度及失败重试提示
