### PR TITLE
路径探测优化：自定义数据目录定位 + global_config 解析修复

### DIFF
--- a/src/wechat_decrypt_tool/wechat_detection.py
+++ b/src/wechat_decrypt_tool/wechat_detection.py
@@ -8,6 +8,7 @@ import logging
 import os
 import plistlib
 import re
+import struct
 import psutil
 import ctypes
 import hashlib
@@ -149,97 +150,105 @@ class PROCESSENTRY32W(ctypes.Structure):
 # 删除了WeChatDecryptor类，解密功能已移至独立的wechat_decrypt.py脚本
 
 
+# AES-128-CFB 解密 key（与 Rust 端 xwechat_crypt_ke 一致）
+_GLOBAL_CONFIG_CRYPT_KEY = b"xwechat_crypt_ke"
+
+
+def _decode_mmkv_varint(data: bytes, offset: int):
+    """读取 MMKV 的 varint，返回（值, 新偏移）。"""
+    shift = value = 0
+    while offset < len(data):
+        byte = data[offset]
+        offset += 1
+        value |= (byte & 0x7F) << shift
+        if byte < 0x80:
+            return value, offset
+        shift += 7
+    return value, offset
+
+
+def _decode_mmkv_value(payload: bytes):
+    """按 MMKV 存储格式解码单条 value（字符串/数字/hex）。"""
+    value_len, offset = _decode_mmkv_varint(payload, 0)
+    if offset + value_len == len(payload):
+        try:
+            return payload[offset:].decode("utf-8")
+        except UnicodeDecodeError:
+            return payload[offset:].hex()
+    if len(payload) == 1:
+        return payload[0]
+    value_len, offset = _decode_mmkv_varint(payload, 0)
+    return value_len if offset == len(payload) else payload.hex()
+
+
+def _parse_mmkv_kv(data: bytes) -> dict:
+    """解析解密后的 MMKV 明文为 KV 字典（vlen == 0 表示删除标记）。"""
+    kv = {}
+    pos = 4  # 跳过明文头部的 4 字节
+    while pos < len(data):
+        key_len, pos = _decode_mmkv_varint(data, pos)
+        key = data[pos:pos + key_len].decode("utf-8", errors="replace")
+        pos += key_len
+        value_len, pos = _decode_mmkv_varint(data, pos)
+        payload = data[pos:pos + value_len]
+        pos += value_len
+        if value_len == 0:
+            kv.pop(key, None)
+        else:
+            kv[key] = _decode_mmkv_value(payload)
+    return kv
+
+
 def parse_global_config(base_path: str) -> dict:
     """
-    解析 all_users/config/global_config 获取最近登录用户信息
-    基于 AES-128-CFB 解密，并解析 MMKV 的 Varint 格式
+    解析 all_users/config/global_config 获取最近登录用户信息。
+
+    使用 global_config.crc 中偏移 12..28 的 m_vector 作为 AES-128-CFB IV，
+    数据长度取文件头 4 字节小端 uint32，解密后按 MMKV varint 逐条解析 KV。
     """
     try:
-        import os
-        config_path = os.path.join(base_path, 'all_users', 'config', 'global_config')
-        if not os.path.exists(config_path):
+        config_path = os.path.join(base_path, "all_users", "config", "global_config")
+        meta_path = config_path + ".crc"
+        if not os.path.isfile(config_path) or not os.path.isfile(meta_path):
             return None
 
-        with open(config_path, 'rb') as f:
-            full_data = f.read()
-
-        if len(full_data) <= 4:
+        raw = Path(config_path).read_bytes()
+        if len(raw) < 8:
+            return None
+        data_len = struct.unpack("<I", raw[:4])[0]
+        if data_len <= 0 or 4 + data_len > len(raw):
             return None
 
-        encrypted_data = full_data[4:]
+        meta = Path(meta_path).read_bytes()
+        if len(meta) < 28:
+            return None
+        iv = meta[12:28]
 
-        # 核心修复 1：强制截断取前 16 字节，等同于 Rust 中的 b"xwechat_crypt_ke"
-        key = b'xwechat_crypt_key'[:16]
-        iv = b'\0' * 16
-
-        # 尝试主流的两种密码库
+        encrypted = raw[4:4 + data_len]
         try:
             from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-            from cryptography.hazmat.backends import default_backend
-            cipher = Cipher(algorithms.AES(key), modes.CFB(iv), backend=default_backend())
-            decryptor = cipher.decryptor()
-            decrypted = decryptor.update(encrypted_data) + decryptor.finalize()
+            decryptor = Cipher(algorithms.AES(_GLOBAL_CONFIG_CRYPT_KEY), modes.CFB(iv)).decryptor()
+            plaintext = decryptor.update(encrypted) + decryptor.finalize()
         except ImportError:
             from Crypto.Cipher import AES
             # PyCryptodome 中 CFB 模式默认 segment_size 是 8，需要指定为 128
-            cipher = AES.new(key, AES.MODE_CFB, iv=iv, segment_size=128)
-            decrypted = cipher.decrypt(encrypted_data)
+            plaintext = AES.new(
+                _GLOBAL_CONFIG_CRYPT_KEY, AES.MODE_CFB, iv=iv, segment_size=128
+            ).decrypt(encrypted)
 
-        # MMKV Varint 长度解码
-        def decode_varint(data, offset):
-            result = 0
-            shift = 0
-            while offset < len(data):
-                byte = data[offset]
-                offset += 1
-                result |= (byte & 0x7f) << shift
-                if not (byte & 0x80):
-                    break
-                shift += 7
-            return result, offset
-
-        def extract_mmkv_string(data: bytes, key_str: str) -> str:
-            key_bytes = key_str.encode('utf-8')
-            idx = data.find(key_bytes)
-            if idx == -1: return None
-
-            offset = idx + len(key_bytes)
-            try:
-                value_len, offset = decode_varint(data, offset)
-                if value_len <= 0 or offset >= len(data):
-                    return None
-
-                str_len, offset = decode_varint(data, offset)
-
-                if str_len > 0 and offset + str_len <= len(data):
-                    return data[offset:offset + str_len].decode('utf-8', errors='ignore')
-            except Exception:
-                pass
-            return None
-
-
-        wxid = extract_mmkv_string(decrypted, 'mmkv_key_user_name')
-        nickname = extract_mmkv_string(decrypted, 'mmkv_key_nick_name')
-        avatar_url = extract_mmkv_string(decrypted, 'mmkv_key_head_img_url')
-
-        # 核心修复 2：参考 Rust 逻辑，头像链接往往以 "/0" 结尾（微信头像的尺寸标识）
-        if not avatar_url and b'http' in decrypted:
-            http_idx = decrypted.find(b'http')
-            slash_zero_idx = decrypted.find(b'/0', http_idx)
-            if slash_zero_idx != -1:
-                # 包含 "/0" 这两个字符本身，所以是 +2
-                avatar_url = decrypted[http_idx:slash_zero_idx + 2].decode('utf-8', errors='ignore')
-
-        if wxid or nickname:
-            return {
-                "wxid": wxid,
-                "nickname": nickname,
-                "avatar": avatar_url
-            }
+        kv = _parse_mmkv_kv(plaintext)
+        result = {
+            "wxid": kv.get("mmkv_key_user_name"),
+            "nickname": kv.get("mmkv_key_nick_name"),
+            "avatar": kv.get("mmkv_key_head_img_url"),
+        }
+        if result["wxid"] or result["nickname"]:
+            return result
         return None
     except Exception as e:
         logger.debug("解析 global_config 失败: %s", e)
         return None
+
 
 def find_wechat_databases() -> List[str]:
     """在新的xwechat_files目录中查找微信数据库文件

--- a/src/wechat_decrypt_tool/wechat_detection.py
+++ b/src/wechat_decrypt_tool/wechat_detection.py
@@ -10,6 +10,7 @@ import plistlib
 import re
 import psutil
 import ctypes
+import hashlib
 import sys
 from pathlib import Path
 from typing import List, Dict, Any, Union
@@ -460,12 +461,110 @@ def _build_auto_detect_scan_paths() -> List[str]:
     return scan_paths
 
 
+# 微信 4.x（Windows）通过 %APPDATA%\Tencent\xwechat\config 下的配置文件记录数据目录。
+# 文件名是配置键名的 MD5 而非随机 hex：MD5("KEY_LAST_XWEACHAT_FILE_DIR")。
+XWECHAT_CONFIG_KEY_NAME = "KEY_LAST_XWEACHAT_FILE_DIR"
+
+# CSIDL_PERSONAL（我的文档）：微信默认数据目录位于“我的文档”下。
+CSIDL_PERSONAL = 0x0005
+
+
+def _resolve_known_folder(csidl: int) -> str | None:
+    """将 Windows 已知文件夹 CSIDL 解析为真实目录（仅 Windows）。"""
+    if os.name != "nt":
+        return None
+    try:
+        buffer = ctypes.create_unicode_buffer(wintypes.MAX_PATH)
+        result = ctypes.windll.shell32.SHGetFolderPathW(None, csidl, None, 0, buffer)
+        if result == 0:
+            folder_path = buffer.value
+            if folder_path and os.path.isdir(folder_path):
+                return folder_path
+    except Exception:
+        pass
+    return None
+
+
+def _resolve_wechat_base_dir(value: str) -> str | None:
+    """解析微信配置里的数据目录父路径。
+
+    支持两种格式：
+    - 真实绝对路径，如 C:\\Users\\xxx
+    - 系统 token，如 MyDocument / MyDocument: / MyDocument:<CSIDL>，
+      需用已知文件夹 API 解析为真实目录
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+
+    # 真实绝对路径
+    if re.match(r"^[A-Za-z]:[\\/]", raw):
+        return raw
+
+    # 系统 token：MyDocument[:<CSIDL>]
+    token_match = re.match(r"^mydocument(?::(\d+))?$", raw, flags=re.IGNORECASE)
+    if not token_match:
+        return None
+
+    csidl = int(token_match.group(1)) if token_match.group(1) else CSIDL_PERSONAL
+    # 微信写入的 CSIDL 可能带高位标志位，只保留低 16 位的 CSIDL 值
+    csidl &= 0x0000FFFF
+    return _resolve_known_folder(csidl)
+
+
+def _get_xwechat_data_dir_from_config() -> str | None:
+    """从微信 4.x 配置文件读取数据根目录（仅 Windows）。
+
+    配置路径：%APPDATA%\\Tencent\\xwechat\\config\\MD5("KEY_LAST_XWEACHAT_FILE_DIR").ini
+    配置内容是数据目录的父路径（真实路径或系统 token），
+    实际数据根目录 = 父路径 + xwechat_files。
+    任何一步失败都返回 None，不阻塞后续的目录/进程扫描。
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        appdata = os.environ.get("APPDATA")
+        if not appdata:
+            return None
+        ini_name = hashlib.md5(XWECHAT_CONFIG_KEY_NAME.encode("utf-8")).hexdigest() + ".ini"
+        ini_path = Path(appdata) / "Tencent" / "xwechat" / "config" / ini_name
+        if not ini_path.is_file():
+            return None
+
+        raw_bytes = ini_path.read_bytes()
+        if raw_bytes.startswith(b"\xff\xfe") or raw_bytes.startswith(b"\xfe\xff"):
+            raw = raw_bytes.decode("utf-16", errors="ignore")
+        else:
+            raw = raw_bytes.decode("utf-8", errors="ignore")
+
+        base_dir = _resolve_wechat_base_dir(raw)
+        if not base_dir:
+            return None
+
+        data_root = os.path.join(base_dir, "xwechat_files")
+        if not os.path.isdir(data_root):
+            return None
+        return data_root
+    except Exception:
+        return None
+
+
 def auto_detect_wechat_data_dirs():
     """
     自动检测微信数据目录 - 多策略组合检测
     :return: 检测到的微信数据目录列表
     """
     detected_dirs = []
+
+    # 策略0（仅 Windows）：微信 4.x 配置文件记录的数据根目录，优先级最高。
+    # 自定义数据目录名可能不匹配 COMMON_WECHAT_PATTERNS，只有配置来源能拿到真实路径；
+    # 读取失败（token 无法解析、目录不存在等）时静默跳过，不阻塞后续策略。
+    if sys.platform == "win32":
+        config_data_dir = _get_xwechat_data_dir_from_config()
+        if config_data_dir:
+            _append_detected_dir(detected_dirs, config_data_dir)
+            logger.debug("配置文件检测成功: %s", config_data_dir)
+
 
     # 策略1：常见驱动器 / 用户目录 / 自定义目录的浅层扫描。
     # 这里既检查扫描根目录本身，也检查其直接子目录，兼容：

--- a/tests/test_wechat_detection_auto_detect.py
+++ b/tests/test_wechat_detection_auto_detect.py
@@ -306,5 +306,67 @@ class TestWechatDetectionAutoDetect(unittest.TestCase):
         self.assertEqual(result, [str(data_root)])
 
 
+    def test_parse_global_config_uses_iv_from_crc_meta(self):
+        import struct
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from wechat_decrypt_tool import wechat_detection as wd
+
+        def varint(n):
+            out = bytearray()
+            while True:
+                b = n & 0x7F
+                n >>= 7
+                if n:
+                    out.append(b | 0x80)
+                else:
+                    out.append(b)
+                    return bytes(out)
+
+        key = wd._GLOBAL_CONFIG_CRYPT_KEY
+        entries = [
+            ("mmkv_key_user_name", "wxid_demo"),
+            ("mmkv_key_nick_name", "DemoNick"),
+            ("mmkv_key_head_img_url", "http://example.com/avatar/0"),
+            ("some_other", "value"),
+        ]
+        body = bytearray()
+        for key_name, value in entries:
+            key_bytes = key_name.encode("utf-8")
+            value_bytes = value.encode("utf-8")
+            # 字符串 value 内部还有一层 varint 长度前缀
+            value_payload = varint(len(value_bytes)) + value_bytes
+            body += varint(len(key_bytes)) + key_bytes + varint(len(value_payload)) + value_payload
+        plaintext = b"\x00\x00\x00\x00" + bytes(body)
+        iv = b"\x11" * 16
+        encryptor = Cipher(algorithms.AES(key), modes.CFB(iv)).encryptor()
+        encrypted = encryptor.update(plaintext) + encryptor.finalize()
+
+        with TemporaryDirectory() as td:
+            config_dir = Path(td) / "all_users" / "config"
+            config_dir.mkdir(parents=True)
+            (config_dir / "global_config").write_bytes(struct.pack("<I", len(plaintext)) + encrypted)
+            (config_dir / "global_config.crc").write_bytes(b"\x00" * 12 + iv + b"\x00" * 16)
+
+            result = wd.parse_global_config(td)
+
+        self.assertEqual(result, {
+            "wxid": "wxid_demo",
+            "nickname": "DemoNick",
+            "avatar": "http://example.com/avatar/0",
+        })
+
+    def test_parse_global_config_missing_crc_returns_none(self):
+        from wechat_decrypt_tool import wechat_detection as wd
+
+        with TemporaryDirectory() as td:
+            config_dir = Path(td) / "all_users" / "config"
+            config_dir.mkdir(parents=True)
+            (config_dir / "global_config").write_bytes(b"\x00" * 8)
+
+            result = wd.parse_global_config(td)
+
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wechat_detection_auto_detect.py
+++ b/tests/test_wechat_detection_auto_detect.py
@@ -170,6 +170,7 @@ class TestWechatDetectionAutoDetect(unittest.TestCase):
             with (
                 patch.object(wd, "_build_auto_detect_scan_paths", return_value=[str(nested_scan_root)]),
                 patch.object(wd, "get_process_list", return_value=[]),
+                patch.object(wd, "_get_xwechat_data_dir_from_config", return_value=None),
             ):
                 detected_dirs = wd.auto_detect_wechat_data_dirs()
                 result = wd.detect_wechat_installation()
@@ -205,6 +206,104 @@ class TestWechatDetectionAutoDetect(unittest.TestCase):
             self.assertEqual([item["account_name"] for item in accounts], ["wxid_demo_abcd"])
             self.assertEqual(accounts[0]["data_dir"], str(account_dir))
             self.assertEqual(accounts[0]["database_count"], 1)
+
+
+    def test_xwechat_config_ini_real_path_returns_data_root(self):
+        import hashlib
+        from wechat_decrypt_tool import wechat_detection as wd
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "root"
+            data_root = root / "xwechat_files"
+            data_root.mkdir(parents=True)
+            appdata = Path(td) / "appdata"
+            config_dir = appdata / "Tencent" / "xwechat" / "config"
+            config_dir.mkdir(parents=True)
+            ini_name = hashlib.md5(wd.XWECHAT_CONFIG_KEY_NAME.encode("utf-8")).hexdigest() + ".ini"
+            (config_dir / ini_name).write_text(str(root), encoding="utf-8")
+
+            with (
+                patch.object(wd.sys, "platform", "win32"),
+                patch.dict(os.environ, {"APPDATA": str(appdata)}),
+            ):
+                result = wd._get_xwechat_data_dir_from_config()
+
+        self.assertEqual(result, str(data_root))
+
+    def test_xwechat_config_ini_my_document_token(self):
+        import hashlib
+        from wechat_decrypt_tool import wechat_detection as wd
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "root"
+            data_root = root / "xwechat_files"
+            data_root.mkdir(parents=True)
+            appdata = Path(td) / "appdata"
+            config_dir = appdata / "Tencent" / "xwechat" / "config"
+            config_dir.mkdir(parents=True)
+            ini_name = hashlib.md5(wd.XWECHAT_CONFIG_KEY_NAME.encode("utf-8")).hexdigest() + ".ini"
+            (config_dir / ini_name).write_text("MyDocument:1073741829", encoding="utf-8")
+
+            with (
+                patch.object(wd.sys, "platform", "win32"),
+                patch.dict(os.environ, {"APPDATA": str(appdata)}),
+                patch.object(wd, "_resolve_known_folder", return_value=str(root)),
+            ):
+                result = wd._get_xwechat_data_dir_from_config()
+
+        self.assertEqual(result, str(data_root))
+
+    def test_xwechat_config_ini_missing_returns_none(self):
+        import hashlib
+        from wechat_decrypt_tool import wechat_detection as wd
+
+        with TemporaryDirectory() as td:
+            appdata = Path(td) / "appdata"
+            appdata.mkdir()
+            with (
+                patch.object(wd.sys, "platform", "win32"),
+                patch.dict(os.environ, {"APPDATA": str(appdata)}),
+            ):
+                result = wd._get_xwechat_data_dir_from_config()
+
+        self.assertIsNone(result)
+
+    def test_xwechat_config_ini_data_root_not_exists_returns_none(self):
+        import hashlib
+        from wechat_decrypt_tool import wechat_detection as wd
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "root"
+            root.mkdir()
+            appdata = Path(td) / "appdata"
+            config_dir = appdata / "Tencent" / "xwechat" / "config"
+            config_dir.mkdir(parents=True)
+            ini_name = hashlib.md5(wd.XWECHAT_CONFIG_KEY_NAME.encode("utf-8")).hexdigest() + ".ini"
+            (config_dir / ini_name).write_text(str(root), encoding="utf-8")
+
+            with (
+                patch.object(wd.sys, "platform", "win32"),
+                patch.dict(os.environ, {"APPDATA": str(appdata)}),
+            ):
+                result = wd._get_xwechat_data_dir_from_config()
+
+        self.assertIsNone(result)
+
+    def test_auto_detect_injects_xwechat_config_dir_first(self):
+        from wechat_decrypt_tool import wechat_detection as wd
+
+        with TemporaryDirectory() as td:
+            data_root = Path(td) / "xwechat_files"
+            data_root.mkdir()
+            with (
+                patch.object(wd.sys, "platform", "win32"),
+                patch.object(wd, "_get_xwechat_data_dir_from_config", return_value=str(data_root)),
+                patch.object(wd, "_build_auto_detect_scan_paths", return_value=[]),
+                patch.object(wd, "get_process_list", return_value=[]),
+            ):
+                result = wd.auto_detect_wechat_data_dirs()
+
+        self.assertEqual(result, [str(data_root)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 概述
- 支持从微信 4.x 配置文件自动定位数据根目录，不再依赖目录名扫描兜底
- 修复 global_config 解密 IV 硬编码错误，并按 MMKV 格式完整解析

### 改动内容
- 读取 %APPDATA%\Tencent\xwechat\config\MD5("KEY_LAST_XWEACHAT_FILE_DIR").ini 记录的父路径，拼接 xwechat_files 作为数据根目录
- 兼容真实绝对路径与 MyDocument 系统 token（经 Windows 已知文件夹 API 解析）
- 作为最高优先级注入 auto_detect_wechat_data_dirs()，读取失败静默回退现有扫描策略
- global_config 的 IV 改为从 global_config.crc 的 m_vector（偏移 12..28）读取，数据长度取文件头 4 字节小端 uint32
- 解密后按 MMKV varint 逐条解析 KV（支持删除标记、字符串/数字/hex 值），提取 wxid/昵称/头像
- 仅 Windows，不影响 macOS 逻辑

### 验证
- 真实微信数据目录（含迁移后目录）端到端验证：数据根、账号、当前账号、昵称头像均正确
- 新增 7 个单元测试（配置探测 5 个 + global_config 解析 2 个），相关测试全绿