### PR TITLE
fix(macos): 修复捕获事务、超时清理与原版构建恢复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ wheels/
 /.pnpm-store/
 /.pytest-tmp-*/
 /.testdeps/
+/private/
+/work/
 /.idea
 /.history/
 /.augment/

--- a/docs/MACOS_KEY_CAPTURE.md
+++ b/docs/MACOS_KEY_CAPTURE.md
@@ -1,0 +1,73 @@
+# macOS 登录期密钥捕获与恢复
+
+仅处理使用者本人有权访问的本机微信数据。临时签名和调试可能触发微信或 macOS 的安全保护，不能保证零风险或所有版本都能成功。重要数据应先备份。
+
+## 本次集成范围
+
+本分支基于上游 main 合并捕获修复，不替换上游默认受控 helper，不修改其下载、完整性校验、签名策略或 Windows 流程。主界面的本机调试仍是用户明确同意后的实验性兜底；独立工具源码位于 `macos-key-extractor/`，与主程序复用同一组捕获/恢复模块。没有加入私人聊天页面、AI、媒体下载或存储配置。
+
+## 捕获过程
+
+1. 从用户选择的活动账号 `db_storage` 中读取消息库和会话库首页，进行同账号绑定。账号目录无需以 `wxid_` 开头；不以旧密钥缓存代替本次捕获。
+2. 验证腾讯官方微信身份，建立本机 APFS 写时复制恢复副本和持久备份。事务记录版本、build、CDHash、临时签名身份及事务 ID；同用户、同安装路径跨进程互斥。
+3. 临时调试签名后，先让用户完整登录并进入聊天页，预检实际已加载的捕获位置。预检失败时恢复，不要求继续退出账号。
+4. 用户在未监测时退出账号，然后启动监测、完成管理员授权。只有本次事务和目标进程的就绪标记有效；显示“监测已就绪”后才重新登录。
+5. LLDB 观察 `CCKeyDerivationPBKDF` 和经过模块 UUID/可执行地址验证的 PBKDF 导入桩，读取当前调用中的候选参数。参数形状用于诊断，数据库盐匹配及双库首页 HMAC 才是验真条件。模块 UUID 不匹配时不会套用其他版本偏移。
+6. 256000 轮调用可能提供原始 passphrase；2 轮 HMAC 派生调用也可产生候选，但其中的 password 可能只是单库派生密钥。只有同时通过消息库及会话库校验的候选才可作为账号密钥；不能把一次 rounds=2 命中等同于成功。
+7. 捕获后关闭本次临时微信，复核候选并恢复本次原版。核对恢复版本、build、CDHash，不将任意腾讯签名版本当成正确恢复；发现外部替换或更新时不覆盖，保留恢复资产并报错。
+8. 主程序额外执行现有的完整实时数据库校验，再保存并返回明文密钥到本机输入框，保持现有操作习惯。独立工具也在账号校验及恢复通过后写入当前用户的 `~/.wcdb-key-tool/wechat-passphrase.json`（私有权限），支持用户主动复制。状态轮询、日志、URL 和公开仓库不包含密钥、数据库内容或本地恢复路径。
+
+捕获后的计划关闭不等同于意外崩溃。页面持续显示捕获、复验、恢复阶段，仅在最终请求确认后显示完成；不能仅凭窗口消失或进度标记判断成功。
+
+## 兼容与故障诊断
+
+- 预检及捕获使用同一方案。macOS 27 优先软件 LLDB；原生失败只在确认清理安全时回退。用户取消授权不会触发另一轮自动授权。
+- helper 被系统终止或无法确认调试状态清理时，不在同一目标进程继续切换方案，先结束事务恢复。
+- 原生超时可记录当前系统及微信构建的方案偏好，下一次新事务改用 LLDB，不在已经错过登录时机后原地重复等待。
+- LLDB 提前结束时回收输入保活与超时监护子进程，避免输出管道被计时器占用导致结果继续等满超时；真实超时保护保留。
+- 记录有界参数形状计数、退出码/信号和阶段，不记录候选字节或盐值。未出现崩溃报告并不能证明是微信主动退出。
+- 旧就绪/已捕获文件不能驱动新事务；捕获后的就绪标记不能再次提示登录。恢复失败保留错误与恢复资产，不误报成功。
+
+## 独立工具的手动启动
+
+独立工具调用 `prepare_capture` 时选择 `defer_launch=True`，主程序原有启动方式不变。
+
+准备完成后停在 `awaiting_manual_launch`。用户点击“显示微信窗口”，必要时自行在系统设置确认单应用安全授权，再点击“我已手动打开，检查启动”。工具检查事务归属、应用身份及稳定 PID 后才允许预检。
+
+“打开系统设置”只打开设置应用，不代点允许，不移除隔离属性，不关闭 SIP/Gatekeeper。恶意软件警告或没有允许入口时，应取消并恢复，不保证系统一定放行。单应用授权不是 Apple 公证。参考：[Apple 安全打开应用说明](https://support.apple.com/en-gb/102445)。
+
+独立工具在等待用户操作时以单线程后台检查进程；启动退出或 PID 更换会触发已有恢复路径，同事务仅自动尝试一次。忙碌、关闭或陈旧检查结果不能启动重复恢复。
+
+## 验证边界
+
+2026-09-05，使用者反馈在其 Apple Silicon Mac 的微信 **4.1.7** 上，独立工具 1.1.11 完成密钥获取并正常恢复官方版本。这是用户实测反馈，不代表其他机器、4.1.12/4.1.13、所有 macOS 版本均已验证，也不将其他用户的报错全部标记为解决。
+
+自动化回归使用合成数据库首页、伪 LLDB/进程和假 UI，不启动微信、不读取真实密钥。公开分支与上游接口对齐后另行执行回归。运行示例（Python 环境需安装项目依赖和 pytest）：
+
+```bash
+PYTHONPATH=src python -B -m pytest -q -p no:cacheprovider \
+  tests/test_macos_capture_backend_routing.py tests/test_macos_capture_diagnostics.py \
+  tests/test_macos_capture_validation.py tests/test_macos_restore_identity.py \
+  tests/test_macos_lldb_breakpoint_plan.py tests/test_macos_capture_api_progress.py \
+  tests/test_macos_inplace_capture.py tests/test_macos_clone_capture.py \
+  tests/test_macos_db_key_capture.py tests/test_macos_platform_support.py \
+  tests/test_standalone_macos_key_extractor.py tests/test_macos_native_capture_source.py \
+  tests/test_macos_capture_phases.py tests/test_macos_lldb_command_lifecycle.py \
+  tests/test_macos_prepared_lifecycle.py tests/test_macos_manual_launch.py \
+  -k 'not private_snapshot_replaces_external_xwechat_symlink and not force_clone_preserves_nested_symlink_without_following_it'
+node --test tests/macos-capture-progress.test.mjs
+git diff --check
+```
+
+上述两项 APFS 实盘克隆测试因沙盒环境排除，不计作通过。模拟测试不能替代其他版本的真实登录验证。发布源码不包含构建机器的证书、偏好设置、日志、数据库、密钥或安装产物。
+
+## 实现索引
+
+- `macos_db_key_capture.py`：启动/退出、LLDB 命令生命周期及签名恢复。
+- `macos_clone_capture.py`：断点计划、预检、候选及退出诊断。
+- `macos_inplace_capture.py`：安装事务、方案选择、阶段状态与原样恢复。
+- `macos_capture_validation.py`：只读双库首页快照及候选验真。
+- `macos_native_capture.py`、`native/macos/source/wcdb_native_capture.c`：原生调度、清理及非敏感阶段标记。
+- `routers/keys.py`：保持上游本机访问限制、并发控制、独立线程及结果校验。
+- `frontend/lib/macos-capture-progress.js`、`frontend/pages/decrypt.vue`：事务绑定的持续进度和登录指引。
+- `macos-key-extractor/`：复用上述模块的可选独立工具及构建/隐私审计脚本。

--- a/frontend/composables/useApi.js
+++ b/frontend/composables/useApi.js
@@ -904,12 +904,13 @@ export const useApi = () => {
   }
 
   const getMacosKeyCaptureStatus = async (params = {}) => {
-    return await request('/macos-key-capture/status', params?.signal ? { signal: params.signal } : {})
+    return await request('/macos-key-capture/status', { retry: 0, timeout: 3000, ...(params?.signal ? { signal: params.signal } : {}) })
   }
 
   const macosKeyCaptureRequest = async (action, params = {}) => {
     const options = {
       method: 'POST',
+      retry: 0,
       body: {
         wechat_install_path: params.wechat_install_path || null,
         db_storage_path: params.db_storage_path || null,

--- a/frontend/lib/macos-capture-progress.js
+++ b/frontend/lib/macos-capture-progress.js
@@ -1,0 +1,49 @@
+// The capture request can take minutes. Readiness belongs to its transaction,
+// not to a timer or a ready file left by a previous login.
+const capturePhases = new Set(['waiting_authorization', 'monitoring', 'captured', 'validating', 'restoring'])
+
+export function macosCaptureProgressMessage(ready, phase) {
+  if (phase === 'captured') {
+    return '已捕获密钥并通过消息库与会话库校验，正在完成后续复核。临时微信窗口将按流程关闭，随后恢复腾讯原签名微信；请勿再次登录。'
+  }
+  if (phase === 'validating') {
+    return '正在使用本账号消息库与会话库校验候选密钥。临时微信窗口会关闭并恢复腾讯原签名微信；请勿再次登录。'
+  }
+  if (phase === 'restoring') {
+    return '正在关闭临时微信并恢复腾讯原签名微信，请勿再次登录；恢复尚未完成，请等待本次请求结果。'
+  }
+  return ready === true && phase !== 'waiting_authorization'
+    ? '监测已就绪，可以重新登录。请只在当前微信中登录同一个账号；捕获后临时微信窗口会关闭，并恢复腾讯原签名微信。'
+    : '正在准备监测，请完成管理员授权；监测就绪前请不要登录。'
+}
+
+export async function followMacosCapture({ start, getStatus, transactionId, isActive, onProgress, wait = (ms) => new Promise(resolve => setTimeout(resolve, ms)) }) {
+  const monitor = new AbortController()
+  let finished = false
+  const completion = (async () => {
+    try {
+      return { value: await start() }
+    } catch (error) {
+      return { error }
+    } finally {
+      // Mark completion directly, before a concurrently resolved status can publish.
+      finished = true
+      monitor.abort()
+    }
+  })()
+  while (!finished && isActive()) {
+    await Promise.race([completion, wait(500)])
+    if (finished || !isActive()) break
+    try {
+      const status = await getStatus({ signal: monitor.signal })
+      if (!finished && isActive() && transactionId && status?.transaction_id === transactionId) {
+        onProgress(status.monitor_ready === true, capturePhases.has(status.capture_phase) ? status.capture_phase : null)
+      }
+    } catch {
+      // A transient status failure must never be interpreted as permission to log in.
+    }
+  }
+  const outcome = await completion
+  if (outcome.error) throw outcome.error
+  return outcome.value
+}

--- a/frontend/pages/decrypt.vue
+++ b/frontend/pages/decrypt.vue
@@ -1085,6 +1085,7 @@
 import { ref, reactive, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useApi } from '~/composables/useApi'
 import { normalizeWechatInstallPath, readStoredWechatInstallPath } from '~/lib/wechat-install-path'
+import { followMacosCapture, macosCaptureProgressMessage } from '~/lib/macos-capture-progress'
 
 const {
   decryptDatabase,
@@ -2097,14 +2098,16 @@ const runMacosLldbFallback = async ({ requestRevision, requestController, helper
     return false
   }
 
+  const captureTransactionId = String(response?.data?.transaction_id || '')
   const loggedOut = await requestGuideDialog({
     eyebrow: '步骤 2 / 3',
     title: '请在临时微信中退出当前账号',
-    description: '退出到二维码登录界面后不要重新扫码；回到这里点击开始监测，再用手机确认登录。',
+    description: '退出到二维码登录界面后不要重新扫码；点击开始监测并完成管理员授权，等页面明确显示“监测已就绪”后再登录。',
     details: [
       '必须使用微信菜单中的“退出登录”，不要关闭微信窗口',
       '看到二维码后先回到 WCDA 点击“开始监测”',
-      '监测启动后再扫码或在手机上确认同一账号登录'
+      '监测已就绪后再扫码或在手机上确认同一账号登录',
+      '捕获后临时微信窗口会关闭，随后恢复腾讯原签名微信；不要再次登录'
     ],
     note: '捕获只针对这次重新登录计算，并使用所选账号数据库实时校验结果。',
     primaryLabel: '已看到二维码，开始监测',
@@ -2117,38 +2120,25 @@ const runMacosLldbFallback = async ({ requestRevision, requestController, helper
   }
 
   warning.value = '正在等待管理员授权并启动本机监测；显示“监测已就绪”前请不要登录微信。'
-  const captureOutcomePromise = captureMacosKey({
-    ...macosKeyCapturePayload(),
-    signal: requestController.signal
-  }).then(
-    captureResponse => ({ response: captureResponse, captureError: null }),
-    captureError => ({ response: null, captureError })
-  )
-  let captureOutcome = null
-  let monitorReady = false
-  while (isDbKeyRequestActive(requestRevision, requestController) && !captureOutcome && !monitorReady) {
-    captureOutcome = await Promise.race([
-      captureOutcomePromise,
-      waitForDbKeyDelay(350, requestController.signal).then(() => null)
-    ])
-    if (captureOutcome) break
-    try {
-      const statusResponse = await getMacosKeyCaptureStatus({ signal: requestController.signal })
-      monitorReady = statusResponse?.status === 0 && statusResponse?.data?.monitor_ready === true
-    } catch (statusError) {
-      if (statusError?.name === 'AbortError') throw statusError
+  response = await followMacosCapture({
+    transactionId: captureTransactionId,
+    isActive: () => isDbKeyRequestActive(requestRevision, requestController),
+    start: () => captureMacosKey({
+      ...macosKeyCapturePayload(),
+      signal: requestController.signal
+    }),
+    getStatus: async ({ signal }) => {
+      const statusResponse = await getMacosKeyCaptureStatus({ signal })
+      return statusResponse?.status === 0 ? statusResponse.data : null
+    },
+    onProgress: (ready, phase) => {
+      warning.value = macosCaptureProgressMessage(ready, phase)
     }
-  }
+  })
   if (!isDbKeyRequestActive(requestRevision, requestController)) {
     await cleanupMacosKeyCapture({ silent: true })
     return false
   }
-  if (monitorReady) {
-    warning.value = '监测已就绪：现在请扫码或在手机上确认登录，完成前不要关闭微信或 WCDA。'
-  }
-  if (!captureOutcome) captureOutcome = await captureOutcomePromise
-  if (captureOutcome.captureError) throw captureOutcome.captureError
-  response = captureOutcome.response
   macosKeyCapturePrepared.value = response?.data?.needs_cleanup === true
   macosKeyCaptureOwnedByPage.value = macosKeyCapturePrepared.value
   const key = String(response?.data?.db_key || '').trim().toLowerCase()

--- a/macos-key-extractor/.gitignore
+++ b/macos-key-extractor/.gitignore
@@ -1,0 +1,5 @@
+build/
+dist/
+spec/
+__pycache__/
+key_extractor/__pycache__/

--- a/macos-key-extractor/README.md
+++ b/macos-key-extractor/README.md
@@ -1,0 +1,59 @@
+# WeData 密钥提取器（macOS）
+
+这是一个面向普通 Mac 用户、独立且完全在本机运行的工具。它不读取其他应用的设置，也不预设任何用户名、磁盘或网络存储路径，只负责：
+
+- 自动发现微信账号与可校验数据库；
+- 强制执行一次全新捕获，不使用开始前已有的密钥缓存；
+- 在明确确认后临时重签默认路径微信并使用 LLDB 捕获本次登录产生的 passphrase；
+- 使用所选数据库校验密钥，并恢复腾讯原签名微信；
+- 将验证后的密钥保存到当前用户的 `~/.wcdb-key-tool/wechat-passphrase.json`，并支持复制。
+
+工具没有联网、更新或遥测功能。仅用于处理使用者本人有权访问的本机微信数据。
+
+## 使用
+
+1. 将 `WeDataKeyExtractor.app` 放到 `/Applications`。
+2. 在“系统设置 → 隐私与安全性 → 完全磁盘访问权限”中启用它，然后完全退出并重新打开。
+3. 工具会扫描常见微信数据目录；也可以手动选择微信数据库和临时工作目录，然后点击“检查环境并开始”。
+4. 准备完成后点击“显示微信窗口”；如有系统安全提示，由本人决定是否在系统设置中确认。点击“我已手动打开，检查启动”，再依次完成：登录临时微信 → 检查断点 → 退出账号 → 启动监测并授权 → 等待“监测已就绪” → 重新登录同一账号。
+5. 成功或取消后，工具会恢复腾讯原签名微信；成功时可以复制密钥或打开缓存位置。
+
+## 构建
+
+在仓库根目录准备好 `.venv` 后运行：
+
+```bash
+./macos-key-extractor/build-macos.sh
+```
+
+产物位于 `macos-key-extractor/dist/`，文件名会包含当前构建机器的原生架构。默认使用 ad-hoc 签名，适合本人测试；其他用户首次打开时需要按 macOS 提示确认，并单独授予完全磁盘访问权限。
+
+需要让源码构建在升级后继续沿用 macOS 隐私授权时，应显式使用钥匙串中已有的固定签名身份，不要在每次构建时生成新证书。例如：
+
+```bash
+WEDATA_CODESIGN_IDENTITY="Your Existing Code Signing Identity" \
+./macos-key-extractor/build-macos.sh
+```
+
+本地自签名证书只适用于创建它的 Mac，不能作为公共 Release 的发布证书，也不会被打进安装包。
+
+面向公众提供顺畅安装体验时，应使用自己的 Apple Developer ID Application 证书并完成 Apple 公证：
+
+```bash
+WEDATA_CODESIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
+WEDATA_NOTARY_PROFILE="your-notary-profile" \
+./macos-key-extractor/build-macos.sh
+```
+
+构建会强制执行发布审计，发现用户主目录绝对路径、数据库、日志、偏好设置或密钥缓存文件时会终止，不会生成最终安装包。
+
+## 兼容性与隐私
+
+- 当前密钥捕获仅支持 Apple Silicon Mac；构建脚本能生成 Intel 原生产物不代表 LLDB 捕获流程已经兼容 Intel。
+- 默认识别当前微信沙盒目录以及若干旧版常见目录，多账号会分别列出；扫描不到时可手动选择任一加密微信数据库。
+- 微信 4.x 必须使用 `Documents/app_data/xwechat_files` 下的活动数据库；工具不会退回同账号的旧 `Documents/xwechat_files` 副本，避免用错误 salt 拒绝正确候选密钥。
+- 工作文件位于当前登录用户自己的 `~/Library/Application Support/WeDataKeyExtractor/`，不会引用构建者的目录。
+- 密钥只在提取成功并校验后写入当前用户的 `~/.wcdb-key-tool/wechat-passphrase.json`；安装包不包含任何聊天数据库、日志、偏好设置或密钥。
+- 工具不联网、不上传聊天数据，也没有更新、广告或遥测模块。
+
+集成范围、状态机、安全恢复及验证边界见 [macOS 捕获说明](../docs/MACOS_KEY_CAPTURE.md)。本工具的源码不包含本地证书；临时微信签名与工具自身的发布签名是两回事，不能替代 Apple 公证或保证所有微信版本兼容。

--- a/macos-key-extractor/THIRD_PARTY_NOTICES.md
+++ b/macos-key-extractor/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,9 @@
+# Third-party notices
+
+WeData Key Extractor includes a macOS LLDB capture workflow adapted from
+[`TANGandXUE/wcdb-key-tool`](https://github.com/TANGandXUE/wcdb-key-tool),
+which is distributed under the MIT License.
+
+The packaged application also contains the Python runtime and third-party
+Python modules collected by PyInstaller. Their respective licenses continue
+to apply.

--- a/macos-key-extractor/build-macos.sh
+++ b/macos-key-extractor/build-macos.sh
@@ -1,0 +1,133 @@
+#!/bin/zsh
+set -euo pipefail
+
+tool_dir="${0:A:h}"
+repo_root="${tool_dir:h}"
+python_bin="$repo_root/.venv/bin/python"
+dist_dir="${WEDATA_KEY_EXTRACTOR_DIST_DIR:-$tool_dir/dist}"
+work_dir="$tool_dir/build"
+spec_dir="$tool_dir/spec"
+app_path="$dist_dir/WeDataKeyExtractor.app"
+version="1.1.11"
+build_number="14"
+arch_name="$(/usr/bin/uname -m)"
+case "$arch_name" in
+  arm64|x86_64) ;;
+  *)
+    print -u2 "不支持的 Mac 架构: $arch_name"
+    exit 1
+    ;;
+esac
+zip_path="$dist_dir/WeDataKeyExtractor-$version-mac-$arch_name.zip"
+temporary_zip="$dist_dir/.WeDataKeyExtractor-$version-mac-$arch_name.zip.building"
+notary_zip="$dist_dir/.WeDataKeyExtractor-$version-notary.zip"
+
+set_plist_string() {
+  local key="$1"
+  local value="$2"
+  local plist="$3"
+  if /usr/libexec/PlistBuddy -c "Print :$key" "$plist" >/dev/null 2>&1; then
+    /usr/libexec/PlistBuddy -c "Set :$key $value" "$plist"
+  else
+    /usr/libexec/PlistBuddy -c "Add :$key string $value" "$plist"
+  fi
+}
+
+clear_signature_breaking_xattrs() {
+  local target="$1"
+  local attribute
+  for attribute in com.apple.FinderInfo com.apple.ResourceFork; do
+    if /usr/bin/xattr -p "$attribute" "$target" >/dev/null 2>&1; then
+      /usr/bin/xattr -d "$attribute" "$target"
+    fi
+  done
+}
+
+if [[ ! -x "$python_bin" ]]; then
+  print -u2 "找不到项目 Python 环境: $python_bin"
+  exit 1
+fi
+
+"$python_bin" -m PyInstaller \
+  --noconfirm \
+  --clean \
+  --windowed \
+  --onedir \
+  --name WeDataKeyExtractor \
+  --osx-bundle-identifier com.wedata.keyextractor \
+  --paths "$repo_root/src" \
+  --distpath "$dist_dir" \
+  --workpath "$work_dir" \
+  --specpath "$spec_dir" \
+  --hidden-import tkinter \
+  --hidden-import _tkinter \
+  --add-data "$repo_root/src/wechat_decrypt_tool/native/macos/source/wcdb_native_capture.c:wechat_decrypt_tool/native/macos/source" \
+  --add-data "$tool_dir/THIRD_PARTY_NOTICES.md:." \
+  "$tool_dir/main.py"
+
+set_plist_string "CFBundleDisplayName" "WeData 密钥提取器" "$app_path/Contents/Info.plist"
+set_plist_string "CFBundleShortVersionString" "$version" "$app_path/Contents/Info.plist"
+set_plist_string "CFBundleVersion" "$build_number" "$app_path/Contents/Info.plist"
+clear_signature_breaking_xattrs "$app_path"
+
+identity="${WEDATA_CODESIGN_IDENTITY:-}"
+[[ -n "$identity" ]] || identity="-"
+if [[ "$identity" != "-" ]] && ! /usr/bin/security find-identity -v -p codesigning | /usr/bin/grep -Fq "\"$identity\""; then
+  print -u2 "找不到指定的代码签名证书: $identity"
+  exit 1
+fi
+
+signing_arguments=(
+  --force
+  --deep
+  --options runtime
+  --entitlements "$tool_dir/entitlements.plist"
+  --identifier com.wedata.keyextractor
+  --sign "$identity"
+)
+if [[ "$identity" == "WeData Local Code Signing" ]]; then
+  signer_sha1="$(
+    /usr/bin/security find-identity -v -p codesigning \
+      | /usr/bin/sed -nE '/"WeData Local Code Signing"/s/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]{40}).*/\1/p' \
+      | /usr/bin/head -1
+  )"
+  if [[ -z "$signer_sha1" ]]; then
+    print -u2 "无法读取本地代码签名证书指纹"
+    exit 1
+  fi
+  signing_arguments+=(
+    --timestamp=none
+    --requirements "=designated => identifier \"com.wedata.keyextractor\" and certificate leaf = H\"$signer_sha1\""
+  )
+fi
+/usr/bin/codesign "${signing_arguments[@]}" "$app_path"
+clear_signature_breaking_xattrs "$app_path"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$app_path"
+
+if [[ -n "${WEDATA_NOTARY_PROFILE:-}" ]]; then
+  if [[ "$identity" == "-" ]]; then
+    print -u2 "公证必须同时提供 Developer ID Application 签名证书"
+    exit 1
+  fi
+  /usr/bin/ditto -c -k --sequesterRsrc --keepParent "$app_path" "$notary_zip"
+  /usr/bin/xcrun notarytool submit "$notary_zip" \
+    --keychain-profile "$WEDATA_NOTARY_PROFILE" \
+    --wait
+  /usr/bin/xcrun stapler staple "$app_path"
+  /usr/bin/xcrun stapler validate "$app_path"
+fi
+
+"$python_bin" "$tool_dir/release_audit.py" "$app_path"
+/usr/bin/ditto -c -k --sequesterRsrc --keepParent "$app_path" "$temporary_zip"
+/bin/mv -f "$temporary_zip" "$zip_path"
+clear_signature_breaking_xattrs "$app_path"
+clear_signature_breaking_xattrs "$zip_path"
+"$python_bin" "$tool_dir/release_audit.py" "$zip_path"
+verification_dir="$(/usr/bin/mktemp -d /tmp/wedata-key-package.XXXXXX)"
+/usr/bin/ditto -x -k "$zip_path" "$verification_dir"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$verification_dir/WeDataKeyExtractor.app"
+/bin/rm -rf "$verification_dir"
+/usr/bin/shasum -a 256 "$zip_path" > "$zip_path.sha256"
+
+print "已生成: $app_path"
+print "安装包: $zip_path"

--- a/macos-key-extractor/entitlements.plist
+++ b/macos-key-extractor/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/macos-key-extractor/key_extractor/__init__.py
+++ b/macos-key-extractor/key_extractor/__init__.py
@@ -1,0 +1,3 @@
+"""Standalone macOS WeChat database-key extractor."""
+
+__version__ = "1.1.8"

--- a/macos-key-extractor/key_extractor/app.py
+++ b/macos-key-extractor/key_extractor/app.py
@@ -1,0 +1,910 @@
+from __future__ import annotations
+
+import queue
+import re
+import subprocess
+import sys
+import threading
+import time
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+from typing import Any, Callable
+
+from .core import (
+    DEFAULT_WECHAT_APP,
+    account_label,
+    cancel_capture,
+    capture_status,
+    confirm_manual_launch,
+    default_backup_root,
+    discover_default_probe_databases,
+    finish_capture,
+    inspect_environment,
+    load_preferences,
+    mask_database_key,
+    prepare_capture,
+    preflight_capture,
+    prefer_active_probe_database,
+    resolve_probe_database,
+    save_preferences,
+    validate_database_key,
+)
+
+
+_CAPTURE_CLOSE_NOTICE = (
+    "捕获值通过校验后，工具会自动关闭临时微信并恢复腾讯原签名版本；"
+    "这是正常流程，并非闪退，无需重新登录。请等待工具显示最终结果。"
+)
+_CAPTURE_PHASE_ORDER = {
+    "waiting_authorization": 0,
+    "monitoring": 1,
+    # Native and LLDB report capture/validation in different valid orders.
+    "captured": 2,
+    "validating": 2,
+    "restoring": 3,
+}
+
+
+class KeyExtractorApp:
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("WeData 密钥提取器 · 1.1.11")
+        self.root.geometry("760x760")
+        self.root.minsize(700, 720)
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        self._dark = self._system_uses_dark_mode()
+        self._configure_style()
+        preferences = load_preferences()
+        self.wechat_var = tk.StringVar(value=preferences["wechat_app"])
+        self.database_var = tk.StringVar(value=preferences["database_path"])
+        self.work_root_var = tk.StringVar(value=preferences["work_root"])
+        self.status_var = tk.StringVar(value="等待检查本机环境")
+        self.detail_var = tk.StringVar(value="本次不会读取旧密钥缓存；只有重新捕获并校验成功才会显示结果。")
+        self.key_var = tk.StringVar(value="尚未提取")
+        self.stage = "idle"
+        self.db_choices: dict[str, str] = {}
+        self.database_choice_var = tk.StringVar()
+        self.current_key = ""
+        self.last_error = ""
+        self._busy = False
+        self._closing_after_cleanup = False
+        self._closed = False
+        self._capture_waiting_for_ready = False
+        self._capture_ready_deadline = 0.0
+        self._capture_transaction_id = ""
+        self._capture_poll_generation = 0
+        self._capture_poll_active = False
+        self._capture_poll_after_id = None
+        self._tasks: queue.Queue[tuple[bool, Any, Callable[[Any], None] | None]] = queue.Queue()
+        self._prepared_health_results = queue.Queue()
+        self._prepared_health_inflight = False
+        self._prepared_exit_attempted_transaction = ""
+
+        self._build_ui()
+        self._discover_accounts()
+        self.root.after(100, self._drain_tasks)
+        self.root.after(250, self._check_pending_capture)
+        self.root.after(1000, self._poll_prepared_health)
+
+    def _poll_prepared_health(self) -> None:
+        """Detect late startup rejection without blocking Tk or touching capture."""
+        if self._closed:
+            return
+        try:
+            transaction_id, status = self._prepared_health_results.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            self._prepared_health_inflight = False
+            self._apply_prepared_health(transaction_id, status)
+        if (not self._busy and self.stage in {"prepared", "preflight"}
+                and self._capture_transaction_id and not self._prepared_health_inflight):
+            self._prepared_health_inflight = True
+            transaction_id = self._capture_transaction_id
+            wechat_app = self.wechat_var.get()
+            results = self._prepared_health_results
+
+            def read_health() -> None:
+                try:
+                    status = capture_status(wechat_app)
+                except Exception:
+                    status = {}
+                results.put((transaction_id, status))
+
+            threading.Thread(target=read_health, daemon=True).start()
+        self.root.after(1000, self._poll_prepared_health)
+
+    def _apply_prepared_health(self, transaction_id: str, status: dict[str, Any]) -> None:
+        if (self._busy or self._closed or self._closing_after_cleanup
+                or self.stage not in {"prepared", "preflight"}
+                or not transaction_id or transaction_id != self._capture_transaction_id
+                or transaction_id == self._prepared_exit_attempted_transaction
+                or status.get("transaction_id") != transaction_id
+                or status.get("stage") not in {"launched", "preflight_passed"}
+                or status.get("prepared_process_exited") is not True):
+            return
+        self._prepared_exit_attempted_transaction = transaction_id
+        self.last_error = "临时微信已退出或启动被中止，本次未完成提取。请勿反复登录或绕过系统安全提示。"
+        self.detail_var.set(self.last_error)
+        # Run the existing serialized, identity-checked recovery. Never swap
+        # bundles from a status reader or while another operation is active.
+        self._run_task(
+            lambda: cancel_capture(self.wechat_var.get(), self.work_root_var.get()),
+            self._prepared_exit_recovered,
+            status="临时微信已退出，正在检查并恢复官方原版…",
+        )
+
+    def _prepared_exit_recovered(self, result: dict[str, Any]) -> None:
+        self._cancelled(result)
+        if result.get("official_wechat_verified") is True and not self._closed:
+            self.status_var.set("本次提取已停止，官方微信已恢复" if result.get("official_wechat_restored")
+                                else "本次提取已停止，当前官方微信已确认")
+
+    @staticmethod
+    def _system_uses_dark_mode() -> bool:
+        result = subprocess.run(
+            ["/usr/bin/defaults", "read", "-g", "AppleInterfaceStyle"],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0 and "dark" in result.stdout.lower()
+
+    def _configure_style(self) -> None:
+        self.colors = (
+            {
+                "bg": "#181818",
+                "surface": "#252525",
+                "soft": "#2E2E2E",
+                "text": "#F5F5F5",
+                "muted": "#C7C7C7",
+                "border": "#3D3D3D",
+                "accent": "#07C160",
+                "danger": "#FF7373",
+            }
+            if self._dark
+            else {
+                "bg": "#F4FAF6",
+                "surface": "#FFFFFF",
+                "soft": "#F1F8F3",
+                "text": "#18201B",
+                "muted": "#66736B",
+                "border": "#D8E8DD",
+                "accent": "#07C160",
+                "danger": "#C43A3A",
+            }
+        )
+        self.root.configure(bg=self.colors["bg"])
+        style = ttk.Style(self.root)
+        style.theme_use("clam")
+        style.configure("TFrame", background=self.colors["bg"])
+        style.configure("Card.TFrame", background=self.colors["surface"])
+        style.configure("TLabel", background=self.colors["bg"], foreground=self.colors["text"])
+        style.configure("Card.TLabel", background=self.colors["surface"], foreground=self.colors["text"])
+        style.configure("Muted.TLabel", background=self.colors["surface"], foreground=self.colors["muted"])
+        style.configure(
+            "TEntry",
+            fieldbackground=self.colors["soft"],
+            foreground=self.colors["text"],
+            bordercolor=self.colors["border"],
+            insertcolor=self.colors["text"],
+        )
+        style.configure(
+            "TCombobox",
+            fieldbackground=self.colors["soft"],
+            foreground=self.colors["text"],
+            background=self.colors["soft"],
+            bordercolor=self.colors["border"],
+            arrowcolor=self.colors["muted"],
+        )
+        style.map("TCombobox", fieldbackground=[("readonly", self.colors["soft"])])
+        style.configure(
+            "TButton",
+            padding=(12, 8),
+            background=self.colors["soft"],
+            foreground=self.colors["text"],
+            bordercolor=self.colors["border"],
+        )
+        style.map("TButton", background=[("active", self.colors["border"])])
+        style.configure(
+            "Accent.TButton",
+            padding=(14, 9),
+            background=self.colors["accent"],
+            foreground="#FFFFFF",
+            bordercolor=self.colors["accent"],
+        )
+        style.map("Accent.TButton", background=[("active", "#06AD56"), ("disabled", self.colors["border"])])
+
+    def _build_ui(self) -> None:
+        outer = ttk.Frame(self.root, padding=20)
+        outer.pack(fill="both", expand=True)
+
+        ttk.Label(outer, text="本机工具 · 不联网", foreground=self.colors["accent"]).pack(anchor="w")
+        ttk.Label(outer, text="WeData 密钥提取器", font=("SF Pro Display", 26, "bold")).pack(anchor="w", pady=(4, 2))
+
+        settings = ttk.Frame(outer, style="Card.TFrame", padding=16)
+        settings.pack(fill="x", pady=(10, 0))
+        settings.columnconfigure(1, weight=1)
+
+        self._field_row(settings, 0, "微信应用", self.wechat_var, self._pick_wechat_app)
+        ttk.Label(settings, text="微信账号", style="Card.TLabel").grid(row=1, column=0, sticky="w", padx=(0, 12), pady=6)
+        self.account_combo = ttk.Combobox(settings, textvariable=self.database_choice_var, state="readonly")
+        self.account_combo.grid(row=1, column=1, sticky="ew", pady=6)
+        self.account_combo.bind("<<ComboboxSelected>>", self._on_account_selected)
+        ttk.Button(settings, text="重新扫描", command=self._discover_accounts).grid(row=1, column=2, padx=(8, 0), pady=6)
+
+        self._field_row(settings, 2, "数据库", self.database_var, self._pick_database)
+        self._field_row(settings, 3, "备份根目录", self.work_root_var, self._pick_work_root)
+
+        status = ttk.Frame(outer, style="Card.TFrame", padding=16)
+        status.pack(fill="x", pady=(12, 0))
+        ttk.Label(status, textvariable=self.status_var, style="Card.TLabel", font=("SF Pro Text", 16, "bold")).pack(anchor="w")
+        ttk.Label(
+            status,
+            textvariable=self.detail_var,
+            style="Muted.TLabel",
+            wraplength=680,
+            justify="left",
+        ).pack(anchor="w", pady=(7, 12))
+        self.progress = ttk.Progressbar(status, mode="indeterminate")
+        self.progress.pack(fill="x")
+
+        key_card = ttk.Frame(outer, style="Card.TFrame", padding=16)
+        key_card.pack(fill="x", pady=(12, 0))
+        ttk.Label(key_card, text="数据库密钥", style="Card.TLabel").pack(anchor="w")
+        ttk.Label(key_card, textvariable=self.key_var, style="Card.TLabel", font=("SF Mono", 15, "bold")).pack(anchor="w", pady=(7, 10))
+        key_actions = ttk.Frame(key_card, style="Card.TFrame")
+        key_actions.pack(fill="x")
+        self.copy_button = ttk.Button(key_actions, text="复制密钥", command=self._copy_key, state="disabled")
+        self.copy_button.pack(side="left")
+        ttk.Button(key_actions, text="打开缓存位置", command=self._open_key_location).pack(side="left", padx=(8, 0))
+
+        actions = ttk.Frame(outer)
+        actions.pack(fill="x", pady=(14, 0))
+        self.primary_button = ttk.Button(actions, text="检查环境并开始", style="Accent.TButton", command=self._start)
+        self.primary_button.pack(side="left")
+        self.cancel_button = ttk.Button(actions, text="取消并恢复微信", command=self._cancel, state="disabled")
+        self.cancel_button.pack(side="left", padx=(8, 0))
+        ttk.Button(actions, text="完全磁盘访问设置", command=self._open_full_disk_access).pack(side="right")
+        ttk.Button(actions, text="显示微信窗口", command=self._show_wechat).pack(side="right", padx=(0, 8))
+        ttk.Button(outer, text="打开系统设置（安全授权需本人确认）", command=self._open_security_settings).pack(anchor="e", pady=(6, 0))
+
+        ttk.Label(
+            outer,
+            text="仅供处理你本人有权访问的微信数据。提取期间会临时重签默认路径微信，并在结束时恢复腾讯原签名版本。",
+            foreground=self.colors["muted"],
+            wraplength=700,
+            justify="left",
+        ).pack(anchor="w", pady=(14, 0))
+
+    def _field_row(
+        self,
+        parent: ttk.Frame,
+        row: int,
+        label: str,
+        variable: tk.StringVar,
+        command: Callable[[], None],
+    ) -> None:
+        ttk.Label(parent, text=label, style="Card.TLabel").grid(row=row, column=0, sticky="w", padx=(0, 12), pady=6)
+        ttk.Entry(parent, textvariable=variable).grid(row=row, column=1, sticky="ew", pady=6)
+        ttk.Button(parent, text="选择", command=command).grid(row=row, column=2, padx=(8, 0), pady=6)
+
+    def _discover_accounts(self) -> None:
+        current = self.database_var.get().strip()
+        databases = []
+        current_path = Path(current).expanduser() if current else None
+        try:
+            current_is_usable = bool(
+                current_path
+                and current_path.is_file()
+                and current_path.stat().st_size >= 4096
+            )
+        except OSError:
+            current_is_usable = False
+        if current_is_usable:
+            try:
+                databases = [
+                    Path(prefer_active_probe_database(
+                        current,
+                        wechat_app=self.wechat_var.get(),
+                    ))
+                ]
+            except (FileNotFoundError, PermissionError, OSError):
+                databases = []
+        if not databases:
+            databases = [
+                Path(prefer_active_probe_database(path, wechat_app=self.wechat_var.get()))
+                for path in discover_default_probe_databases()
+            ]
+        self.db_choices = {
+            f"{account_label(path)} · {path.name}": str(path)
+            for path in databases
+        }
+        selected = next((label for label, path in self.db_choices.items() if path == current), "")
+        if current and not selected:
+            # An updated ad-hoc application can temporarily lose its macOS
+            # Full Disk Access grant.  Do not silently replace the saved
+            # app_data database with a visible but stale legacy duplicate;
+            # preserve the explicit path so environment inspection reports
+            # the permission problem to the user.
+            saved_label = f"{account_label(current)} · {Path(current).name} · 已保存路径"
+            while saved_label in self.db_choices:
+                saved_label += "*"
+            self.db_choices[saved_label] = current
+            selected = saved_label
+        elif not selected and self.db_choices:
+            selected = next(iter(self.db_choices))
+            self.database_var.set(self.db_choices[selected])
+        self.account_combo["values"] = list(self.db_choices)
+        self.database_choice_var.set(selected or "未自动找到账号，请手动选择数据库")
+
+    def _on_account_selected(self, _event: object = None) -> None:
+        selected = self.db_choices.get(self.database_choice_var.get())
+        if selected:
+            self.database_var.set(selected)
+
+    def _pick_wechat_app(self) -> None:
+        selected = filedialog.askdirectory(initialdir="/Applications", title="选择 WeChat.app")
+        if selected:
+            self.wechat_var.set(selected)
+
+    def _pick_database(self) -> None:
+        selected = filedialog.askopenfilename(
+            title="选择任意加密微信数据库",
+            filetypes=[("微信数据库", "*.db"), ("所有文件", "*")],
+        )
+        if selected:
+            self.database_var.set(selected)
+
+    def _pick_work_root(self) -> None:
+        selected = filedialog.askdirectory(title="选择原版微信备份根目录")
+        if selected:
+            self.work_root_var.set(selected)
+
+    def _persist(self) -> None:
+        save_preferences(
+            {
+                "wechat_app": self.wechat_var.get().strip() or str(DEFAULT_WECHAT_APP),
+                "database_path": self.database_var.get().strip(),
+                "work_root": self.work_root_var.get().strip(),
+            }
+        )
+
+    def _set_busy(self, busy: bool) -> None:
+        self._busy = busy
+        if busy:
+            self.progress.start(10)
+            self.primary_button.configure(state="disabled")
+            self.cancel_button.configure(state="disabled")
+        else:
+            self.progress.stop()
+            self.primary_button.configure(state="normal")
+            self.cancel_button.configure(state="normal" if self.stage in {"system_approval", "prepared", "preflight"} else "disabled")
+
+    def _run_task(
+        self,
+        operation: Callable[[], Any],
+        success: Callable[[Any], None],
+        *,
+        status: str,
+    ) -> None:
+        if self._busy:
+            return
+        self.status_var.set(status)
+        self._set_busy(True)
+
+        def worker() -> None:
+            try:
+                self._tasks.put((True, operation(), success))
+            except Exception as exc:
+                self._tasks.put((False, exc, None))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _drain_tasks(self) -> None:
+        if self._closed:
+            return
+        try:
+            while True:
+                ok, value, callback = self._tasks.get_nowait()
+                self._set_busy(False)
+                if ok and callback is not None:
+                    callback(value)
+                elif not ok:
+                    self._handle_error(value)
+                if self._closed:
+                    return
+        except queue.Empty:
+            pass
+        self.root.after(100, self._drain_tasks)
+
+    def _start(self) -> None:
+        if self.stage == "system_approval":
+            self._run_task(
+                lambda: confirm_manual_launch(self.wechat_var.get(), self.work_root_var.get(), self._capture_transaction_id),
+                self._manual_launch_checked,
+                status="正在检查你手动打开的微信；不会自动授权或启动监测…",
+            )
+            return
+        if self.stage == "prepared":
+            self._run_preflight()
+            return
+        if self.stage == "preflight":
+            self._run_capture()
+            return
+        if self.stage == "success":
+            self._copy_key()
+            return
+
+        self._persist()
+        self._run_task(
+            lambda: inspect_environment(
+                self.wechat_var.get(),
+                self.database_var.get(),
+                self.work_root_var.get(),
+            ),
+            self._environment_ready,
+            status="正在检查微信、数据库和备份目录…",
+        )
+
+    def _environment_ready(self, result: dict[str, Any]) -> None:
+        if result.get("errors"):
+            self._handle_error(RuntimeError("\n".join(result["errors"])))
+            return
+        self.database_var.set(str(result["database"]))
+        self._persist()
+        self.detail_var.set("环境检查通过。本次不会读取旧密钥缓存，将直接开始全新捕获。")
+        self._confirm_fresh_capture()
+
+    def _confirm_fresh_capture(self) -> None:
+        restarting = self.stage == "external_install_conflict"
+        confirmed = messagebox.askokcancel(
+            "以当前版本重新开始" if restarting else "开始全新提取",
+            ("将重新验证当前腾讯官方微信，并以当前版本建立新事务。旧备份和原版保护副本会保留，"
+             "不会用旧版本覆盖当前安装。\n\n" if restarting else "")
+            + "本次将忽略已有密钥缓存。接下来会先在所选备份目录保存并验证腾讯原版微信，"
+            "然后临时重签 /Applications/WeChat.app。\n\n"
+            "准备完成后，请点击“显示微信窗口”手动打开。若系统提示无法验证，你可以自行决定是否在"
+            "系统设置中为该应用授权；工具不会关闭安全保护，也不会代替你确认。\n\n"
+            + _CAPTURE_CLOSE_NOTICE + "\n\n是否继续？",
+        )
+        if not confirmed:
+            self.status_var.set("已取消")
+            return
+        self._run_task(
+            lambda: prepare_capture(self.wechat_var.get(), self.work_root_var.get()),
+            self._prepared,
+            status="正在验证原版备份并准备临时微信…",
+        )
+
+    def _prepared(self, result: dict[str, Any]) -> None:
+        self._capture_transaction_id = str(result.get("transaction_id") or "")
+        if result.get("requires_manual_launch") is True:
+            self.stage = "system_approval"
+            self.status_var.set("等待你手动打开微信；尚未启动监测")
+            self.detail_var.set(
+                "先点击“显示微信窗口”。若仅提示“Apple 无法验证”，且你确认来源可信，可自行在"
+                "系统设置 → 隐私与安全性中查看该微信的“仍要打开”。这是单应用授权，不是 Apple 公证。\n"
+                "若提示含恶意软件、会损害电脑，或没有允许入口，请取消并恢复，不要继续。\n"
+                "微信正常打开后点击下方“检查启动”；未能打开也可随时取消并恢复。"
+            )
+            self.primary_button.configure(text="我已手动打开，检查启动")
+            self.cancel_button.configure(state="normal")
+            return
+        self.stage = "prepared"
+        self.status_var.set("第一步：先登录临时微信")
+        self.detail_var.set(
+            "请只使用系统自动打开的微信窗口，完成扫码、手机确认和验证码，直到进入聊天主界面；"
+            "然后点击“我已登录，检查断点”。此时监测尚未启动。"
+        )
+        self.primary_button.configure(text="我已登录，检查断点")
+        self.cancel_button.configure(state="normal")
+        self.root.after(150, self._show_wechat)
+
+    def _manual_launch_checked(self, result: dict[str, Any]) -> None:
+        if not self._capture_transaction_id or result.get("transaction_id") != self._capture_transaction_id:
+            self._handle_error(RuntimeError("启动确认不属于本次事务，请先取消并恢复微信。"))
+            return
+        if result.get("ready_for_preflight") is not True:
+            self.status_var.set("尚未检测到稳定运行的临时微信")
+            self.detail_var.set("系统可能仍在等待你的决定，也可能启动失败。工具未启动监测、未重新签名。"
+                                "请先处理系统提示；若仍打不开，请取消并恢复微信。")
+            return
+        self._prepared(result)
+
+    def _run_preflight(self) -> None:
+        self._run_task(
+            lambda: preflight_capture(self.wechat_var.get(), self.work_root_var.get()),
+            self._preflight_ready,
+            status="正在检查可用断点；授权后会立即分离…",
+        )
+
+    def _preflight_ready(self, result: dict[str, Any]) -> None:
+        self._capture_transaction_id = str(result.get("transaction_id") or "")
+        self.stage = "preflight"
+        self.status_var.set("第二步：退出账号，再启动监测")
+        method = str(result.get("method") or "")
+        check_label = (
+            "低内存原生断点检查通过"
+            if "native" in method
+            else "断点检查通过"
+        )
+        self.detail_var.set(
+            f"{check_label}。现在请在当前微信里打开设置并退出账号，"
+            "等到显示二维码登录界面后，不要先扫码；"
+            "回到这里点击“已退出，启动监测”。"
+        )
+        self.primary_button.configure(text="已退出，启动监测")
+        self.cancel_button.configure(state="normal")
+
+    def _run_capture(self) -> None:
+        if self._busy:
+            return
+        confirmed = messagebox.askokcancel(
+            "确认已退出账号",
+            "请确认临时微信现在停留在二维码登录界面。点击继续后允许管理员授权，"
+            "等待工具明确显示“监测已就绪，可以重新登录”后，再登录同一个微信账号。\n\n"
+            + _CAPTURE_CLOSE_NOTICE,
+        )
+        if not confirmed:
+            return
+        hidden = self._hide_wechat()
+        self._stop_capture_polling()
+        self._capture_poll_active = True
+        self._capture_waiting_for_ready = True
+        self._capture_ready_deadline = time.monotonic() + 60.0
+        self._capture_phase_order = -1
+        self._capture_ready_shown = False
+        self._capture_status_inflight = False
+        self._capture_status_results: queue.Queue[dict[str, Any]] = queue.Queue()
+        generation = self._capture_poll_generation
+        self.detail_var.set(
+            ("微信登录窗口已暂时隐藏。请先完成管理员授权；只有界面提示“监测已就绪”后，"
+            "微信才会重新显示，此时再登录同一个账号。"
+            if hidden
+            else "正在安装登录监测。请先完成管理员授权；监测就绪前不要扫码或登录微信。")
+            + "\n" + _CAPTURE_CLOSE_NOTICE
+        )
+        self._run_task(
+            lambda: finish_capture(
+                self.wechat_var.get(),
+                self.database_var.get(),
+                self.work_root_var.get(),
+            ),
+            lambda result: self._capture_finished(result, generation),
+            status="等待管理员授权并安装登录监测…",
+        )
+        self._capture_poll_after_id = self.root.after(250, lambda: self._wait_for_monitor_ready(generation))
+
+    def _wait_for_monitor_ready(self, generation: int | None = None) -> None:
+        """Keep polling through restore; filesystem/signature reads never run on Tk."""
+        if generation is not None and generation != self._capture_poll_generation:
+            return
+        if not self._capture_poll_active or getattr(self, "_closed", False):
+            return
+        self._capture_poll_after_id = None
+        if not self._busy or self._closing_after_cleanup:
+            self._stop_capture_polling()
+            return
+        generation = self._capture_poll_generation
+        try:
+            status = self._capture_status_results.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            self._capture_status_inflight = False
+            self._apply_capture_status(status)
+        if self._capture_waiting_for_ready and time.monotonic() >= self._capture_ready_deadline:
+            self.detail_var.set(
+                "仍在等待管理员授权或登录监测安装完成；监测就绪前不要扫码或登录。\n"
+                + _CAPTURE_CLOSE_NOTICE
+            )
+        if not self._capture_status_inflight:
+            self._capture_status_inflight = True
+            wechat_app = self.wechat_var.get()
+            results = self._capture_status_results
+
+            def read_status() -> None:
+                try:
+                    value = capture_status(wechat_app)
+                except Exception:
+                    value = {}
+                # A per-run queue prevents an old reader from entering a new run.
+                results.put(value)
+
+            threading.Thread(target=read_status, daemon=True).start()
+        self._capture_poll_after_id = self.root.after(250, lambda: self._wait_for_monitor_ready(generation))
+
+    def _apply_capture_status(self, status: dict[str, Any]) -> None:
+        if (not status.get("pending") or not self._capture_transaction_id
+                or status.get("transaction_id") != self._capture_transaction_id):
+            # Clearing state is not success: finish_capture still has to return.
+            return
+        phase = status.get("capture_phase")
+        order = _CAPTURE_PHASE_ORDER.get(phase, -1)
+        if order < 0 or order < self._capture_phase_order:
+            return
+        if phase == "monitoring" and status.get("monitor_ready") is not True:
+            return
+        self._capture_phase_order = order
+        if phase == "waiting_authorization":
+            self.status_var.set("等待管理员授权并安装登录监测…")
+            return
+        self._capture_waiting_for_ready = False
+        if phase == "monitoring":
+            self.status_var.set("监测已就绪，可以重新登录")
+            self.detail_var.set("登录监测已安装并正在监听。请登录同一个账号。\n" + _CAPTURE_CLOSE_NOTICE)
+            if not self._capture_ready_shown:
+                self._capture_ready_shown = True
+                self._show_wechat()
+        elif phase == "captured":
+            self.status_var.set("捕获值已通过消息库与会话库校验")
+            self.detail_var.set(_CAPTURE_CLOSE_NOTICE)
+        elif phase == "validating":
+            self.status_var.set("正在复验本次捕获结果…")
+            self.detail_var.set("正在进行最终数据库复验，尚未完成提取。无需重新登录；请等待复验与恢复流程结束。")
+        elif phase == "restoring":
+            self.status_var.set("正在恢复腾讯原签名微信…")
+            self.detail_var.set(
+                "正在结束临时微信并恢复原版；成功和失败都会执行此步骤，尚不能据此确认提取成功。"
+                "无需重新登录，请等待最终结果。"
+            )
+
+    def _stop_capture_polling(self) -> None:
+        self._capture_poll_active = False
+        self._capture_waiting_for_ready = False
+        self._capture_poll_generation = getattr(self, "_capture_poll_generation", 0) + 1
+        callback_id = getattr(self, "_capture_poll_after_id", None)
+        self._capture_poll_after_id = None
+        if callback_id is not None:
+            self.root.after_cancel(callback_id)
+
+    def _capture_finished(self, result: dict[str, Any], generation: int | None = None) -> None:
+        if getattr(self, "_closed", False) or (
+            generation is not None and generation != self._capture_poll_generation
+        ):
+            return
+        self._stop_capture_polling()
+        if result.get("fresh_capture") is not True or result.get("process_attached") is not True:
+            self._handle_error(RuntimeError("本次结果缺少实时捕获证明，已拒绝显示旧缓存密钥"))
+            return
+        if result.get("official_wechat_verified") is not True:
+            self._handle_error(RuntimeError("尚未确认腾讯官方微信恢复，已拒绝显示提取成功；请保留恢复状态与备份。"))
+            return
+        self._show_success(result.get("db_key"))
+
+    def _show_success(self, key: Any) -> None:
+        self.current_key = validate_database_key(key)
+        self.key_var.set(mask_database_key(self.current_key))
+        self.stage = "success"
+        self.status_var.set("密钥已获取并通过数据库校验")
+        self.detail_var.set(
+            "本次密钥来自刚刚完成的实时登录捕获；临时调试微信已关闭，腾讯原签名微信已恢复。"
+            "你可以点击下方按钮复制密钥，或打开本机受限缓存位置。"
+        )
+        self.primary_button.configure(text="复制密钥")
+        self.copy_button.configure(state="normal")
+        self.cancel_button.configure(state="disabled")
+
+    def _cancel(self) -> None:
+        if self._busy:
+            return
+        if not messagebox.askokcancel("取消并恢复", "将关闭临时微信并恢复腾讯原签名版本，是否继续？"):
+            return
+        self._stop_capture_polling()
+        self._run_task(
+            lambda: cancel_capture(self.wechat_var.get(), self.work_root_var.get()),
+            self._cancelled,
+            status="正在恢复腾讯原签名微信…",
+        )
+
+    def _cancelled(self, result: dict[str, Any]) -> None:
+        self._stop_capture_polling()
+        if result.get("official_wechat_verified") is not True:
+            self._handle_error(RuntimeError("尚未确认腾讯官方微信；恢复状态与备份均需保留。"))
+            return
+        self.stage = "idle"
+        restored = result.get("official_wechat_restored") is True
+        self.status_var.set("已取消并恢复腾讯原签名微信" if restored else "已取消，当前腾讯官方签名已确认")
+        detail = "可以重新检查环境并开始提取。" if restored else "本次未替换当前微信，可以重新检查环境并开始提取。"
+        if self.last_error:
+            detail += f"\n上次错误：{self.last_error}"
+        self.detail_var.set(detail)
+        self.primary_button.configure(text="检查环境并开始")
+        self.cancel_button.configure(state="disabled")
+        if self._closing_after_cleanup:
+            self._destroy_window()
+
+    def _check_pending_capture(self) -> None:
+        try:
+            status = capture_status(self.wechat_var.get())
+        except Exception:
+            status = {"pending": True, "stage": "invalid"}
+        if self._show_recovery_conflict(status):
+            return
+        if status.get("pending"):
+            self.stage = "prepared"
+            self.status_var.set("发现上次未完成的临时重签状态")
+            self.detail_var.set("请先点击“取消并恢复微信”，确认腾讯原签名版本恢复后再开始新的提取。")
+            self.primary_button.configure(state="disabled", text="等待恢复")
+            self.cancel_button.configure(state="normal")
+
+    def _show_recovery_conflict(self, status: dict[str, Any], message: str = "") -> bool:
+        if not status.get("pending"):
+            return False
+        recovery_stage = status.get("stage")
+        if recovery_stage == "external_install_conflict":
+            self.stage = "external_install_conflict"
+            self.status_var.set("微信安装已变化，未执行旧版恢复")
+            self.detail_var.set(
+                (f"{message}\n" if message else "")
+                + "可点击“以当前版本重新开始”：重新验证当前腾讯官方版并建立新备份。旧备份和保护副本会保留，不会用旧版覆盖当前安装。"
+            )
+            self.primary_button.configure(state="normal", text="以当前版本重新开始")
+            self.cancel_button.configure(state="disabled")
+            return True
+        if recovery_stage in {"recovery_blocked", "invalid"}:
+            self.stage = "recovery_blocked"
+            self.status_var.set("应用身份待确认，已停止自动处理")
+            self.detail_var.set(
+                (f"{message}\n" if message else "")
+                + "当前应用无法安全归属本次事务，未覆盖安装。请先确认或重新安装所需的腾讯官方版，再重新打开工具检查；旧备份和恢复状态会保留。"
+            )
+            self.primary_button.configure(state="disabled", text="需要手动处理")
+            self.cancel_button.configure(state="disabled")
+            return True
+        return False
+
+    def _copy_key(self) -> None:
+        if not self.current_key:
+            return
+        self.root.clipboard_clear()
+        self.root.clipboard_append(self.current_key)
+        self.status_var.set("密钥已复制到剪贴板")
+
+    @staticmethod
+    def _open_key_location() -> None:
+        path = Path.home() / ".wcdb-key-tool"
+        path.mkdir(parents=True, exist_ok=True)
+        subprocess.Popen(["/usr/bin/open", str(path)])
+
+    def _show_wechat(self) -> None:
+        if getattr(self, "_closed", False):
+            return
+        wechat_app = Path(self.wechat_var.get().strip() or DEFAULT_WECHAT_APP).expanduser()
+        if not wechat_app.is_dir():
+            messagebox.showerror("WeData 密钥提取器", f"微信应用不存在: {wechat_app}")
+            return
+        subprocess.Popen(
+            ["/usr/bin/open", str(wechat_app)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def _hide_wechat(self) -> bool:
+        """Hide the selected WeChat process without relying on its AppleEvent handler."""
+
+        wechat_app = Path(self.wechat_var.get().strip() or DEFAULT_WECHAT_APP).expanduser()
+        executable = wechat_app / "Contents" / "MacOS" / "WeChat"
+        try:
+            processes = subprocess.run(
+                ["/usr/bin/pgrep", "-f", f"^{re.escape(str(executable))}$"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+            pids = [line.strip() for line in processes.stdout.splitlines() if line.strip().isdigit()]
+            if not pids:
+                return False
+            script = (
+                "ObjC.import('AppKit'); "
+                f"const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier({int(pids[0])}); "
+                "if (!app || !app.hide()) { throw new Error('unable to hide WeChat'); }"
+            )
+            result = subprocess.run(
+                ["/usr/bin/osascript", "-l", "JavaScript", "-e", script],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            return result.returncode == 0
+        except (OSError, subprocess.TimeoutExpired, ValueError):
+            return False
+
+    @staticmethod
+    def _open_security_settings() -> None:
+        # Open the settings app only; no trust exceptions or security options
+        # are changed, and no confirmation is automated.
+        subprocess.Popen(["/usr/bin/open", "-b", "com.apple.systempreferences"])
+
+    @staticmethod
+    def _open_full_disk_access() -> None:
+        subprocess.Popen(
+            [
+                "/usr/bin/open",
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+            ]
+        )
+
+    def _on_close(self) -> None:
+        if self._busy:
+            messagebox.showinfo("操作进行中", "当前操作尚未结束，请等待完成或系统返回错误后再关闭。")
+            return
+        try:
+            status = capture_status(self.wechat_var.get())
+        except Exception:
+            status = {"pending": True, "stage": "invalid"}
+        if status.get("pending") and status.get("stage") in {"external_install_conflict", "recovery_blocked", "invalid"}:
+            if messagebox.askokcancel("保留当前微信并退出", "恢复尚未完成。关闭工具不会替换当前微信，旧备份和恢复状态都会保留。是否退出？"):
+                self._destroy_window()
+            return
+        if not status.get("pending"):
+            self._destroy_window()
+            return
+        if not messagebox.askokcancel("先恢复微信", "当前微信处于临时调试状态。关闭前必须恢复腾讯原签名版本。"):
+            return
+        self._closing_after_cleanup = True
+        self._stop_capture_polling()
+        self._run_task(
+            lambda: cancel_capture(self.wechat_var.get(), self.work_root_var.get()),
+            self._cancelled,
+            status="关闭前正在恢复腾讯原签名微信…",
+        )
+
+    def _destroy_window(self) -> None:
+        self._closed = True
+        self._stop_capture_polling()
+        self.root.destroy()
+
+    def _handle_error(self, error: Exception) -> None:
+        if getattr(self, "_closed", False):
+            return
+        self._stop_capture_polling()
+        message = str(error)
+        code = str(getattr(error, "code", "unclassified_error") or "unclassified_error")
+        safe_message = message.replace(str(Path.home()), "<HOME>")
+        safe_message = re.sub(r"\b[0-9a-fA-F]{64}\b", "<REDACTED_KEY>", safe_message)
+        self.last_error = f"[{code}] {safe_message}"
+        print(
+            f"WEDATA_UI_ERROR stage={self.stage} code={code} message={safe_message}",
+            file=sys.stderr,
+            flush=True,
+        )
+        try:
+            status = capture_status(self.wechat_var.get())
+        except Exception:
+            status = {"pending": True, "stage": "invalid"}
+        if code in {"in_place_debug_identity_unknown", "official_restore_staging_conflict"}:
+            status = {**status, "pending": True, "stage": "recovery_blocked"}
+        handled_conflict = self._show_recovery_conflict(status, message)
+        if handled_conflict:
+            pass
+        elif status.get("pending"):
+            self.stage = "prepared"
+            self.status_var.set("操作失败，请先恢复微信")
+            self.detail_var.set(f"{message}\n请点击“取消并恢复微信”，确认恢复后再重新开始。")
+            self.primary_button.configure(state="disabled", text="等待恢复")
+            self.cancel_button.configure(state="normal")
+        else:
+            self.stage = "idle"
+            self.status_var.set("提取失败，可以重新开始")
+            self.detail_var.set(message)
+            self.primary_button.configure(state="normal", text="重新开始")
+            self.cancel_button.configure(state="disabled")
+        if self._closing_after_cleanup:
+            self._closing_after_cleanup = False
+        messagebox.showerror("WeData 密钥提取器", message)
+
+
+def main() -> None:
+    root = tk.Tk()
+    KeyExtractorApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/macos-key-extractor/key_extractor/core.py
+++ b/macos-key-extractor/key_extractor/core.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_WECHAT_APP = Path("/Applications/WeChat.app")
+DEFAULT_DATA_RELATIVE = Path(
+    "Library/Containers/com.tencent.xinWeChat/Data/Documents/app_data/xwechat_files"
+)
+DEFAULT_DATA_RELATIVES = (
+    DEFAULT_DATA_RELATIVE,
+    Path("Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files"),
+    Path("Documents/xwechat_files"),
+    Path("Documents/WeChat Files"),
+)
+APP_SUPPORT_RELATIVE = Path("Library/Application Support/WeDataKeyExtractor")
+DATABASE_PRIORITY = (
+    "msg0.db",
+    "msg.db",
+    "message_0.db",
+    "message_1.db",
+    "session.db",
+    "contact.db",
+    "favorite.db",
+    "sns.db",
+    "general.db",
+    "media_0.db",
+    "head_image.db",
+)
+KNOWN_DATABASE_RELATIVES = (
+    Path("msg0.db"),
+    Path("msg.db"),
+    Path("message_0.db"),
+    Path("message/message_0.db"),
+    Path("message/message_1.db"),
+    Path("session.db"),
+    Path("session/session.db"),
+    Path("contact.db"),
+    Path("contact/contact.db"),
+    Path("sns.db"),
+    Path("sns/sns.db"),
+    Path("general.db"),
+    Path("general/general.db"),
+)
+
+
+def app_support_root(home: str | Path | None = None) -> Path:
+    base = Path(home).expanduser() if home is not None else Path.home()
+    return base / APP_SUPPORT_RELATIVE
+
+
+def default_work_root(home: str | Path | None = None) -> Path:
+    """Use this app's per-user support directory on every machine."""
+
+    base = Path(home).expanduser() if home is not None else Path.home()
+    return app_support_root(base) / "work"
+
+
+def default_backup_root(work_root: str | Path) -> Path:
+    return Path(work_root).expanduser() / "wechat-app-backups"
+
+
+def _candidate_rank(path: Path) -> tuple[int, str]:
+    name = path.name.lower()
+    try:
+        priority = DATABASE_PRIORITY.index(name)
+    except ValueError:
+        priority = len(DATABASE_PRIORITY)
+    return priority, path.as_posix().lower()
+
+
+def _usable_database(path: Path) -> bool:
+    try:
+        return path.is_file() and path.suffix.lower() == ".db" and path.stat().st_size >= 4096
+    except OSError:
+        return False
+
+
+def resolve_probe_database(selected_path: str | Path) -> Path:
+    selected = Path(selected_path).expanduser()
+    if _usable_database(selected):
+        return selected
+    if not selected.is_dir():
+        raise FileNotFoundError(f"数据库路径不存在: {selected}")
+
+    known = [selected / relative for relative in KNOWN_DATABASE_RELATIVES]
+    known = sorted((path for path in known if _usable_database(path)), key=_candidate_rank)
+    if known:
+        return known[0]
+
+    candidates = sorted(
+        (path for path in selected.rglob("*.db") if _usable_database(path)),
+        key=_candidate_rank,
+    )
+    if not candidates:
+        raise FileNotFoundError(f"目录中没有可用于校验的微信数据库: {selected}")
+    return candidates[0]
+
+
+def discover_default_probe_databases(home: str | Path | None = None) -> list[Path]:
+    base = Path(home).expanduser() if home is not None else Path.home()
+    found: list[Path] = []
+    seen: set[str] = set()
+    seen_accounts: set[str] = set()
+    for relative_root in DEFAULT_DATA_RELATIVES:
+        data_root = base / relative_root
+        if not data_root.is_dir():
+            continue
+        account_candidates = [
+            *data_root.glob("wxid_*"),
+        ]
+        if data_root.name.lower().startswith("wxid_"):
+            account_candidates.append(data_root)
+        for account_dir in sorted(account_candidates, key=lambda item: item.as_posix().lower()):
+            account_key = account_dir.name.lower()
+            if account_key in seen_accounts:
+                continue
+            storage = account_dir / "db_storage"
+            if not storage.is_dir():
+                continue
+            try:
+                database = resolve_probe_database(storage)
+                normalized = str(database.resolve())
+            except (FileNotFoundError, PermissionError, OSError):
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            seen_accounts.add(account_key)
+            found.append(database)
+    return found
+
+
+def account_label(database: str | Path) -> str:
+    path = Path(database)
+    for parent in path.parents:
+        if parent.name.lower().startswith("wxid_"):
+            return parent.name
+    return path.parent.name or path.name
+
+
+def _active_layout_counterpart(selected_path: str | Path) -> Path | None:
+    """Return the v4 app_data path corresponding to a legacy database path."""
+
+    selected = Path(selected_path).expanduser()
+    parts = selected.parts
+    for index in range(len(parts) - 1):
+        if parts[index] != "Documents" or parts[index + 1] != "xwechat_files":
+            continue
+        return Path(*parts[: index + 1], "app_data", *parts[index + 1 :])
+    return None
+
+
+def _wechat_uses_app_data_layout(wechat_app: str | Path | None) -> bool:
+    if not wechat_app:
+        return False
+    info_plist = Path(wechat_app).expanduser() / "Contents" / "Info.plist"
+    try:
+        with info_plist.open("rb") as handle:
+            payload = plistlib.load(handle)
+        version = str(payload.get("CFBundleShortVersionString") or "")
+        major = int(version.split(".", 1)[0])
+    except (OSError, ValueError, TypeError, plistlib.InvalidFileException):
+        return False
+    return major >= 4
+
+
+def prefer_active_probe_database(
+    selected_path: str | Path,
+    *,
+    home: str | Path | None = None,
+    wechat_app: str | Path | None = None,
+) -> Path:
+    """Replace a stale legacy-layout database with the active account copy."""
+
+    # WeChat 4 always writes under Documents/app_data/xwechat_files.  When an
+    # updated standalone build temporarily lacks Full Disk Access, pathlib may
+    # report that tree as absent even though it is the live database.  Derive
+    # the v4 path from a visible legacy duplicate before touching either file;
+    # environment inspection will then report the permission error instead of
+    # silently validating against an obsolete salt.
+    active_counterpart = _active_layout_counterpart(selected_path)
+    if active_counterpart is not None and _wechat_uses_app_data_layout(wechat_app):
+        return active_counterpart
+
+    selected = resolve_probe_database(selected_path)
+    selected_parts = selected.parts
+    if any(
+        selected_parts[index : index + 3] == ("Documents", "app_data", "xwechat_files")
+        for index in range(max(0, len(selected_parts) - 2))
+    ):
+        return selected
+    account = account_label(selected).lower()
+    for candidate in discover_default_probe_databases(home=home):
+        if account_label(candidate).lower() != account:
+            continue
+        try:
+            if candidate.resolve() == selected.resolve():
+                return selected
+        except OSError:
+            return selected
+        # DEFAULT_DATA_RELATIVES is ordered with app_data first and discovery
+        # keeps only the first usable database for each wxid.  Reaching this
+        # branch means the stored preference points at an older duplicate.
+        return candidate
+    return selected
+
+
+def mask_database_key(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return "尚未提取"
+    if len(normalized) <= 16:
+        return "••••••••"
+    return f"{normalized[:8]}……{normalized[-8:]}"
+
+
+def validate_database_key(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+        raise ValueError("提取结果不是有效的 32 字节十六进制数据库密钥")
+    return normalized
+
+
+def merge_fresh_capture_result(
+    capture: dict[str, Any],
+    captured_key: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Keep capture provenance while returning the newly validated key."""
+
+    key = validate_database_key((captured_key or capture).get("db_key"))
+    return {
+        **capture,
+        "db_key": key,
+        "validated": True,
+        "fresh_capture": True,
+    }
+
+
+def preferences_path(home: str | Path | None = None) -> Path:
+    return app_support_root(home) / "preferences.json"
+
+
+def load_preferences(home: str | Path | None = None) -> dict[str, str]:
+    path = preferences_path(home)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    return {
+        "wechat_app": str(payload.get("wechat_app") or DEFAULT_WECHAT_APP),
+        "database_path": str(payload.get("database_path") or ""),
+        "work_root": str(payload.get("work_root") or default_work_root(home)),
+    }
+
+
+def save_preferences(payload: dict[str, Any], home: str | Path | None = None) -> Path:
+    path = preferences_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(
+            {
+                "wechat_app": str(payload.get("wechat_app") or DEFAULT_WECHAT_APP),
+                "database_path": str(payload.get("database_path") or ""),
+                "work_root": str(payload.get("work_root") or default_work_root(home)),
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    os.chmod(temporary, 0o600)
+    temporary.replace(path)
+    os.chmod(path, 0o600)
+    return path
+
+
+def inspect_environment(
+    wechat_app: str | Path,
+    database_path: str | Path,
+    work_root: str | Path,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "platform_ok": sys.platform == "darwin",
+        "lldb_ok": shutil.which("lldb") is not None,
+        "wechat_ok": False,
+        "wechat_official": False,
+        "database_ok": False,
+        "database_plaintext": False,
+        "work_root_ok": False,
+        "database": "",
+        "errors": [],
+    }
+    if not result["platform_ok"]:
+        result["errors"].append("该工具只支持 macOS")
+    if not result["lldb_ok"]:
+        result["errors"].append("未找到 LLDB，请先运行 xcode-select --install")
+
+    try:
+        from wechat_decrypt_tool.macos_db_key_capture import (
+            _is_tencent_official_signature,
+            inspect_wechat_signature,
+            normalize_wechat_app_path,
+        )
+
+        normalized_app = normalize_wechat_app_path(wechat_app)
+        result["wechat_ok"] = True
+        result["wechat_official"] = _is_tencent_official_signature(
+            inspect_wechat_signature(normalized_app)
+        )
+        if not result["wechat_official"]:
+            result["errors"].append("微信当前不是腾讯原签名，需先恢复原版微信")
+    except Exception as exc:
+        result["errors"].append(str(exc))
+
+    try:
+        database = prefer_active_probe_database(database_path, wechat_app=wechat_app)
+        with database.open("rb") as handle:
+            page = handle.read(4096)
+        result["database"] = str(database)
+        result["database_plaintext"] = page.startswith(b"SQLite format 3")
+        result["database_ok"] = len(page) >= 4096 and not result["database_plaintext"]
+        if result["database_plaintext"]:
+            result["errors"].append("所选数据库已经是明文 SQLite，无需提取密钥")
+        elif not result["database_ok"]:
+            result["errors"].append("所选文件不是完整的加密微信数据库")
+    except Exception as exc:
+        result["errors"].append(str(exc))
+
+    try:
+        work = Path(work_root).expanduser()
+        work.mkdir(parents=True, exist_ok=True)
+        probe = work / f".wedata-key-extractor-write-test-{os.getpid()}"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+        result["work_root_ok"] = True
+    except Exception as exc:
+        result["errors"].append(f"工作目录不可写: {exc}")
+    return result
+
+
+def discover_cached_key(database_path: str | Path) -> dict[str, Any]:
+    from wechat_decrypt_tool.macos_db_key_discovery import discover_macos_db_key
+
+    database = prefer_active_probe_database(database_path)
+    return discover_macos_db_key(database)
+
+
+def prepare_capture(wechat_app: str | Path, work_root: str | Path) -> dict[str, Any]:
+    from wechat_decrypt_tool.macos_inplace_capture import prepare_in_place_capture
+
+    return prepare_in_place_capture(
+        wechat_app,
+        backup_root=default_backup_root(work_root),
+        defer_launch=True,
+    )
+
+
+def confirm_manual_launch(wechat_app: str | Path, work_root: str | Path, transaction_id: str) -> dict[str, Any]:
+    from wechat_decrypt_tool.macos_inplace_capture import confirm_manual_in_place_launch
+
+    return confirm_manual_in_place_launch(wechat_app, backup_root=default_backup_root(work_root),
+                                         transaction_id=transaction_id)
+
+
+def preflight_capture(wechat_app: str | Path, work_root: str | Path) -> dict[str, Any]:
+    from wechat_decrypt_tool.macos_db_key_capture import preflight_prepared_macos_passphrase
+
+    return preflight_prepared_macos_passphrase(
+        wechat_app,
+        backup_root=default_backup_root(work_root),
+    )
+
+
+def finish_capture(
+    wechat_app: str | Path,
+    database_path: str | Path,
+    work_root: str | Path,
+    *,
+    timeout: int = 180,
+) -> dict[str, Any]:
+    from wechat_decrypt_tool.macos_db_key_capture import (
+        MacOSDBKeyCaptureFailure,
+        capture_prepared_macos_passphrase,
+        save_passphrase,
+    )
+    from wechat_decrypt_tool.wechat_decrypt import validate_realtime_database_key
+
+    database = prefer_active_probe_database(database_path, wechat_app=wechat_app)
+    capture = capture_prepared_macos_passphrase(
+        wechat_app,
+        backup_root=default_backup_root(work_root),
+        probe_db_path=database,
+        timeout=timeout,
+        save_result=False,
+    )
+    fresh = merge_fresh_capture_result(capture)
+    db_storage = next(
+        (parent for parent in database.parents if parent.name.lower() == "db_storage"),
+        None,
+    )
+    if db_storage is None:
+        raise MacOSDBKeyCaptureFailure(
+            "capture_account_database_missing",
+            "无法从所选数据库定位账号 db_storage，已拒绝保存捕获值。",
+        )
+    validation = validate_realtime_database_key(db_storage, fresh["db_key"])
+    if validation.get("valid") is not True:
+        missing = ",".join(validation.get("required_roles") or ["message", "session"])
+        raise MacOSDBKeyCaptureFailure(
+            "capture_account_key_mismatch",
+            f"捕获值未通过账号消息库与会话库完整校验（{missing}），已拒绝保存。",
+        )
+    fresh["cache_path"] = str(save_passphrase(fresh["db_key"]))
+    fresh["account_roles_validated"] = True
+    return fresh
+
+
+def capture_monitor_ready() -> bool:
+    """Whether the native login monitor is armed for the current run."""
+
+    from wechat_decrypt_tool.macos_inplace_capture import native_capture_monitor_ready
+
+    return native_capture_monitor_ready()
+
+
+def cancel_capture(wechat_app: str | Path, work_root: str | Path) -> dict[str, Any]:
+    from wechat_decrypt_tool.macos_db_key_capture import cleanup_macos_passphrase_capture
+
+    return cleanup_macos_passphrase_capture(
+        wechat_app,
+        backup_root=default_backup_root(work_root),
+    )
+
+
+def capture_is_pending() -> bool:
+    from wechat_decrypt_tool.macos_inplace_capture import has_pending_in_place_capture
+
+    return has_pending_in_place_capture()
+
+
+def capture_status(wechat_app: str | Path | None = None) -> dict[str, Any]:
+    """Expose only safe recovery state; recheck an external app before retry UI."""
+    from wechat_decrypt_tool.macos_inplace_capture import get_in_place_capture_status
+
+    status = dict(get_in_place_capture_status())
+    if status.get("pending") and status.get("stage") in {"external_install_conflict", "recovery_blocked"}:
+        from wechat_decrypt_tool.macos_db_key_capture import (
+            _is_tencent_official_signature, inspect_wechat_signature, normalize_wechat_app_path,
+        )
+        try:
+            app = normalize_wechat_app_path(wechat_app or DEFAULT_WECHAT_APP)
+            official = _is_tencent_official_signature(inspect_wechat_signature(app))
+        except Exception:
+            official = False
+        # This is only an affordance, not restoration authorization: prepare
+        # reacquires the installation lock and verifies the live bundle again.
+        status["restart_allowed"] = official
+        status["stage"] = "external_install_conflict" if official else "recovery_blocked"
+    return status

--- a/macos-key-extractor/main.py
+++ b/macos-key-extractor/main.py
@@ -1,0 +1,5 @@
+from key_extractor.app import main
+
+
+if __name__ == "__main__":
+    main()

--- a/macos-key-extractor/release_audit.py
+++ b/macos-key-extractor/release_audit.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import zipfile
+from pathlib import Path
+from typing import Iterable
+
+
+SENSITIVE_ENTRY_NAMES = {
+    ".env",
+    "account_keys.json",
+    "desktop-settings.json",
+    "preferences.json",
+    "wechat-passphrase.json",
+}
+SENSITIVE_SUFFIXES = {".db", ".log"}
+PERSONAL_PATH_PATTERN = re.compile(rb"/(?:Users|home)/[^/\x00\r\n\t ]+/")
+MACHO_MAGICS = {
+    b"\xca\xfe\xba\xbe",
+    b"\xcf\xfa\xed\xfe",
+    b"\xce\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xcf",
+    b"\xfe\xed\xfa\xce",
+}
+
+
+def _entry_is_sensitive(name: str) -> bool:
+    path = Path(name)
+    return path.name.lower() in SENSITIVE_ENTRY_NAMES or path.suffix.lower() in SENSITIVE_SUFFIXES
+
+
+def _personal_markers() -> tuple[bytes, ...]:
+    markers: set[bytes] = set()
+    home = str(Path.home())
+    if home not in {"", "/"}:
+        markers.add(home.encode("utf-8"))
+    username = os.environ.get("USER", "").strip()
+    if len(username) >= 3:
+        markers.add(f"/{username}/".encode("utf-8"))
+    return tuple(sorted(markers))
+
+
+def _content_violations(label: str, payload: bytes) -> list[str]:
+    violations: list[str] = []
+    # Prebuilt extension modules commonly retain harmless CI paths such as
+    # /Users/runner. We still scan every byte for this builder's exact home and
+    # username, while applying the generic home-directory rule to non-Mach-O
+    # code and resources where a path would indicate accidental bundling.
+    is_macho = payload[:4] in MACHO_MAGICS
+    if not is_macho and PERSONAL_PATH_PATTERN.search(payload):
+        violations.append(f"{label}: 包含用户主目录绝对路径")
+    for marker in _personal_markers():
+        if marker in payload:
+            violations.append(f"{label}: 包含当前构建用户信息")
+            break
+    return violations
+
+
+def audit_directory(root: Path) -> list[str]:
+    violations: list[str] = []
+    if not root.is_dir():
+        return [f"目录不存在: {root}"]
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root).as_posix()
+        if _entry_is_sensitive(relative):
+            violations.append(f"{relative}: 不应打包运行时数据或私密文件")
+            continue
+        try:
+            violations.extend(_content_violations(relative, path.read_bytes()))
+        except OSError as exc:
+            violations.append(f"{relative}: 无法审计: {exc}")
+    return violations
+
+
+def audit_zip(path: Path) -> list[str]:
+    violations: list[str] = []
+    if not path.is_file():
+        return [f"安装包不存在: {path}"]
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                if _entry_is_sensitive(info.filename):
+                    violations.append(f"{info.filename}: 不应打包运行时数据或私密文件")
+    except (OSError, zipfile.BadZipFile) as exc:
+        violations.append(f"无法读取安装包 {path}: {exc}")
+    return violations
+
+
+def run_audit(paths: Iterable[Path]) -> list[str]:
+    violations: list[str] = []
+    for path in paths:
+        if path.is_dir():
+            violations.extend(audit_directory(path))
+        elif path.suffix.lower() == ".zip":
+            violations.extend(audit_zip(path))
+        else:
+            violations.append(f"不支持的审计目标: {path}")
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="检查公开安装包是否混入个人路径或运行时私密文件")
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args()
+    violations = run_audit(args.paths)
+    if violations:
+        print("发布审计失败：")
+        for item in violations:
+            print(f"- {item}")
+        return 1
+    print("发布审计通过：未发现个人路径、数据库、日志或密钥缓存文件。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/wechat_decrypt_tool/macos_capture_validation.py
+++ b/src/wechat_decrypt_tool/macos_capture_validation.py
@@ -1,0 +1,153 @@
+"""Read-only account snapshots and fail-closed macOS capture validation.
+
+Both realtime roles must verify before a candidate becomes an account key.
+Diagnostics deliberately contain role names and key modes, never key material.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from .macos_db_key_capture import MacOSDBKeyCaptureFailure
+from .wechat_decrypt import PAGE_SIZE, SQLITE_HEADER, _resolve_page1_key_material
+
+
+REQUIRED_ACCOUNT_ROLES = ("message", "session")
+
+
+def normalize_account_probe_pages(account_probe_pages: Mapping[str, bytes]) -> dict[str, bytes]:
+    """Require complete encrypted snapshots for every required account role."""
+
+    pages: dict[str, bytes] = {}
+    for role in REQUIRED_ACCOUNT_ROLES:
+        page = account_probe_pages.get(role)
+        if not isinstance(page, (bytes, bytearray, memoryview)) or len(page) != PAGE_SIZE:
+            raise MacOSDBKeyCaptureFailure(
+                "account_probe_invalid", f"账号数据库校验缺少完整的 {role} 首页，未启动密钥捕获。"
+            )
+        page = bytes(page)
+        if page.startswith(SQLITE_HEADER):
+            raise MacOSDBKeyCaptureFailure(
+                "account_probe_unencrypted", f"{role} 数据库不是加密来源，无法用于账号密钥校验。"
+            )
+        pages[role] = page
+    return pages
+
+
+def resolve_account_probe_paths(
+    probe_db_path: str | Path, *, account_root: str | Path | None = None
+) -> dict[str, Path]:
+    """Resolve the same message/session layouts as realtime key validation.
+
+    Only the selected database's own account is considered. In the absence of
+    a db_storage ancestor, flat legacy layouts and immediate role folders are
+    supported; we never recursively search neighbouring account directories.
+    """
+
+    try:
+        selected_probe = Path(probe_db_path).expanduser().absolute()
+        probe = selected_probe.resolve(strict=True)
+        if not probe.is_file():
+            raise OSError("probe is not a file")
+        if account_root is not None:
+            root = Path(account_root).expanduser().resolve(strict=True)
+            if (root / "db_storage").is_dir():
+                root = (root / "db_storage").resolve(strict=True)
+        else:
+            root = next((parent for parent in selected_probe.parents if parent.name == "db_storage"), None)
+            if root is None:
+                root = selected_probe.parent.parent if selected_probe.parent.name in REQUIRED_ACCOUNT_ROLES else selected_probe.parent
+            root = root.resolve(strict=True)
+        if not root.is_dir() or not probe.is_relative_to(root):
+            raise OSError("probe is outside selected account")
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise MacOSDBKeyCaptureFailure(
+            "account_probe_path_invalid", "无法定位所选数据库的账号目录，未启动密钥捕获。"
+        ) from exc
+
+    def first_file(candidates: list[Path]) -> Path | None:
+        for candidate in candidates:
+            try:
+                if candidate.is_file():
+                    resolved = candidate.resolve(strict=True)
+                    if not resolved.is_relative_to(root):
+                        raise MacOSDBKeyCaptureFailure(
+                            "account_probe_path_invalid", "账号数据库指向所选账号目录之外，已停止校验。"
+                        )
+                    return resolved
+            except OSError:
+                continue
+        return None
+
+    combined = first_file([root / "MicroMsg.db", root / "micromsg.db"])
+    session = first_file([root / "session/session.db", root / "session.db", root / "Session.db"]) or combined
+    message_candidates: list[Path] = []
+    for directory, pattern in (
+        (root / "message", "message_*.db"),
+        (root, "message_*.db"),
+        (root, "MSG*.db"),
+        (root, "msg*.db"),
+    ):
+        try:
+            message_candidates.extend(sorted(directory.glob(pattern)))
+        except OSError:
+            continue
+    message = first_file(message_candidates) or combined
+    paths = {"message": message, "session": session}
+    missing = [role for role, path in paths.items() if path is None]
+    if missing:
+        raise MacOSDBKeyCaptureFailure(
+            "account_probe_missing", "账号数据库校验缺少必需库：" + ", ".join(missing) + "。"
+        )
+    return {role: path for role, path in paths.items() if path is not None}
+
+
+def read_account_probe_pages(
+    probe_db_path: str | Path, *, account_root: str | Path | None = None
+) -> dict[str, bytes]:
+    """Snapshot both encrypted page-1 values before capture or database changes."""
+
+    paths = resolve_account_probe_paths(probe_db_path, account_root=account_root)
+    pages: dict[str, bytes] = {}
+    read_pages: dict[Path, bytes] = {}
+    for role, path in paths.items():
+        try:
+            if path not in read_pages:
+                with path.open("rb", buffering=0) as stream:
+                    read_pages[path] = stream.read(PAGE_SIZE)
+            pages[role] = read_pages[path]
+        except OSError as exc:
+            raise MacOSDBKeyCaptureFailure(
+                "account_probe_unreadable", f"无法读取 {role} 数据库首页，未启动密钥捕获。"
+            ) from exc
+    return normalize_account_probe_pages(pages)
+
+
+def validate_account_candidate(candidate: str | bytes, account_probe_pages: Mapping[str, bytes]) -> dict[str, Any]:
+    """Return non-secret validation metadata, or raise without exposing a key."""
+
+    pages = normalize_account_probe_pages(account_probe_pages)
+    try:
+        material = bytes.fromhex(candidate.strip()) if isinstance(candidate, str) else bytes(candidate)
+    except (TypeError, ValueError):
+        material = b""
+    if len(material) != 32:
+        raise MacOSDBKeyCaptureFailure("account_key_invalid", "捕获候选格式无效，未保存账号密钥。")
+    modes: dict[str, str] = {}
+    for role, page in pages.items():
+        resolved = _resolve_page1_key_material(material, page)
+        if resolved is not None:
+            modes[role] = str(resolved[2])
+    missing = [role for role in REQUIRED_ACCOUNT_ROLES if role not in modes]
+    if missing:
+        raise MacOSDBKeyCaptureFailure(
+            "account_key_validation_failed", "账号密钥未通过数据库校验：" + ", ".join(missing) + "；未保存候选。"
+        )
+    unique_modes = set(modes.values())
+    return {
+        "valid": True,
+        "key_mode": next(iter(unique_modes)) if len(unique_modes) == 1 else "mixed",
+        "validated_roles": list(REQUIRED_ACCOUNT_ROLES),
+        "modes": modes,
+    }

--- a/src/wechat_decrypt_tool/macos_clone_capture.py
+++ b/src/wechat_decrypt_tool/macos_clone_capture.py
@@ -1,10 +1,9 @@
-"""Safe macOS WCDB passphrase capture using an isolated APFS clone.
+"""Legacy isolated capture workflow and shared macOS LLDB callbacks.
 
-The Tencent-signed application is never modified.  A disposable ad-hoc copy
-runs with a private HOME containing a copy-on-write clone of the real WeChat
-container.  LLDB is attached only to that disposable process and accepts a
-PBKDF2 password only when the KDF profile and salt match a cloned database and
-the candidate passes that database's page-one HMAC verification.
+The legacy workflow uses a disposable APFS application/profile clone. The
+production in-place workflow also reuses these LLDB builders, under its own
+recoverable temporary-signature transaction. Account-aware callbacks require
+both message and session page HMACs before accepting any candidate.
 """
 
 from __future__ import annotations
@@ -23,6 +22,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from .macos_capture_validation import normalize_account_probe_pages, validate_account_candidate
 from .macos_db_key_capture import (
     DEFAULT_DEBUG_ROOT,
     MacOSDBKeyCaptureFailure,
@@ -53,6 +53,83 @@ WECHAT_DOCUMENTS_RELATIVE = Path("Documents")
 WECHAT_KEY_RETURN_POINTS = {
     "1B1A6433-A445-3247-B7E1-753C09CDB137": 0x2FC6880,
 }
+# Exact arm64 Mach-O identities only; offsets must never cross builds.
+WECHAT_PBKDF_STUB_POINTS = {
+    "8F7D3DD4-D676-36F9-8C31-CEE02C26C284": 0x6C737F8,
+    "07EE7CDA-5F9B-38A2-9E0C-E4DF83DB22E4": 0x6CD0ACC,
+}
+
+_LLDB_BREAKPOINT_VALIDATION_SOURCE = '''
+def _resolved_locations(breakpoint, target):
+    count = 0
+    for index in range(breakpoint.GetNumLocations()):
+        location = breakpoint.GetLocationAtIndex(index)
+        address = location.GetAddress()
+        if not location.IsResolved() or not address.IsValid():
+            continue
+        section = address.GetSection()
+        if (
+            section.IsValid()
+            and section.GetPermissions() & lldb.ePermissionsExecutable
+            and address.GetLoadAddress(target) != lldb.LLDB_INVALID_ADDRESS
+        ):
+            count += 1
+    return count
+'''
+
+
+def _normalize_pbkdf_stub_plan(plan: dict[str, int] | None) -> dict[str, int]:
+    points = dict(WECHAT_PBKDF_STUB_POINTS)
+    if plan is None:
+        return points
+    if not isinstance(plan, dict) or len(plan) > 128:
+        raise MacOSDBKeyCaptureFailure("capture_breakpoint_plan_invalid", "LLDB 断点计划格式无效，已停止监测。")
+    for identifier, offset in plan.items():
+        if (
+            not isinstance(identifier, str)
+            or not re.fullmatch(r"[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}", identifier)
+            or type(offset) is not int or not 0 < offset < 2**64 or offset % 4
+        ):
+            raise MacOSDBKeyCaptureFailure("capture_breakpoint_plan_invalid", "LLDB 断点计划缺少有效的模块身份或地址。")
+        points[identifier.upper()] = offset
+    return points
+
+
+def resolve_lldb_pbkdf_stub_plan(wechat_app: str | Path | None) -> dict[str, int]:
+    """Read a UUID-bound arm64 import stub, without launching or attaching.
+
+    A parsed address is only a plan: both LLDB stages must still find the same
+    UUID at a loaded executable address. Known exact-UUID entries remain useful
+    when optional static inspection is unavailable; no version guess is made.
+    """
+
+    plan = _normalize_pbkdf_stub_plan(None)
+    if not wechat_app:
+        return plan
+    dylib = Path(wechat_app).expanduser() / "Contents/Resources/wechat.dylib"
+    try:
+        if not dylib.is_file():
+            return plan
+        before = dylib.stat()
+        load_commands = _run(["/usr/bin/otool", "-arch", "arm64", "-l", str(dylib)], timeout=60).stdout
+        uuids = re.findall(
+            r"(?m)^\s*cmd LC_UUID\s*\n\s*cmdsize \d+\s*\n\s*uuid ([0-9a-fA-F-]{36})\s*$",
+            load_commands,
+        )
+        if len(uuids) != 1:
+            return plan
+        from .macos_native_capture import _parse_pbkdf_stub_address
+
+        imports = _run(["/usr/bin/otool", "-arch", "arm64", "-Iv", str(dylib)], timeout=60).stdout
+        offset = _parse_pbkdf_stub_address(imports)
+        after = dylib.stat()
+        if (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns) != (
+            after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns
+        ):
+            return plan
+        return _normalize_pbkdf_stub_plan({**plan, uuids[0]: offset})
+    except (OSError, MacOSDBKeyCaptureFailure, ValueError):
+        return plan
 
 
 def _state_path(debug_root: Path) -> Path:
@@ -372,13 +449,19 @@ def build_lldb_salt_capture_script(
     *,
     probe_page1: bytes | None = None,
     enable_key_return_fallback: bool = True,
+    ready_path: Path | None = None,
+    account_probe_pages: dict[str, bytes] | None = None,
+    transaction_id: str | None = None,
+    pbkdf_stub_plan: dict[str, int] | None = None,
 ) -> str:
     """Build callbacks that validate candidates before stopping the process."""
 
-    salts = _normalize_salts(expected_salts)
+    account_pages = normalize_account_probe_pages(account_probe_pages) if account_probe_pages is not None else {}
+    salts = _normalize_salts([*expected_salts, *(page[:16] for page in account_pages.values())])
     if not salts:
         raise MacOSDBKeyCaptureFailure("capture_salts_missing", "没有可用于过滤 PBKDF2 调用的数据库 salt")
     result_literal = json.dumps(str(result_path))
+    ready_literal = json.dumps(str(ready_path) if ready_path is not None else "")
     salts_literal = json.dumps(salts)
     hmac_salts_literal = json.dumps(
         {
@@ -387,7 +470,8 @@ def build_lldb_salt_capture_script(
         },
         sort_keys=True,
     )
-    page1_literal = json.dumps(bytes(probe_page1 or b"").hex())
+    page1_literal = json.dumps(bytes(probe_page1 or account_pages.get("message", b"")).hex())
+    account_pages_literal = json.dumps({role: page.hex() for role, page in account_pages.items()})
     return f'''import hashlib
 import hmac
 import json
@@ -395,26 +479,57 @@ import lldb
 import os
 
 RESULT_PATH = {result_literal}
+READY_PATH = {ready_literal}
 EXPECTED_SALTS = frozenset({salts_literal})
 EXPECTED_HMAC_SALTS = {hmac_salts_literal}
 PROBE_PAGE1 = bytes.fromhex({page1_literal})
+ACCOUNT_PROBE_PAGES = {{role: bytes.fromhex(page) for role, page in {account_pages_literal}.items()}}
+TRANSACTION_ID = {json.dumps(str(transaction_id or ""))}
 KEY_RETURN_POINTS = {json.dumps(WECHAT_KEY_RETURN_POINTS)}
+PBKDF_STUB_POINTS = {json.dumps(_normalize_pbkdf_stub_plan(pbkdf_stub_plan))}
 ENABLE_KEY_RETURN_FALLBACK = {bool(enable_key_return_fallback)!r}
 MODULE_NAME = __name__
 DIAGNOSTICS = {{
     "pbkdf_calls": 0,
     "pbkdf_shape_hits": 0,
+    "pbkdf_profiles": {{}},
     "pbkdf_rounds_2_hits": 0,
     "pbkdf_rounds_256000_hits": 0,
     "pbkdf_salt_hits": 0,
     "key_return_hits": 0,
     "candidate_rejections": 0,
+    "partial_candidates": 0,
 }}
 
+{_LLDB_BREAKPOINT_VALIDATION_SOURCE}
+
 def _write_result(payload):
+    if TRANSACTION_ID:
+        payload = dict(payload, transaction_id=TRANSACTION_ID)
     flags = os.O_WRONLY | os.O_TRUNC
     flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
     descriptor = os.open(RESULT_PATH, flags)
+    try:
+        data = json.dumps(payload).encode()
+        view = memoryview(data)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                return False
+            view = view[written:]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return True
+
+def _write_ready(payload):
+    if not READY_PATH:
+        return True
+    if TRANSACTION_ID:
+        payload = dict(payload, transaction_id=TRANSACTION_ID)
+    flags = os.O_WRONLY | os.O_TRUNC
+    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(READY_PATH, flags)
     try:
         data = json.dumps(payload).encode()
         view = memoryview(data)
@@ -435,20 +550,26 @@ def _record_diagnostic(name):
 def _register(frame, name):
     return frame.FindRegister(name).GetValueAsUnsigned()
 
-def _candidate_matches_page1(candidate):
-    if len(candidate) != 32 or len(PROBE_PAGE1) < 4096:
-        return False
-    salt = PROBE_PAGE1[:16]
-    stored_hmac = PROBE_PAGE1[4032:4096]
-    for enc_key in (candidate, hashlib.pbkdf2_hmac("sha512", candidate, salt, 256000, 32)):
+def _candidate_page1_mode(candidate, page):
+    if len(candidate) != 32 or len(page) != 4096 or page.startswith(b"SQLite format 3\\x00"):
+        return ""
+    salt = page[:16]
+    stored_hmac = page[4032:4096]
+    for mode in ("raw_enc_key", "sqlcipher_passphrase"):
+        enc_key = candidate if mode == "raw_enc_key" else hashlib.pbkdf2_hmac("sha512", candidate, salt, 256000, 32)
         mac_salt = bytes(value ^ 0x3A for value in salt)
         mac_key = hashlib.pbkdf2_hmac("sha512", enc_key, mac_salt, 2, 32)
         digest = hmac.new(mac_key, digestmod=hashlib.sha512)
-        digest.update(PROBE_PAGE1[16:4032])
+        digest.update(page[16:4032])
         digest.update((1).to_bytes(4, "little"))
         if hmac.compare_digest(stored_hmac, digest.digest()):
-            return True
-    return False
+            return mode
+    return ""
+
+def _candidate_matches_page1(candidate):
+    # Compatibility for standalone single-database callers. Account captures
+    # always use _save_valid_candidate's mandatory two-role validation below.
+    return bool(_candidate_page1_mode(candidate, PROBE_PAGE1))
 
 def _normalize_candidate(raw):
     if len(raw) == 32:
@@ -463,16 +584,37 @@ def _normalize_candidate(raw):
 
 def _save_valid_candidate(candidate, salt, source, process):
     normalized = _normalize_candidate(candidate)
-    if not _candidate_matches_page1(normalized):
+    pages = ACCOUNT_PROBE_PAGES or {{"probe": PROBE_PAGE1}}
+    required_roles = ("message", "session") if ACCOUNT_PROBE_PAGES else ("probe",)
+    modes = {{}}
+    for role in required_roles:
+        mode = _candidate_page1_mode(normalized, pages.get(role, b""))
+        if mode:
+            modes[role] = mode
+    if len(modes) != len(required_roles):
+        if modes:
+            _record_diagnostic("partial_candidates")
         _record_diagnostic("candidate_rejections")
         return False
-    _write_result({{
+    unique_modes = set(modes.values())
+    if not _write_result({{
         "passphrase": normalized.hex(),
         "salt": salt,
         "source": source,
+        "key_mode": next(iter(unique_modes)) if len(unique_modes) == 1 else "mixed",
+        "validated_roles": list(required_roles),
         "diagnostics": dict(DIAGNOSTICS),
-    }})
+    }}):
+        return False
     print("WEDATA_MATCHED_VALIDATED_DATABASE_KEY", source, flush=True)
+    # This contains no key or salt. It lets the UI stop asking for a login
+    # before the expected shutdown needed to restore the official bundle.
+    try:
+        _write_ready({{"status": "captured", "method": "macos_lldb_stub", "pid": int(process.GetProcessID())}})
+    except Exception:
+        # The validated result is already durable; advisory progress failure
+        # must not keep a modified/debugged process alive or lose that result.
+        pass
     process.Kill()
     os._exit(0)
 
@@ -486,27 +628,35 @@ def _pbkdf_callback(frame, bp_loc, _internal_dict):
     salt_len = _register(frame, "x4")
     prf = _register(frame, "x5")
     rounds = _register(frame, "x6")
-    if algorithm != 2 or password_len != 32 or salt_len != 16 or prf != 5 or rounds not in (2, 256000):
+    profile = f"algorithm={{algorithm}},password_len={{password_len}},salt_len={{salt_len}},prf={{prf}},rounds={{rounds}}"
+    profiles = DIAGNOSTICS.setdefault("pbkdf_profiles", {{}})
+    if len(profiles) < 8 or profile in profiles:
+        profiles[profile] = int(profiles.get(profile, 0)) + 1
+        _write_result({{"diagnostics": dict(DIAGNOSTICS)}})
+    if password_len not in (32, 64) or salt_len != 16:
         return False
     _record_diagnostic("pbkdf_shape_hits")
-    _record_diagnostic("pbkdf_rounds_2_hits" if rounds == 2 else "pbkdf_rounds_256000_hits")
+    if rounds == 2:
+        _record_diagnostic("pbkdf_rounds_2_hits")
+    elif rounds == 256000:
+        _record_diagnostic("pbkdf_rounds_256000_hits")
 
     error = lldb.SBError()
     salt = process.ReadMemory(salt_ptr, salt_len, error)
     if not error.Success() or len(salt) != 16:
         return False
     salt_hex = salt.hex()
-    if rounds == 2:
+    if salt_hex in EXPECTED_HMAC_SALTS:
         database_salt = EXPECTED_HMAC_SALTS.get(salt_hex, "")
-        source = "pbkdf2_hmac_password"
+        source = "pbkdf_hmac_password"
     else:
         database_salt = salt_hex if salt_hex in EXPECTED_SALTS else ""
-        source = "pbkdf2_passphrase"
+        source = "pbkdf_database_password"
     if not database_salt:
         return False
     _record_diagnostic("pbkdf_salt_hits")
     password = process.ReadMemory(password_ptr, password_len, error)
-    if not error.Success() or len(password) != 32:
+    if not error.Success() or len(password) != password_len:
         return False
 
     _save_valid_candidate(password, database_salt, source, process)
@@ -567,7 +717,29 @@ def _setup(debugger, _command, _result, _internal_dict):
     breakpoint = target.BreakpointCreateByName("CCKeyDerivationPBKDF")
     breakpoint.SetScriptCallbackFunction(f"{{MODULE_NAME}}._pbkdf_callback")
     breakpoint.SetAutoContinue(True)
-    pbkdf_locations = breakpoint.GetNumResolvedLocations()
+    pbkdf_locations = _resolved_locations(breakpoint, target)
+    # On 4.1.13 LLDB can report a resolved CommonCrypto name breakpoint yet
+    # miss the call routed through WeChat's import stub.  Always install the
+    # UUID-bound stub breakpoint as well; it observes the original x0-x6 ABI
+    # arguments and is valid only for the exact dylib builds listed above.
+    for module in target.module_iter():
+        uuid = (module.GetUUIDString() or "").upper()
+        offset = PBKDF_STUB_POINTS.get(uuid)
+        if offset is None:
+            continue
+        address = module.ResolveFileAddress(offset)
+        section = address.GetSection() if address.IsValid() else lldb.SBSection()
+        if (
+            not address.IsValid()
+            or not section.IsValid()
+            or not (section.GetPermissions() & lldb.ePermissionsExecutable)
+            or address.GetLoadAddress(target) == lldb.LLDB_INVALID_ADDRESS
+        ):
+            continue
+        stub_breakpoint = target.BreakpointCreateBySBAddress(address)
+        stub_breakpoint.SetScriptCallbackFunction(f"{{MODULE_NAME}}._pbkdf_callback")
+        stub_breakpoint.SetAutoContinue(True)
+        pbkdf_locations += _resolved_locations(stub_breakpoint, target)
     key_locations = 0
     if ENABLE_KEY_RETURN_FALLBACK:
         for module in target.module_iter():
@@ -587,12 +759,19 @@ def _setup(debugger, _command, _result, _internal_dict):
             key_breakpoint = target.BreakpointCreateBySBAddress(address)
             key_breakpoint.SetScriptCallbackFunction(f"{{MODULE_NAME}}._key_return_callback")
             key_breakpoint.SetAutoContinue(True)
-            key_locations += key_breakpoint.GetNumResolvedLocations()
+            key_locations += _resolved_locations(key_breakpoint, target)
     print("WEDATA_KEY_MONITOR_READY", pbkdf_locations, key_locations, flush=True)
     if pbkdf_locations <= 0 and key_locations <= 0:
         process = target.GetProcess()
         process.Detach()
         os._exit(24)
+    _write_ready({{
+        "status": "ready",
+        "method": "macos_lldb_stub",
+        "pid": int(target.GetProcess().GetProcessID() or 0),
+        "pbkdf_locations": int(pbkdf_locations),
+        "key_return_locations": int(key_locations),
+    }})
 
 def __lldb_init_module(debugger, _internal_dict):
     debugger.HandleCommand(f"command script add -f {{MODULE_NAME}}._setup wedata_capture")
@@ -600,7 +779,9 @@ def __lldb_init_module(debugger, _internal_dict):
 '''
 
 
-def build_lldb_breakpoint_preflight_script(result_path: Path) -> str:
+def build_lldb_breakpoint_preflight_script(
+    result_path: Path, *, pbkdf_stub_plan: dict[str, int] | None = None
+) -> str:
     """Build a read-only LLDB command that verifies usable runtime breakpoints."""
 
     result_literal = json.dumps(str(result_path))
@@ -610,7 +791,10 @@ import os
 
 RESULT_PATH = {result_literal}
 KEY_RETURN_POINTS = {json.dumps(WECHAT_KEY_RETURN_POINTS)}
+PBKDF_STUB_POINTS = {json.dumps(_normalize_pbkdf_stub_plan(pbkdf_stub_plan))}
 MODULE_NAME = __name__
+
+{_LLDB_BREAKPOINT_VALIDATION_SOURCE}
 
 def _write_result(payload):
     flags = os.O_WRONLY | os.O_TRUNC
@@ -628,18 +812,56 @@ def _write_result(payload):
     finally:
         os.close(descriptor)
 
-def _resolved_locations(breakpoint):
+def _total_locations(breakpoint):
     try:
-        return breakpoint.GetNumResolvedLocations()
+        return breakpoint.GetNumLocations()
     except AttributeError:
-        return sum(1 for index in range(breakpoint.GetNumLocations()) if breakpoint.GetLocationAtIndex(index).IsResolved())
+        return 0
 
 def _setup(debugger, _command, _result, _internal_dict):
     target = debugger.GetSelectedTarget()
     process = target.GetProcess()
     pbkdf_breakpoint = target.BreakpointCreateByName("CCKeyDerivationPBKDF")
-    pbkdf_locations = _resolved_locations(pbkdf_breakpoint)
+    pbkdf_resolved_locations = _resolved_locations(pbkdf_breakpoint, target)
+    pbkdf_total_locations = _total_locations(pbkdf_breakpoint)
     pbkdf_breakpoint.SetEnabled(False)
+    pbkdf_stub_modules = []
+    rejected_pbkdf_stubs = []
+    for module in target.module_iter():
+        uuid = (module.GetUUIDString() or "").upper()
+        offset = PBKDF_STUB_POINTS.get(uuid)
+        if offset is None:
+            continue
+        module_name = module.GetFileSpec().GetFilename() or "unknown"
+        address = module.ResolveFileAddress(offset)
+        section = address.GetSection() if address.IsValid() else lldb.SBSection()
+        load_address = address.GetLoadAddress(target) if address.IsValid() else lldb.LLDB_INVALID_ADDRESS
+        executable = bool(section.IsValid() and section.GetPermissions() & lldb.ePermissionsExecutable)
+        if (
+            not address.IsValid()
+            or not section.IsValid()
+            or not executable
+            or load_address == lldb.LLDB_INVALID_ADDRESS
+        ):
+            rejected_pbkdf_stubs.append({{
+                "module": module_name,
+                "uuid": uuid,
+                "offset": offset,
+                "section": section.GetName() if section.IsValid() else "",
+            }})
+            continue
+        stub_breakpoint = target.BreakpointCreateBySBAddress(address)
+        locations = _resolved_locations(stub_breakpoint, target)
+        stub_breakpoint.SetEnabled(False)
+        if locations > 0:
+            pbkdf_resolved_locations += locations
+            pbkdf_total_locations += locations
+            pbkdf_stub_modules.append({{
+                "module": module_name,
+                "uuid": uuid,
+                "offset": offset,
+                "section": section.GetName() or "",
+            }})
     key_locations = 0
     matched_modules = []
     rejected_points = []
@@ -667,7 +889,7 @@ def _setup(debugger, _command, _result, _internal_dict):
             }})
             continue
         breakpoint = target.BreakpointCreateBySBAddress(address)
-        locations = _resolved_locations(breakpoint)
+        locations = _resolved_locations(breakpoint, target)
         breakpoint.SetEnabled(False)
         if locations > 0:
             key_locations += locations
@@ -679,27 +901,73 @@ def _setup(debugger, _command, _result, _internal_dict):
             }})
     payload = {{
         "pid": process.GetProcessID(),
-        "pbkdf_locations": pbkdf_locations,
+        "pbkdf_locations": pbkdf_resolved_locations,
+        "pbkdf_total_locations": pbkdf_total_locations,
+        "pbkdf_deferred": pbkdf_total_locations > 0 and pbkdf_resolved_locations <= 0,
+        "pbkdf_stub_modules": pbkdf_stub_modules,
+        "rejected_pbkdf_stubs": rejected_pbkdf_stubs,
         "key_return_locations": key_locations,
         "matched_modules": matched_modules,
         "rejected_points": rejected_points,
     }}
+    try:
+        detached = bool(process.Detach().Success())
+    except Exception:
+        detached = False
+    if not detached:
+        _write_result({{"status": "error", "code": "capture_preflight_detach_failed"}})
+        print("WEDATA_BREAKPOINT_PREFLIGHT_DETACH_FAILED", flush=True)
+        return
     _write_result(payload)
-    print("WEDATA_BREAKPOINT_PREFLIGHT", pbkdf_locations, key_locations, flush=True)
-    process.Detach()
+    print(
+        "WEDATA_BREAKPOINT_PREFLIGHT",
+        pbkdf_resolved_locations,
+        pbkdf_total_locations,
+        key_locations,
+        flush=True,
+    )
 
 def __lldb_init_module(debugger, _internal_dict):
     debugger.HandleCommand(f"command script add -f {{MODULE_NAME}}._setup wedata_preflight")
 '''
 
 
-def preflight_capture_breakpoints(*, pid: int, debug_root: Path = DEFAULT_DEBUG_ROOT) -> dict[str, Any]:
+def _wechat_binary_imports_pbkdf(wechat_app: str | Path | None) -> bool:
+    if not wechat_app:
+        return False
+    app = Path(wechat_app).expanduser()
+    candidates = (
+        app / "Contents/Resources/wechat.dylib",
+        app / "Contents/Resources/roam_migration.framework/Versions/A/roam_migration",
+        app / "Contents/Resources/roam_server.framework/Versions/A/roam_server",
+    )
+    for binary in candidates:
+        if not binary.is_file():
+            continue
+        result = _run(["/usr/bin/nm", "-u", str(binary)], check=False)
+        if result.returncode == 0 and "CCKeyDerivationPBKDF" in result.stdout:
+            return True
+    return False
+
+
+def preflight_capture_breakpoints(
+    *,
+    pid: int,
+    debug_root: Path = DEFAULT_DEBUG_ROOT,
+    wechat_app: str | Path | None = None,
+    pbkdf_stub_plan: dict[str, int] | None = None,
+) -> dict[str, Any]:
     """Attach briefly, validate breakpoint locations, and detach before re-login."""
 
     if platform.machine().lower() not in {"arm64", "aarch64"}:
         raise MacOSDBKeyCaptureFailure("capture_arch_unsupported", "当前安全捕获流程仅支持 Apple Silicon Mac")
     if shutil.which("lldb") is None:
         raise MacOSDBKeyCaptureFailure("lldb_missing", "未安装 LLDB，请先运行 xcode-select --install")
+
+    stub_plan = (
+        resolve_lldb_pbkdf_stub_plan(wechat_app)
+        if pbkdf_stub_plan is None else _normalize_pbkdf_stub_plan(pbkdf_stub_plan)
+    )
 
     result_path = _breakpoint_preflight_path(debug_root)
     result_path.parent.mkdir(parents=True, exist_ok=True)
@@ -710,12 +978,17 @@ def preflight_capture_breakpoints(*, pid: int, debug_root: Path = DEFAULT_DEBUG_
     with tempfile.TemporaryDirectory(prefix="wedata-breakpoint-preflight-") as temporary_dir:
         root = Path(temporary_dir)
         callback_path = root / "preflight_callback.py"
-        callback_path.write_text(build_lldb_breakpoint_preflight_script(result_path), encoding="utf-8")
+        callback_path.write_text(
+            build_lldb_breakpoint_preflight_script(result_path, pbkdf_stub_plan=stub_plan), encoding="utf-8"
+        )
         os.chmod(callback_path, 0o600)
         command_path = root / "preflight.lldb"
         command_path.write_text(
             "settings set target.preload-symbols false\n"
             f"process attach -p {int(pid)}\n"
+            # WeChat legitimately executes BRK during initialization.  LLDB
+            # must neither stop on nor deliver that signal back to the app;
+            # LLDB still owns its own software breakpoint exceptions.
             "process handle SIGTRAP -n false -p false -s false\n"
             f"command script import {callback_path}\n"
             "wedata_preflight\n"
@@ -724,7 +997,7 @@ def preflight_capture_breakpoints(*, pid: int, debug_root: Path = DEFAULT_DEBUG_
         )
         os.chmod(command_path, 0o600)
         command = _build_lldb_capture_command(command_path, 45)
-        output = _run_as_administrator(command, timeout=90)
+        output = _run_as_administrator(command, timeout=180)
 
     try:
         payload = json.loads(result_path.read_text(encoding="utf-8"))
@@ -734,9 +1007,17 @@ def preflight_capture_breakpoints(*, pid: int, debug_root: Path = DEFAULT_DEBUG_
     if "attach failed" in compact or "not allowed to attach" in compact:
         _remove_breakpoint_preflight(debug_root)
         raise MacOSDBKeyCaptureFailure("lldb_attach_failed", "LLDB 无法附加独立调试微信完成断点预检")
+    if isinstance(payload, dict) and payload.get("code") == "capture_preflight_detach_failed":
+        _remove_breakpoint_preflight(debug_root)
+        raise MacOSDBKeyCaptureFailure(
+            "capture_preflight_detach_failed", "LLDB 预检后未能确认分离，已停止进入密钥监测。", process_attached=True,
+        )
 
-    pbkdf_locations = int(payload.get("pbkdf_locations") or 0)
+    pbkdf_resolved_locations = int(payload.get("pbkdf_locations") or 0)
+    pbkdf_total_locations = int(payload.get("pbkdf_total_locations") or 0)
+    pbkdf_locations = pbkdf_resolved_locations
     key_return_locations = int(payload.get("key_return_locations") or 0)
+    pbkdf_deferred = bool(payload.get("pbkdf_deferred"))
     if pbkdf_locations <= 0 and key_return_locations <= 0:
         _remove_breakpoint_preflight(debug_root)
         raise MacOSDBKeyCaptureFailure(
@@ -744,9 +1025,16 @@ def preflight_capture_breakpoints(*, pid: int, debug_root: Path = DEFAULT_DEBUG_
             "当前微信版本没有可用的密钥捕获断点；监测未启动，请不要退出账号。",
             process_attached=True,
         )
-    return {
+    normalized_result = {
         "pid": int(payload.get("pid") or pid),
         "pbkdf_locations": pbkdf_locations,
+        "pbkdf_resolved_locations": pbkdf_resolved_locations,
+        "pbkdf_total_locations": pbkdf_total_locations,
+        "pbkdf_deferred": pbkdf_deferred,
+        "pbkdf_import_verified": bool(payload.get("pbkdf_stub_modules")),
+        "pbkdf_stub_plan": stub_plan,
+        "pbkdf_stub_modules": list(payload.get("pbkdf_stub_modules") or []),
+        "rejected_pbkdf_stubs": list(payload.get("rejected_pbkdf_stubs") or []),
         "key_return_locations": key_return_locations,
         "matched_modules": list(payload.get("matched_modules") or []),
         "rejected_points": list(payload.get("rejected_points") or []),
@@ -754,6 +1042,15 @@ def preflight_capture_breakpoints(*, pid: int, debug_root: Path = DEFAULT_DEBUG_
         "process_attached": True,
         "process_detached": True,
     }
+    temporary = result_path.with_name(f".{result_path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(normalized_result, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    os.chmod(temporary, 0o600)
+    temporary.replace(result_path)
+    os.chmod(result_path, 0o600)
+    return normalized_result
 
 
 def capture_salt_matched_passphrase(
@@ -763,24 +1060,36 @@ def capture_salt_matched_passphrase(
     probe_db_path: str | Path,
     timeout: int = 240,
     enable_key_return_fallback: bool = True,
-) -> str:
+    ready_file: str | Path | None = None,
+    account_probe_pages: dict[str, bytes] | None = None,
+    return_details: bool = False,
+    transaction_id: str | None = None,
+    pbkdf_stub_plan: dict[str, int] | None = None,
+) -> str | dict[str, Any]:
     if platform.machine().lower() not in {"arm64", "aarch64"}:
         raise MacOSDBKeyCaptureFailure("capture_arch_unsupported", "当前安全捕获流程仅支持 Apple Silicon Mac")
     if shutil.which("lldb") is None:
         raise MacOSDBKeyCaptureFailure("lldb_missing", "未安装 LLDB，请先运行 xcode-select --install")
 
     salts = _normalize_salts(expected_salts)
-    probe_database = Path(probe_db_path).expanduser()
-    try:
-        with probe_database.open("rb") as handle:
-            probe_page1 = handle.read(4096)
-    except OSError as exc:
-        raise MacOSDBKeyCaptureFailure(
-            "probe_database_unreadable",
-            f"无法读取目标数据库用于实时校验: {probe_database}",
-        ) from exc
-    if len(probe_page1) < 4096:
-        raise MacOSDBKeyCaptureFailure("probe_database_invalid", f"目标数据库首页不完整: {probe_database}")
+    account_pages = normalize_account_probe_pages(account_probe_pages) if account_probe_pages is not None else None
+    if account_pages is not None:
+        # Use the pre-capture account snapshot, never reread a live database
+        # whose salt may have changed during a relogin.
+        probe_page1 = account_pages["message"]
+        salts = _normalize_salts([*salts, *(page[:16] for page in account_pages.values())])
+    else:
+        probe_database = Path(probe_db_path).expanduser()
+        try:
+            with probe_database.open("rb") as handle:
+                probe_page1 = handle.read(4096)
+        except OSError as exc:
+            raise MacOSDBKeyCaptureFailure(
+                "probe_database_unreadable",
+                f"无法读取目标数据库用于实时校验: {probe_database}",
+            ) from exc
+        if len(probe_page1) < 4096:
+            raise MacOSDBKeyCaptureFailure("probe_database_invalid", f"目标数据库首页不完整: {probe_database}")
     with tempfile.TemporaryDirectory(prefix="wedata-salt-capture-") as temporary_dir:
         root = Path(temporary_dir)
         result_path = root / "result.json"
@@ -792,6 +1101,10 @@ def capture_salt_matched_passphrase(
                 salts,
                 probe_page1=probe_page1,
                 enable_key_return_fallback=enable_key_return_fallback,
+                ready_path=Path(ready_file).expanduser() if ready_file else None,
+                account_probe_pages=account_pages,
+                transaction_id=transaction_id,
+                pbkdf_stub_plan=pbkdf_stub_plan,
             ),
             encoding="utf-8",
         )
@@ -816,10 +1129,20 @@ def capture_salt_matched_passphrase(
         except (OSError, UnicodeError, ValueError):
             payload = {}
 
+    if not isinstance(payload, dict):
+        payload = {}
     passphrase = str(payload.get("passphrase") or "").strip().lower()
     captured_salt = str(payload.get("salt") or "").strip().lower()
     diagnostics = payload.get("diagnostics") if isinstance(payload.get("diagnostics"), dict) else {}
-    if len(passphrase) == 64 and captured_salt in salts:
+    if re.fullmatch(r"[0-9a-f]{64}", passphrase) and captured_salt in salts:
+        if transaction_id and payload.get("transaction_id") != transaction_id:
+            raise MacOSDBKeyCaptureFailure("capture_transaction_mismatch", "捕获结果不属于当前事务，未保存账号密钥。")
+        validation = validate_account_candidate(passphrase, account_pages) if account_pages is not None else {
+            "key_mode": str(payload.get("key_mode") or ""),
+            "validated_roles": ["probe"],
+        }
+        if return_details:
+            return {"passphrase": passphrase, **validation, "diagnostics": diagnostics}
         return passphrase
     compact = " ".join(str(output or "").split()).lower()
     if "attach failed" in compact or "not allowed to attach" in compact:
@@ -833,16 +1156,18 @@ def capture_salt_matched_passphrase(
         )
     pbkdf_calls = int(diagnostics.get("pbkdf_calls") or 0)
     pbkdf_shape_hits = int(diagnostics.get("pbkdf_shape_hits") or 0)
+    pbkdf_profiles = diagnostics.get("pbkdf_profiles") if isinstance(diagnostics.get("pbkdf_profiles"), dict) else {}
     pbkdf_rounds_2_hits = int(diagnostics.get("pbkdf_rounds_2_hits") or 0)
     pbkdf_rounds_256000_hits = int(diagnostics.get("pbkdf_rounds_256000_hits") or 0)
     pbkdf_salt_hits = int(diagnostics.get("pbkdf_salt_hits") or 0)
     key_return_hits = int(diagnostics.get("key_return_hits") or 0)
     candidate_rejections = int(diagnostics.get("candidate_rejections") or 0)
+    partial_candidates = int(diagnostics.get("partial_candidates") or 0)
     detail = (
         f"断点统计：PBKDF2 调用 {pbkdf_calls}，参数匹配 {pbkdf_shape_hits}，"
         f"rounds=2 命中 {pbkdf_rounds_2_hits}，rounds=256000 命中 {pbkdf_rounds_256000_hits}，"
         f"数据库 salt 匹配 {pbkdf_salt_hits}，微信内部断点 {key_return_hits}，"
-        f"候选校验失败 {candidate_rejections}。"
+        f"候选校验失败 {candidate_rejections}，仅部分库匹配 {partial_candidates}，参数样本 {pbkdf_profiles}。"
     )
     process_exit = payload.get("process_exit") if isinstance(payload.get("process_exit"), dict) else None
     if process_exit is not None:
@@ -855,9 +1180,8 @@ def capture_salt_matched_passphrase(
             exit_detail += f"，原因 {exit_description}"
         raise MacOSDBKeyCaptureFailure(
             "debug_wechat_exited_during_capture",
-            f"独立调试微信在捕获阶段提前结束（{exit_detail}）。" + detail
-            + "未保存任何未经数据库校验的候选；"
-            + "请将这段非敏感诊断随微信版本和 build 一并反馈。",
+            f"临时调试微信在捕获阶段提前结束（{exit_detail}）。" + detail
+            + "未保存任何未经数据库校验的候选；请将这段非敏感诊断随微信版本和 build 一并反馈。",
             process_attached=True,
         )
     raise MacOSDBKeyCaptureFailure(
@@ -999,7 +1323,7 @@ def preflight_prepared_clone(
         raise MacOSDBKeyCaptureFailure("debug_capture_state_stale", "独立微信进程与捕获快照不匹配，请重新准备")
 
     try:
-        result = preflight_capture_breakpoints(pid=debug_pid, debug_root=debug_root)
+        result = preflight_capture_breakpoints(pid=debug_pid, debug_root=debug_root, wechat_app=debug_app)
     except Exception:
         _cleanup_prepared_clone(debug_root)
         raise
@@ -1081,6 +1405,7 @@ def capture_prepared_clone(
             # necessarily called again by every re-login path; the verified
             # internal return point is therefore required as a live fallback.
             enable_key_return_fallback=int(preflight.get("key_return_locations") or 0) > 0,
+            pbkdf_stub_plan=preflight.get("pbkdf_stub_plan"),
         )
         _validate_captured_passphrase(passphrase, probe_db_path)
         cache_path = save_passphrase(passphrase)
@@ -1111,6 +1436,7 @@ __all__ = [
     "build_lldb_salt_capture_script",
     "capture_prepared_clone",
     "capture_salt_matched_passphrase",
+    "resolve_lldb_pbkdf_stub_plan",
     "cleanup_clone_capture",
     "preflight_capture_breakpoints",
     "preflight_prepared_clone",

--- a/src/wechat_decrypt_tool/macos_db_key_capture.py
+++ b/src/wechat_decrypt_tool/macos_db_key_capture.py
@@ -157,6 +157,49 @@ def _wechat_version(wechat_app: Path) -> tuple[str, str]:
     return safe(info.get("CFBundleShortVersionString")), safe(info.get("CFBundleVersion"))
 
 
+def _official_identity_matches(
+    wechat_app: Path,
+    signature: dict[str, Any],
+    expected_version: tuple[str, str] | None,
+    expected_cdhash: str | None,
+) -> bool:
+    return bool(
+        _is_tencent_official_signature(signature)
+        and (expected_version is None or _wechat_version(wechat_app) == expected_version)
+        and (not expected_cdhash or str(signature.get("cdhash") or "").lower() == expected_cdhash.lower())
+    )
+
+
+def _wechat_bundle_identity(wechat_app: Path, signature: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Identify the exact bundle we created, not just any compatible ad-hoc app."""
+    signature = signature if signature is not None else inspect_wechat_signature(wechat_app)
+    version, build = _wechat_version(wechat_app)
+    stat = wechat_app.stat()
+    return {
+        "version": version, "build": build, "cdhash": str(signature.get("cdhash") or "").lower(),
+        "device": stat.st_dev, "inode": stat.st_ino,
+    }
+
+
+def _debug_identity_matches(
+    wechat_app: Path, expected: dict[str, Any] | None, signature: dict[str, Any] | None = None,
+) -> bool:
+    if not isinstance(expected, dict) or not expected.get("cdhash"):
+        return False
+    if not all(field in expected for field in ("version", "build", "device", "inode")):
+        return False
+    try:
+        if wechat_app.is_symlink() or not wechat_app.is_dir():
+            return False
+        signature = signature if signature is not None else inspect_wechat_signature(wechat_app)
+        return bool(
+            signature.get("valid") and signature.get("ad_hoc") and not signature.get("hardened_runtime")
+            and _wechat_bundle_identity(wechat_app, signature) == expected
+        )
+    except (OSError, ValueError, plistlib.InvalidFileException, MacOSDBKeyCaptureFailure):
+        return False
+
+
 def _original_backup_path(wechat_app: Path, backup_root: Path) -> Path:
     version, build = _wechat_version(wechat_app)
     return backup_root.expanduser() / f"WeChat-{version}-{build}-original.zip"
@@ -462,8 +505,13 @@ def _launch_wechat(
         if pid:
             time.sleep(2)
             stable_pid = _find_wechat_main_pid(wechat_app)
-            if stable_pid:
+            if stable_pid == pid:
                 return stable_pid
+            raise MacOSDBKeyCaptureFailure(
+                "wechat_launch_exited",
+                "临时微信在启动检查期间退出或更换了进程，已停止等待并尝试恢复官方原版。"
+                "如果系统提示无法验证，请勿继续登录或绕过安全检查。",
+            )
         time.sleep(0.25)
     raise MacOSDBKeyCaptureFailure("wechat_launch_failed", f"未能启动微信副本: {wechat_app}")
 
@@ -701,7 +749,7 @@ def ensure_wechat_in_place_debuggable(
     )
     original_cdhash = str(signature.get("cdhash") or "").lower()
     backup_cdhash = str(backup_verification.get("cdhash") or "").lower()
-    if original_cdhash and backup_cdhash != original_cdhash:
+    if not original_cdhash or not backup_cdhash or backup_cdhash != original_cdhash:
         raise MacOSDBKeyCaptureFailure(
             "official_backup_identity_mismatch",
             "所选目录中的原版备份虽有腾讯签名，但与当前安装的微信不是同一构建，已停止临时重签。",
@@ -720,6 +768,10 @@ def ensure_wechat_in_place_debuggable(
 
     try:
         _quit_wechat(wechat_app)
+        if os.path.lexists(_local_restore_staging_path(wechat_app)):
+            raise MacOSDBKeyCaptureFailure(
+                "official_restore_staging_conflict", "原版保护位置已有恢复资产，请由事务流程保留后再重试。",
+            )
         staged_app = _prepare_local_restore_staging(
             wechat_app,
             expected_version=(str(recovery["version"]), str(recovery["build"])),
@@ -758,13 +810,35 @@ def ensure_wechat_in_place_debuggable(
                 requires_wechat_resign=True,
                 wechat_modified=True,
             )
+        recovery["debug_identity"] = _wechat_bundle_identity(staged_app, signature)
+        if before_resign is not None:
+            # Persist the exact debug inode before it can enter the installed slot.
+            before_resign(dict(recovery))
+        current_signature = inspect_wechat_signature(wechat_app)
+        if not _official_identity_matches(
+            wechat_app, current_signature,
+            (str(recovery["version"]), str(recovery["build"])), str(recovery["official_cdhash"]),
+        ):
+            raise MacOSDBKeyCaptureFailure(
+                "external_install_conflict", "准备期间微信安装已变化；已保留当前应用和恢复资产，未覆盖。",
+            )
         _atomic_swap_paths(wechat_app, staged_app)
         installed_signature = inspect_wechat_signature(wechat_app)
+        if not _official_identity_matches(
+            staged_app, inspect_wechat_signature(staged_app),
+            (str(recovery["version"]), str(recovery["build"])), str(recovery["official_cdhash"]),
+        ):
+            # An external installer won the race between the last check and
+            # swap. Put its bundle back; do not classify it as our debug waste.
+            if _debug_identity_matches(wechat_app, recovery["debug_identity"], installed_signature):
+                _atomic_swap_paths(wechat_app, staged_app)
+            raise MacOSDBKeyCaptureFailure("external_install_conflict", "交换期间检测到其他微信安装，已停止本次捕获并保留恢复资产。")
         if (
             not installed_signature.get("valid")
             or not installed_signature.get("ad_hoc")
             or installed_signature.get("hardened_runtime")
             or not _has_compatible_in_place_signature(wechat_app)
+            or not _debug_identity_matches(wechat_app, recovery["debug_identity"], installed_signature)
         ):
             raise MacOSDBKeyCaptureFailure(
                 "in_place_swap_verify_failed",
@@ -779,8 +853,13 @@ def ensure_wechat_in_place_debuggable(
                 backup_path,
                 expected_version=(str(recovery["version"]), str(recovery["build"])),
                 expected_cdhash=str(recovery["official_cdhash"]),
+                expected_debug_identity=recovery.get("debug_identity"),
             )
         except Exception as restore_error:
+            if isinstance(restore_error, MacOSDBKeyCaptureFailure) and restore_error.code in {
+                "external_install_conflict", "in_place_debug_identity_unknown", "official_restore_staging_conflict",
+            }:
+                raise restore_error from capture_error
             raise MacOSDBKeyCaptureFailure(
                 "official_restore_failed",
                 f"临时重签失败，且自动恢复腾讯原版微信失败: {restore_error}",
@@ -800,6 +879,7 @@ def ensure_wechat_in_place_debuggable(
         "backup_created": backup_created,
         "backup_verified": True,
         "official_cdhash": backup_cdhash,
+        "debug_identity": recovery["debug_identity"],
     }
 
 
@@ -810,17 +890,35 @@ def restore_official_wechat_if_needed(
     work_root: Path | None = None,
     expected_version: tuple[str, str] | None = None,
     expected_cdhash: str | None = None,
+    expected_debug_identity: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Verify the normal Tencent build and restore it atomically when needed."""
 
     staged = _local_restore_staging_path(wechat_app)
     current = inspect_wechat_signature(wechat_app)
     if _is_tencent_official_signature(current):
-        # Recovery may have been interrupted just after the atomic exchange.
-        # At that point the installed path is already official and ``staged``
-        # contains only WCDA's displaced ad-hoc bundle.
-        _remove_local_restore_staging(staged)
-        return {"official_wechat_verified": True, "official_wechat_restored": False}
+        if not _official_identity_matches(wechat_app, current, expected_version, expected_cdhash):
+            raise MacOSDBKeyCaptureFailure(
+                "external_install_conflict",
+                "当前腾讯官方微信与本次备份版本或构建不同；已保留当前应用、备份和恢复状态，未自动覆盖。",
+            )
+        # A matching official app can be an interrupted completed restore. Only
+        # delete staging when its exact identity proves that it is our debug app.
+        if _debug_identity_matches(staged, expected_debug_identity):
+            _remove_local_restore_staging(staged)
+        return {
+            "official_wechat_verified": True, "official_wechat_restored": False,
+            "original_identity_verified": bool(expected_version is not None and expected_cdhash),
+        }
+
+    if not _debug_identity_matches(wechat_app, expected_debug_identity, current):
+        raise MacOSDBKeyCaptureFailure(
+            "in_place_debug_identity_unknown",
+            "当前非官方微信无法确认为本次生成的调试副本；已保留恢复资产，拒绝自动覆盖。",
+            wechat_modified=True,
+        )
+    if expected_version is None or not all(expected_version) or not expected_cdhash:
+        raise MacOSDBKeyCaptureFailure("in_place_capture_state_invalid", "缺少原版构建身份，已停止自动恢复。", wechat_modified=True)
 
     use_local_staging = False
     if os.path.lexists(staged):
@@ -842,7 +940,12 @@ def restore_official_wechat_if_needed(
         except (OSError, plistlib.InvalidFileException, MacOSDBKeyCaptureFailure):
             use_local_staging = False
         if not use_local_staging:
-            _remove_local_restore_staging(staged)
+            if _debug_identity_matches(staged, expected_debug_identity):
+                _remove_local_restore_staging(staged)
+            else:
+                raise MacOSDBKeyCaptureFailure(
+                    "official_restore_staging_conflict", "原版保护位置存在身份不匹配的应用；已保留，未覆盖。", wechat_modified=True,
+                )
 
     if not use_local_staging:
         restore_root = (work_root or DEFAULT_DEBUG_ROOT).expanduser()
@@ -868,20 +971,43 @@ def restore_official_wechat_if_needed(
                     _remove_local_restore_staging(staged)
                 raise
         staged_signature = inspect_wechat_signature(staged)
-        if not _is_tencent_official_signature(staged_signature):
-            _remove_local_restore_staging(staged)
+        if not _official_identity_matches(staged, staged_signature, expected_version, expected_cdhash):
             raise MacOSDBKeyCaptureFailure("official_restore_staging_invalid", "恢复暂存的腾讯微信签名校验失败")
 
+    if not _debug_identity_matches(wechat_app, expected_debug_identity):
+        raise MacOSDBKeyCaptureFailure("external_install_conflict", "恢复前微信安装已变化；已保留应用和恢复资产。")
     _quit_wechat(wechat_app, force_for_restore=True)
+    if not _debug_identity_matches(wechat_app, expected_debug_identity):
+        raise MacOSDBKeyCaptureFailure("external_install_conflict", "关闭微信期间安装已变化；已停止恢复。")
+    if not _official_identity_matches(staged, inspect_wechat_signature(staged), expected_version, expected_cdhash):
+        raise MacOSDBKeyCaptureFailure("official_restore_staging_invalid", "恢复前原版保护身份已变化，已停止恢复。")
+    restore_identity = _wechat_bundle_identity(staged)
     swapped = False
     try:
         _atomic_swap_paths(wechat_app, staged)
         swapped = True
         installed = inspect_wechat_signature(wechat_app)
-        if not _is_tencent_official_signature(installed):
+        if not _official_identity_matches(wechat_app, installed, expected_version, expected_cdhash):
             raise MacOSDBKeyCaptureFailure("official_restore_verify_failed", "恢复后的腾讯微信签名校验失败")
-    except Exception:
+        if not _debug_identity_matches(staged, expected_debug_identity):
+            raise MacOSDBKeyCaptureFailure("external_install_conflict", "交换时微信被其他程序替换，已回滚并保留恢复资产。")
+    except Exception as restore_error:
         if swapped:
+            # An installer may also replace the destination immediately after
+            # our exchange. A blind rollback would overwrite that new install.
+            # Only exchange back when the destination is still our exact source.
+            current_signature = inspect_wechat_signature(wechat_app)
+            try:
+                still_our_restore = bool(
+                    _official_identity_matches(wechat_app, current_signature, expected_version, expected_cdhash)
+                    and _wechat_bundle_identity(wechat_app, current_signature) == restore_identity
+                )
+            except (OSError, ValueError, plistlib.InvalidFileException, MacOSDBKeyCaptureFailure):
+                still_our_restore = False
+            if not still_our_restore:
+                raise MacOSDBKeyCaptureFailure(
+                    "external_install_conflict", "恢复交换后安装身份再次变化；为避免覆盖外部安装，已停止回滚并保留恢复资产。",
+                ) from restore_error
             try:
                 _atomic_swap_paths(wechat_app, staged)
                 swapped = False
@@ -891,12 +1017,13 @@ def restore_official_wechat_if_needed(
                     f"微信原版恢复校验失败，且无法回滚交换: {rollback_error}",
                     wechat_modified=True,
                 ) from rollback_error
-        if os.path.lexists(staged):
-            _remove_local_restore_staging(staged)
+        # Keep the recovery source after rollback; it may be the only available
+        # original when the selected backup volume is offline.
         raise
-    _remove_local_restore_staging(staged)
+    if _debug_identity_matches(staged, expected_debug_identity):
+        _remove_local_restore_staging(staged)
 
-    return {"official_wechat_verified": True, "official_wechat_restored": True}
+    return {"official_wechat_verified": True, "official_wechat_restored": True, "original_identity_verified": True}
 
 
 def _atomic_swap_paths(first: Path, second: Path) -> None:
@@ -937,7 +1064,9 @@ def _build_lldb_capture_command(script_path: Path, timeout: int) -> str:
     ``do shell script`` only returns stdout after the privileged command exits,
     so a plain ``(cat; sleep) | lldb`` makes a successful capture appear stuck
     until the sleep finishes.  This wrapper preserves the upstream stdin
-    behaviour while explicitly killing the producer when LLDB detaches.
+    behaviour while reaping both the producer and the watchdog's child timer
+    when LLDB exits.  A surviving timer also holds AppleScript's output pipe
+    open, even after the wrapper shell itself has returned.
     """
 
     script_arg = shlex.quote(str(script_path))
@@ -949,12 +1078,19 @@ def _build_lldb_capture_command(script_path: Path, timeout: int) -> str:
         'lldb_pid=""\n'
         'watchdog_pid=""\n'
         "cleanup() {\n"
+        "  trap '' HUP INT TERM\n"
         '  if [ -n "$producer_pid" ]; then /bin/kill "$producer_pid" 2>/dev/null || true; fi\n'
         '  if [ -n "$watchdog_pid" ]; then /bin/kill "$watchdog_pid" 2>/dev/null || true; fi\n'
         '  if [ -n "$lldb_pid" ]; then /bin/kill "$lldb_pid" 2>/dev/null || true; fi\n'
+        '  if [ -n "$producer_pid" ]; then wait "$producer_pid" 2>/dev/null || true; fi\n'
+        '  if [ -n "$watchdog_pid" ]; then wait "$watchdog_pid" 2>/dev/null || true; fi\n'
+        '  if [ -n "$lldb_pid" ]; then wait "$lldb_pid" 2>/dev/null || true; fi\n'
         '  /bin/rm -rf "$capture_dir"\n'
         "}\n"
-        "trap cleanup EXIT HUP INT TERM\n"
+        "trap cleanup EXIT\n"
+        "trap 'exit 129' HUP\n"
+        "trap 'exit 130' INT\n"
+        "trap 'exit 143' TERM\n"
         '/usr/bin/mkfifo "$capture_fifo"\n'
         # ``exec`` makes the recorded producer PID become the sleep process
         # after cat finishes, so SIGTERM actually ends the keepalive instead
@@ -963,7 +1099,28 @@ def _build_lldb_capture_command(script_path: Path, timeout: int) -> str:
         "producer_pid=$!\n"
         '/usr/bin/env TERM=dumb /usr/bin/lldb < "$capture_fifo" 2>&1 &\n'
         "lldb_pid=$!\n"
-        f'( /bin/sleep {keepalive}; /bin/kill -TERM "$lldb_pid" 2>/dev/null || true ) &\n'
+        "(\n"
+        '  watchdog_sleep_pid=""\n'
+        '  watchdog_cancelled=""\n'
+        # Defer cancellation until the child PID is recorded, including a
+        # signal arriving between the background launch and its assignment.
+        "  trap 'watchdog_cancelled=1' HUP INT TERM\n"
+        "  cleanup_watchdog() {\n"
+        "    trap '' HUP INT TERM\n"
+        '    if [ -n "$watchdog_sleep_pid" ]; then\n'
+        '      /bin/kill "$watchdog_sleep_pid" 2>/dev/null || true\n'
+        '      wait "$watchdog_sleep_pid" 2>/dev/null || true\n'
+        "    fi\n"
+        "  }\n"
+        "  trap cleanup_watchdog EXIT\n"
+        f"  /bin/sleep {keepalive} &\n"
+        "  watchdog_sleep_pid=$!\n"
+        "  trap 'exit 0' HUP INT TERM\n"
+        '  if [ -n "$watchdog_cancelled" ]; then exit 0; fi\n'
+        '  wait "$watchdog_sleep_pid"\n'
+        '  watchdog_sleep_pid=""\n'
+        '  /bin/kill -TERM "$lldb_pid" 2>/dev/null || true\n'
+        ") &\n"
         "watchdog_pid=$!\n"
         'wait "$lldb_pid"\n'
         "lldb_status=$?\n"

--- a/src/wechat_decrypt_tool/macos_inplace_capture.py
+++ b/src/wechat_decrypt_tool/macos_inplace_capture.py
@@ -10,14 +10,20 @@ is restored on every terminal path.
 from __future__ import annotations
 
 import json
+import functools
+import hashlib
 import os
 import platform
+import re
 import subprocess
+import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
 from .macos_clone_capture import (
+    capture_salt_matched_passphrase,
     _breakpoint_preflight_path,
     _remove_breakpoint_preflight,
 )
@@ -27,8 +33,11 @@ from .macos_db_key_capture import (
     MacOSDBKeyCaptureFailure,
     _find_wechat_bundle_pids,
     _find_wechat_main_pid,
+    _debug_identity_matches,
     _has_compatible_in_place_signature,
     _is_tencent_official_signature,
+    _local_restore_staging_path,
+    _official_identity_matches,
     _launch_wechat,
     _run_as_administrator,
     _validate_captured_passphrase,
@@ -45,7 +54,123 @@ from .macos_native_capture import (
 
 IN_PLACE_STATE_NAME = "prepared-in-place-capture.json"
 NATIVE_CAPTURE_READY_NAME = "native-capture-ready.json"
-STATE_SCHEMA_VERSION = 1
+STATE_SCHEMA_VERSION = 2
+CAPTURE_PHASES = frozenset({"waiting_authorization", "monitoring", "captured", "validating", "restoring"})
+DEFAULT_CAPTURE_LOCK_ROOT = Path.home() / "Library/Application Support/WeData/capture-locks"
+_OWNER_SESSION = uuid.uuid4().hex
+_INSTALLATION_LOCKS: dict[str, dict[str, Any]] = {}
+_INSTALLATION_LOCKS_MUTEX = threading.Lock()
+_INSTALLATION_OPERATIONS: dict[str, tuple[int, int]] = {}
+
+
+def _serialized_installation_operation(function):
+    """Serialize a synchronous API call, without pinning future calls to its thread."""
+    @functools.wraps(function)
+    def guarded(wechat_install_path, *args, **kwargs):
+        wechat_app = normalize_wechat_app_path(wechat_install_path)
+        key, thread = str(wechat_app), threading.get_ident()
+        with _INSTALLATION_LOCKS_MUTEX:
+            owner, depth = _INSTALLATION_OPERATIONS.get(key, (thread, 0))
+            if owner != thread:
+                raise MacOSDBKeyCaptureFailure("in_place_capture_busy", "此微信安装的操作尚未结束，请等待完成后重试。")
+            _INSTALLATION_OPERATIONS[key] = (thread, depth + 1)
+        try:
+            return function(wechat_install_path, *args, **kwargs)
+        finally:
+            with _INSTALLATION_LOCKS_MUTEX:
+                owner, depth = _INSTALLATION_OPERATIONS[key]
+                if depth == 1:
+                    del _INSTALLATION_OPERATIONS[key]
+                else:
+                    _INSTALLATION_OPERATIONS[key] = (owner, depth - 1)
+    return guarded
+
+
+def _acquire_installation_lock(wechat_app: Path, debug_root: Path) -> dict[str, Any]:
+    """Keep a same-user OS lock across HTTP workers and selected data roots.
+
+    The local per-user directory deliberately needs no /Applications write or
+    administrator authorization. Transactions by other OS users are not covered.
+    """
+    import fcntl
+
+    key, owner = str(wechat_app.resolve()), str(debug_root.expanduser().resolve())
+    with _INSTALLATION_LOCKS_MUTEX:
+        existing = _INSTALLATION_LOCKS.get(key)
+        if existing is not None and existing["owner_pid"] != os.getpid():
+            # A fork must not treat its parent's inherited descriptor as a new
+            # independent transaction owner.
+            os.close(existing["fd"])
+            del _INSTALLATION_LOCKS[key]
+            existing = None
+        if existing is not None:
+            if existing["debug_root"] != owner:
+                raise MacOSDBKeyCaptureFailure("in_place_capture_busy", "此微信安装已有其他捕获事务，请先结束该事务。")
+            return existing
+        lock_root = DEFAULT_CAPTURE_LOCK_ROOT.expanduser()
+        lock_path = lock_root / f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.lock"
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = None
+        try:
+            if lock_root.is_symlink():
+                raise OSError("capture lock directory must not be a symlink")
+            lock_root.mkdir(parents=True, exist_ok=True)
+            os.chmod(lock_root, 0o700)
+            descriptor = os.open(lock_path, flags, 0o600)
+            os.fchmod(descriptor, 0o600)
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            if descriptor is not None:
+                os.close(descriptor)
+            raise MacOSDBKeyCaptureFailure("in_place_capture_busy", "此微信安装正由另一个进程操作，请稍后重试。") from exc
+        except OSError as exc:
+            if descriptor is not None:
+                os.close(descriptor)
+            raise MacOSDBKeyCaptureFailure("in_place_capture_lock_unavailable", "无法创建当前用户的本地捕获锁，已停止临时修改。") from exc
+        lease = {"fd": descriptor, "debug_root": owner, "transaction_id": uuid.uuid4().hex, "owner_pid": os.getpid()}
+        _INSTALLATION_LOCKS[key] = lease
+        return lease
+
+
+def _release_installation_lock(wechat_app: Path, debug_root: Path) -> None:
+    key, owner = str(wechat_app.resolve()), str(debug_root.expanduser().resolve())
+    with _INSTALLATION_LOCKS_MUTEX:
+        lease = _INSTALLATION_LOCKS.get(key)
+        if lease is not None and lease["debug_root"] == owner:
+            del _INSTALLATION_LOCKS[key]
+            os.close(lease["fd"])
+
+
+def _transaction_is_active(wechat_app: Path, state: dict[str, Any]) -> bool:
+    with _INSTALLATION_LOCKS_MUTEX:
+        lease = _INSTALLATION_LOCKS.get(str(wechat_app.resolve()))
+        return bool(
+            lease and state.get("transaction_id") == lease["transaction_id"]
+            and state.get("owner_session") == _OWNER_SESSION and state.get("owner_pid") == os.getpid()
+        )
+
+
+def _preserve_recovery_assets(wechat_app: Path, debug_root: Path, state: dict[str, Any]) -> None:
+    """Retire an inactive transaction without destroying its original bundle."""
+    archived = dict(state)
+    archived["stage"] = "superseded_by_external_install"
+    archived["superseded_at"] = int(time.time())
+    identifier = uuid.uuid4().hex
+    staged = _local_restore_staging_path(wechat_app)
+    if os.path.lexists(staged):
+        if staged.is_symlink() or not staged.is_dir():
+            raise MacOSDBKeyCaptureFailure("local_restore_path_unsafe", "原版保护路径异常，已保留并停止操作。")
+        preserved = staged.with_name(f".WeChat.wedata-preserved-{identifier}.app")
+        # Save the intended destination first so interruption never loses the
+        # relationship between the old state and its preserved bundle.
+        archived["preserved_staging_path"] = str(preserved)
+    else:
+        preserved = None
+    archive_root = debug_root.expanduser() / "recovery-history" / identifier
+    _write_state(archive_root, archived)
+    if preserved is not None:
+        staged.rename(preserved)
+    _remove_state(debug_root)
 
 
 def _state_path(debug_root: Path) -> Path:
@@ -69,20 +194,68 @@ def _prepare_native_capture_ready(debug_root: Path) -> Path:
     return target
 
 
-def native_capture_monitor_ready(*, debug_root: Path = DEFAULT_DEBUG_ROOT) -> bool:
-    """Return true only after the native monitor has armed its breakpoint."""
-
+def _capture_signal(state: dict[str, Any], debug_root: Path) -> str | None:
+    """Read only a transaction/PID-bound, non-secret helper progress signal."""
     target = _native_capture_ready_path(debug_root)
     try:
         payload = json.loads(target.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, ValueError):
-        return False
-    return bool(
+        return None
+    try:
+        pid = int(payload.get("pid") or 0) if isinstance(payload, dict) else 0
+        preflight = state.get("preflight")
+        expected_pid = int((preflight.get("pid") if isinstance(preflight, dict) else None) or state.get("debug_pid") or 0)
+    except (TypeError, ValueError):
+        return None
+    valid = (
         isinstance(payload, dict)
-        and payload.get("status") == "ready"
-        and payload.get("method") == "macos_native_mach"
-        and int(payload.get("pid") or 0) > 0
+        and state.get("stage") == "capturing"
+        and state.get("transaction_id")
+        and payload.get("transaction_id") == state.get("transaction_id")
+        and payload.get("status") in ("ready", "captured")
+        and payload.get("method") in ("macos_native_mach", "macos_lldb_stub")
+        and pid > 0
+        and pid == expected_pid
     )
+    return payload["status"] if valid else None
+
+
+def _capture_phase(state: dict[str, Any], debug_root: Path) -> str | None:
+    if state.get("stage") != "capturing":
+        return None
+    phase = state.get("capture_phase")
+    if phase in ("captured", "validating", "restoring"):
+        # The ready file can outlive the monitor. Never invite another login
+        # after capture, or while the verified original is being restored.
+        return phase
+    signal = _capture_signal(state, debug_root)
+    if signal == "captured":
+        return "captured"
+    if signal == "ready":
+        return "monitoring"
+    if phase == "monitoring":
+        return "waiting_authorization"
+    return phase if isinstance(phase, str) and phase in CAPTURE_PHASES else None
+
+
+def native_capture_monitor_ready(*, debug_root: Path = DEFAULT_DEBUG_ROOT) -> bool:
+    """Return true only while this transaction's login monitor is armed."""
+    try:
+        state = _read_state(debug_root)
+    except MacOSDBKeyCaptureFailure:
+        return False
+    return _capture_phase(state, debug_root) == "monitoring"
+
+
+def _set_capture_phase(debug_root: Path, state: dict[str, Any], phase: str) -> None:
+    """Progress is advisory: a UI write failure must never prevent recovery."""
+    if state.get("stage") != "capturing" or phase not in CAPTURE_PHASES:
+        return
+    state["capture_phase"] = phase
+    try:
+        _write_state(debug_root, state)
+    except OSError:
+        pass
 
 
 def _remove_native_capture_ready(debug_root: Path) -> None:
@@ -105,19 +278,46 @@ def get_in_place_capture_status(*, debug_root: Path = DEFAULT_DEBUG_ROOT) -> dic
             "stage": "idle",
             "needs_cleanup": False,
             "monitor_ready": False,
+            "capture_backend": None,
+            "capture_phase": None,
+            "prepared_process_exited": None,
+            "transaction_id": None,
+            "recovery_error_code": None,
         }
     try:
         state = _read_state(debug_root)
         stage = str(state.get("stage") or "unknown").strip().lower()
     except MacOSDBKeyCaptureFailure:
         stage = "invalid"
-    if stage not in {"backup_verified", "resigned", "launched", "preflight_passed", "invalid"}:
+        state = {}
+    if stage not in {"backup_verified", "debug_prepared", "resigned", "awaiting_manual_launch", "launched", "preflight_passed", "capturing", "external_install_conflict", "recovery_blocked", "invalid"}:
         stage = "unknown"
+    backend = state.get("capture_backend")
+    recovery_code = state.get("recovery_error_code")
+    transaction_id = state.get("transaction_id")
+    phase = _capture_phase(state, debug_root)
+    prepared_process_exited = None
+    # Read-only health information for the idle login/preflight UI. Never
+    # interpret the deliberate post-capture shutdown as an abnormal exit.
+    if stage in {"launched", "preflight_passed"} and state.get("wechat_app_path") == str(DEFAULT_WECHAT_APP):
+        try:
+            expected_pid = int(state.get("debug_pid") or 0)
+            if expected_pid > 0:
+                prepared_process_exited = _find_wechat_main_pid(DEFAULT_WECHAT_APP) != expected_pid
+        except (OSError, subprocess.SubprocessError, TypeError, ValueError):
+            pass  # Unknown is not proof of exit and must not trigger recovery.
     return {
         "pending": True,
         "stage": stage,
         "needs_cleanup": True,
-        "monitor_ready": native_capture_monitor_ready(debug_root=debug_root),
+        "monitor_ready": phase == "monitoring",
+        "capture_phase": phase,
+        "prepared_process_exited": prepared_process_exited,
+        "capture_backend": backend if isinstance(backend, str) and backend in {"native", "lldb"} else None,
+        "transaction_id": transaction_id if isinstance(transaction_id, str) and re.fullmatch(r"[A-Za-z0-9_-]{1,128}", transaction_id) else None,
+        "recovery_error_code": recovery_code if isinstance(recovery_code, str) and recovery_code in {
+            "external_install_conflict", "in_place_debug_identity_unknown", "official_restore_staging_conflict",
+        } else None,
     }
 
 
@@ -191,16 +391,25 @@ def _write_state(debug_root: Path, payload: dict[str, Any]) -> Path:
     flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(temporary, flags, 0o600)
     try:
-        view = memoryview(encoded)
-        while view:
-            written = os.write(descriptor, view)
-            if written <= 0:
-                raise OSError("short write")
-            view = view[written:]
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-    temporary.replace(target)
+        try:
+            view = memoryview(encoded)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short write")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        temporary.replace(target)
+    except OSError:
+        # Only remove the temporary file created by this invocation. Retain
+        # the last durable recovery state and allow a later update to retry.
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
     os.chmod(target, 0o600)
     try:
         directory_fd = os.open(target.parent, os.O_RDONLY)
@@ -269,7 +478,7 @@ def _read_state(debug_root: Path) -> dict[str, Any]:
             "in_place_capture_not_prepared",
             "没有找到可恢复的临时重签状态，请重新开始。",
         ) from exc
-    if not isinstance(payload, dict) or int(payload.get("schema_version") or 0) != STATE_SCHEMA_VERSION:
+    if not isinstance(payload, dict) or payload.get("schema_version") not in (1, STATE_SCHEMA_VERSION):
         raise MacOSDBKeyCaptureFailure("in_place_capture_state_invalid", "临时重签恢复状态无效，已停止操作")
     return payload
 
@@ -316,6 +525,7 @@ def _prepared_signature_is_valid(wechat_app: Path) -> bool:
     )
 
 
+@_serialized_installation_operation
 def recover_stale_in_place_capture(
     wechat_install_path: str | Path | None,
     *,
@@ -325,7 +535,6 @@ def recover_stale_in_place_capture(
     """Restore a Tencent-signed bundle from a previously recorded transaction."""
 
     wechat_app = normalize_wechat_app_path(wechat_install_path)
-    _terminate_native_capture_processes(debug_root)
     if not has_pending_in_place_capture(debug_root=debug_root):
         signature = inspect_wechat_signature(wechat_app)
         if not _is_tencent_official_signature(signature):
@@ -334,41 +543,51 @@ def recover_stale_in_place_capture(
                 "微信当前不是腾讯原签名，且没有可信恢复状态；为避免覆盖错误应用，已停止自动恢复。",
                 wechat_modified=True,
             )
+        _release_installation_lock(wechat_app, debug_root)
         return {
             "official_wechat_verified": True,
             "official_wechat_restored": False,
             "wechat_modified": False,
         }
 
-    state = _read_state(debug_root)
-    _validate_state_target(state, wechat_app)
-    backup_path = _safe_backup_from_state(state, backup_root)
-    expected_version = (str(state.get("version") or ""), str(state.get("build") or ""))
-    expected_cdhash = str(state.get("official_cdhash") or "").lower()
-    result = restore_official_wechat_if_needed(
-        wechat_app,
-        backup_path,
-        expected_version=expected_version,
-        expected_cdhash=expected_cdhash or None,
-    )
-    signature = inspect_wechat_signature(wechat_app)
-    if not _is_tencent_official_signature(signature):
-        raise MacOSDBKeyCaptureFailure(
-            "official_restore_verify_failed",
-            "自动恢复完成后仍无法验证腾讯原版微信签名，恢复状态已保留。",
-            wechat_modified=True,
+    _acquire_installation_lock(wechat_app, debug_root)
+    try:
+        state = _read_state(debug_root)
+        _validate_state_target(state, wechat_app)
+        backup_path = _safe_backup_from_state(state, backup_root)
+        expected_version = (str(state.get("version") or ""), str(state.get("build") or ""))
+        expected_cdhash = str(state.get("official_cdhash") or "").lower()
+        if not all(expected_version) or not expected_cdhash:
+            raise MacOSDBKeyCaptureFailure("in_place_capture_state_invalid", "恢复状态缺少原版构建身份，已保留并停止操作。")
+        _terminate_native_capture_processes(debug_root)
+        result = restore_official_wechat_if_needed(
+            wechat_app,
+            backup_path,
+            expected_version=expected_version,
+            expected_cdhash=expected_cdhash,
+            expected_debug_identity=state.get("debug_identity"),
         )
-    _remove_breakpoint_preflight(debug_root)
-    _remove_native_capture_ready(debug_root)
-    # Remove durable state last.  If the process dies after the atomic app
-    # exchange but before this unlink, the next startup observes an official
-    # installation, removes any displaced staging bundle, and finishes safely.
-    _remove_state(debug_root)
-    return {
-        **result,
-        "wechat_modified": False,
-        "backup_path": str(backup_path),
-    }
+        signature = inspect_wechat_signature(wechat_app)
+        if not _official_identity_matches(wechat_app, signature, expected_version, expected_cdhash):
+            raise MacOSDBKeyCaptureFailure(
+                "official_restore_verify_failed", "恢复后微信与本次原版构建身份不符；恢复状态已保留。", wechat_modified=True,
+            )
+        _remove_breakpoint_preflight(debug_root)
+        _remove_native_capture_ready(debug_root)
+        _remove_state(debug_root)
+        return {**result, "wechat_modified": False, "backup_path": str(backup_path)}
+    except MacOSDBKeyCaptureFailure as exc:
+        if exc.code == "external_install_conflict":
+            state["stage"] = "external_install_conflict"
+            state["recovery_error_code"] = exc.code
+            _write_state(debug_root, state)
+        elif exc.code in {"in_place_debug_identity_unknown", "official_restore_staging_conflict"}:
+            state["stage"] = "recovery_blocked"
+            state["recovery_error_code"] = exc.code
+            _write_state(debug_root, state)
+        raise
+    finally:
+        _release_installation_lock(wechat_app, debug_root)
 
 
 def _restore_after_terminal_path(
@@ -385,6 +604,10 @@ def _restore_after_terminal_path(
             debug_root=debug_root,
         )
     except Exception as restore_error:
+        if isinstance(restore_error, MacOSDBKeyCaptureFailure) and restore_error.code in {
+            "external_install_conflict", "in_place_debug_identity_unknown", "official_restore_staging_conflict", "in_place_capture_busy",
+        }:
+            raise
         if original_error is None:
             raise
         raise MacOSDBKeyCaptureFailure(
@@ -395,11 +618,13 @@ def _restore_after_terminal_path(
         ) from restore_error
 
 
+@_serialized_installation_operation
 def prepare_in_place_capture(
     wechat_install_path: str | Path | None,
     *,
     backup_root: Path,
     debug_root: Path = DEFAULT_DEBUG_ROOT,
+    defer_launch: bool = False,
 ) -> dict[str, Any]:
     """Verify backup, persist recovery state, re-sign in place, and launch."""
 
@@ -412,33 +637,56 @@ def prepare_in_place_capture(
             "临时重签仅允许作用于 /Applications/WeChat.app，请先使用微信默认安装路径。",
         )
 
-    # A killed prior run is recovered before a new mutation can begin.
-    if has_pending_in_place_capture(debug_root=debug_root):
-        recover_stale_in_place_capture(wechat_app, backup_root=backup_root, debug_root=debug_root)
-    else:
-        signature = inspect_wechat_signature(wechat_app)
-        if not _is_tencent_official_signature(signature):
-            raise MacOSDBKeyCaptureFailure(
-                "in_place_recovery_state_missing",
-                "微信当前不是腾讯原签名，且没有可信恢复状态；已停止临时重签。",
-                wechat_modified=True,
-            )
     debug_root = debug_root.expanduser()
     debug_root.mkdir(parents=True, exist_ok=True)
     os.chmod(debug_root, 0o700)
+    lease = _acquire_installation_lock(wechat_app, debug_root)
+    superseded = False
 
     def record_recovery_state(recovery: dict[str, Any]) -> None:
         _write_state(
             debug_root,
             {
                 "schema_version": STATE_SCHEMA_VERSION,
-                "stage": "backup_verified",
+                "stage": "debug_prepared" if recovery.get("debug_identity") else "backup_verified",
                 "created_at": int(time.time()),
+                "transaction_id": lease["transaction_id"],
+                "owner_session": _OWNER_SESSION,
+                "owner_pid": os.getpid(),
                 **recovery,
             },
         )
 
     try:
+        if has_pending_in_place_capture(debug_root=debug_root):
+            previous = _read_state(debug_root)
+            _validate_state_target(previous, wechat_app)
+            signature = inspect_wechat_signature(wechat_app)
+            previous_version = (str(previous.get("version") or ""), str(previous.get("build") or ""))
+            previous_cdhash = str(previous.get("official_cdhash") or "")
+            if (
+                not _transaction_is_active(wechat_app, previous)
+                and _is_tencent_official_signature(signature)
+                and (not all(previous_version) or not previous_cdhash or not _official_identity_matches(wechat_app, signature, previous_version, previous_cdhash))
+            ):
+                # A fresh explicit prepare after the old owner has ended may
+                # adopt the user's new official installation, never replace it.
+                _preserve_recovery_assets(wechat_app, debug_root, previous)
+                superseded = True
+            else:
+                recover_stale_in_place_capture(wechat_app, backup_root=backup_root, debug_root=debug_root)
+                lease = _acquire_installation_lock(wechat_app, debug_root)
+        signature = inspect_wechat_signature(wechat_app)
+        if not _is_tencent_official_signature(signature):
+            raise MacOSDBKeyCaptureFailure(
+                "in_place_recovery_state_missing", "微信当前不是腾讯原签名，且没有可确认的调试副本身份；已停止临时重签。", wechat_modified=True,
+            )
+        # Staging without state can survive a crash before the first swap.
+        # Preserve it before the low-level clone helper uses the fixed slot.
+        if os.path.lexists(_local_restore_staging_path(wechat_app)):
+            _preserve_recovery_assets(wechat_app, debug_root, {"schema_version": STATE_SCHEMA_VERSION, "wechat_app_path": str(wechat_app)})
+        with _INSTALLATION_LOCKS_MUTEX:
+            lease["transaction_id"] = uuid.uuid4().hex
         prepared = ensure_wechat_in_place_debuggable(
             wechat_app,
             backup_root,
@@ -447,18 +695,20 @@ def prepare_in_place_capture(
         state = _read_state(debug_root)
         state["stage"] = "resigned"
         _write_state(debug_root, state)
-        debug_pid = _launch_wechat(wechat_app)
-        state["stage"] = "launched"
+        # Desktop opt-in: keep the recovery transaction while the user decides
+        # whether to open the app. This neither grants trust nor changes policy.
+        debug_pid = None if defer_launch else _launch_wechat(wechat_app)
+        state["stage"] = "awaiting_manual_launch" if defer_launch else "launched"
         state["debug_pid"] = debug_pid
         _write_state(debug_root, state)
     except Exception as exc:
-        if has_pending_in_place_capture(debug_root=debug_root):
-            _restore_after_terminal_path(
-                wechat_app,
-                backup_root=backup_root,
-                debug_root=debug_root,
-                original_error=exc,
-            )
+        try:
+            if has_pending_in_place_capture(debug_root=debug_root):
+                _restore_after_terminal_path(
+                    wechat_app, backup_root=backup_root, debug_root=debug_root, original_error=exc,
+                )
+        finally:
+            _release_installation_lock(wechat_app, debug_root)
         raise
 
     return {
@@ -467,11 +717,52 @@ def prepare_in_place_capture(
         "debug_pid": debug_pid,
         "state_path": str(_state_path(debug_root)),
         "process_attached": False,
-        "ready_for_preflight": True,
+        "ready_for_preflight": not defer_launch,
+        "requires_manual_launch": defer_launch,
         "normal_wechat_running": False,
+        "previous_transaction_superseded": superseded,
+        "transaction_id": state["transaction_id"],
     }
 
 
+@_serialized_installation_operation
+def confirm_manual_in_place_launch(
+    wechat_install_path: str | Path | None,
+    *,
+    backup_root: Path,
+    transaction_id: str,
+    debug_root: Path = DEFAULT_DEBUG_ROOT,
+) -> dict[str, Any]:
+    """Check an explicitly user-started app, never launch or authorize it."""
+    app = normalize_wechat_app_path(wechat_install_path)
+    state = _read_state(debug_root)
+    _validate_state_target(state, app)
+    _safe_backup_from_state(state, backup_root)
+    if (state.get("stage") != "awaiting_manual_launch" or not transaction_id
+            or transaction_id != state.get("transaction_id")
+            or not _transaction_is_active(app, state)):
+        raise MacOSDBKeyCaptureFailure("in_place_capture_owner_changed", "等待启动的事务已变化，请先恢复微信。", wechat_modified=True)
+
+    def verify_identity() -> None:
+        if not _prepared_signature_is_valid(app) or not _debug_identity_matches(app, state.get("debug_identity")):
+            raise MacOSDBKeyCaptureFailure("in_place_debug_identity_unknown", "微信安装已变化，已停止检查并保留恢复资产。", wechat_modified=True)
+
+    verify_identity()
+    result = {"transaction_id": transaction_id, "ready_for_preflight": False, "requires_manual_launch": True}
+    pid = _find_wechat_main_pid(app)
+    if not pid:
+        return result
+    time.sleep(2)
+    if _find_wechat_main_pid(app) != pid:
+        return result
+    verify_identity()
+    state["debug_pid"] = pid
+    state["stage"] = "launched"
+    _write_state(debug_root, state)
+    return {**result, "ready_for_preflight": True, "requires_manual_launch": False}
+
+
+@_serialized_installation_operation
 def cleanup_in_place_capture(
     wechat_install_path: str | Path | None,
     *,
@@ -479,7 +770,6 @@ def cleanup_in_place_capture(
     debug_root: Path = DEFAULT_DEBUG_ROOT,
 ) -> dict[str, Any]:
     wechat_app = normalize_wechat_app_path(wechat_install_path)
-    _terminate_native_capture_processes(debug_root)
     if has_pending_in_place_capture(debug_root=debug_root):
         recovery = recover_stale_in_place_capture(
             wechat_app,
@@ -499,6 +789,7 @@ def cleanup_in_place_capture(
             "official_wechat_restored": False,
             "wechat_modified": False,
         }
+        _release_installation_lock(wechat_app, debug_root)
     return {
         "method": "macos_inplace_lldb_cancelled",
         "wechat_resigned": False,
@@ -517,12 +808,16 @@ def _require_prepared_process(
     state = _read_state(debug_root)
     _validate_state_target(state, wechat_app)
     _safe_backup_from_state(state, backup_root)
+    if not _transaction_is_active(wechat_app, state):
+        raise MacOSDBKeyCaptureFailure("in_place_capture_owner_changed", "捕获事务已结束或来自先前进程，请重新准备微信。", wechat_modified=True)
     if not _prepared_signature_is_valid(wechat_app):
         raise MacOSDBKeyCaptureFailure(
             "in_place_signature_changed",
-            "临时调试微信签名状态已变化，将先恢复腾讯原版后再重新开始。",
+            "微信安装签名状态已变化，已停止捕获并检查本次恢复条件。",
             wechat_modified=True,
         )
+    if not _debug_identity_matches(wechat_app, state.get("debug_identity")):
+        raise MacOSDBKeyCaptureFailure("in_place_debug_identity_unknown", "当前调试微信不是本次准备的同一副本，已停止捕获。", wechat_modified=True)
     saved_pid = int(state.get("debug_pid") or 0)
     current_pid = _find_wechat_main_pid(wechat_app)
     if saved_pid <= 0 or current_pid is None or saved_pid != current_pid:
@@ -572,6 +867,84 @@ def _candidate_bundle_pids(wechat_app: Path, main_pid: int) -> list[int]:
     )
 
 
+def _backend_identity(state: dict[str, Any]) -> dict[str, str]:
+    return {
+        field: str(state.get(field) or "")
+        for field in ("version", "build", "official_cdhash")
+    } | {"macos_version": platform.mac_ver()[0]}
+
+
+def _remember_software_backend(state: dict[str, Any], debug_root: Path) -> None:
+    """Remember compatibility for this exact official build, without key data."""
+    import uuid
+
+    root = debug_root.expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / "capture-backend-preference.json"
+    temporary = root / f".capture-backend-{uuid.uuid4().hex}.tmp"
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump({"backend": "lldb", "identity": _backend_identity(state)}, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _preferred_capture_backend(wechat_app: Path, state: dict[str, Any], debug_root: Path) -> str:
+    try:
+        if int(platform.mac_ver()[0].split(".")[0]) >= 27:
+            return "lldb"
+    except (ValueError, IndexError):
+        pass
+    try:
+        remembered = json.loads((debug_root.expanduser() / "capture-backend-preference.json").read_text(encoding="utf-8"))
+        if remembered.get("backend") == "lldb" and remembered.get("identity") == _backend_identity(state):
+            return "lldb"
+    except (OSError, ValueError, AttributeError):
+        pass
+    # Older Mac builds need not contain the native helper's expected dylib.
+    if not (wechat_app / "Contents/Resources/wechat.dylib").is_file():
+        return "lldb"
+    return "native"
+
+
+def _can_use_software_backend(error: MacOSDBKeyCaptureFailure) -> bool:
+    # Only failures before native debug-state mutation may reuse this PID.
+    # task_for_pid alone obtains a task port; image/stub inspection does not
+    # suspend threads, install breakpoints, or replace exception ports.
+    return error.code in {
+        "native_image_not_found", "native_wechat_dylib_missing", "native_pbkdf_stub_missing",
+        "native_text_vmaddr_missing", "native_vmmap_image_missing", "native_breakpoint_shape_mismatch",
+    }
+
+
+def _requires_fresh_software_transaction(error: MacOSDBKeyCaptureFailure) -> bool:
+    # These outcomes have no verified rollback receipt. Even a live, matching
+    # PID can still be suspended or retain native debug state after helper death.
+    return error.code in {
+        "native_breakpoint_install_failed", "native_exception_port_failed", "native_capture_helper_terminated",
+        "native_cleanup_failed",
+    } or (
+        error.code == "administrator_failed"
+        and any(marker in str(error).lower() for marker in ("(1009)", "sigkill", "由于收到信号"))
+    )
+
+
+def _preflight_backend(backend: str, pid: int, wechat_app: Path, debug_root: Path) -> dict[str, Any]:
+    if backend == "lldb":
+        from .macos_clone_capture import preflight_capture_breakpoints
+
+        result = preflight_capture_breakpoints(pid=pid, debug_root=debug_root, wechat_app=wechat_app)
+    else:
+        result = preflight_native_wcdb_capture(pid=pid, wechat_app=wechat_app, debug_root=debug_root)
+        result = {"pbkdf_locations": 1, "key_return_locations": 0, **result}
+    return {**result, "pid": pid, "capture_backend": backend, "ready_for_monitoring": True}
+
+
+@_serialized_installation_operation
 def preflight_prepared_in_place_capture(
     wechat_install_path: str | Path | None,
     *,
@@ -585,18 +958,28 @@ def preflight_prepared_in_place_capture(
             backup_root=backup_root,
             debug_root=debug_root,
         )
+        _remove_native_capture_ready(debug_root)
+        backend = _preferred_capture_backend(wechat_app, state, debug_root)
         result: dict[str, Any] | None = None
         last_error: MacOSDBKeyCaptureFailure | None = None
         for candidate_pid in _candidate_bundle_pids(wechat_app, debug_pid):
             try:
-                result = preflight_native_wcdb_capture(
-                    pid=candidate_pid,
-                    wechat_app=wechat_app,
-                    debug_root=debug_root,
-                )
+                result = _preflight_backend(backend, candidate_pid, wechat_app, debug_root)
                 break
             except MacOSDBKeyCaptureFailure as exc:
                 last_error = exc
+                if backend == "native" and _requires_fresh_software_transaction(exc):
+                    _remember_software_backend(state, debug_root)
+                    raise MacOSDBKeyCaptureFailure(
+                        exc.code,
+                        "原生预检未能确认调试状态已清理，本次操作将结束并恢复微信；"
+                        "已记录下次使用 LLDB。请重新开始新事务，勿继续登录当前临时微信。",
+                        process_attached=True,
+                    ) from exc
+                if backend == "native" and _can_use_software_backend(exc):
+                    result = _preflight_backend("lldb", candidate_pid, wechat_app, debug_root)
+                    _remember_software_backend(state, debug_root)
+                    break
                 if exc.code != "native_image_not_found":
                     raise
         if result is None:
@@ -607,7 +990,10 @@ def preflight_prepared_in_place_capture(
                 "临时微信进程中没有找到可用于原生预检的 wechat.dylib。",
                 process_attached=True,
             )
+        result["transaction_id"] = str(state.get("transaction_id") or "")
         _write_preflight_result(debug_root, result)
+        state["preflight"] = result
+        state["capture_backend"] = result["capture_backend"]
         state["stage"] = "preflight_passed"
         _write_state(debug_root, state)
     except Exception as exc:
@@ -621,7 +1007,7 @@ def preflight_prepared_in_place_capture(
         raise
     result.update(
         {
-            "method": "macos_inplace_native_preflight",
+            "method": "macos_inplace_" + result["capture_backend"] + "_preflight",
             "debug_app_path": str(wechat_app),
             "official_wechat_preserved": False,
             "wechat_modified": True,
@@ -631,6 +1017,7 @@ def preflight_prepared_in_place_capture(
     return result
 
 
+@_serialized_installation_operation
 def capture_prepared_in_place(
     wechat_install_path: str | Path | None,
     *,
@@ -640,6 +1027,8 @@ def capture_prepared_in_place(
     save_result: bool = True,
     debug_root: Path = DEFAULT_DEBUG_ROOT,
 ) -> dict[str, Any]:
+    from .macos_capture_validation import read_account_probe_pages, validate_account_candidate
+
     wechat_app = normalize_wechat_app_path(wechat_install_path)
     cache_path: Path | None = None
     probe_page1_path: Path | None = None
@@ -665,34 +1054,92 @@ def capture_prepared_in_place(
             ) from exc
         if len(probe_page1) < 4096 or probe_page1.startswith(b"SQLite format 3"):
             raise MacOSDBKeyCaptureFailure("probe_database_invalid", f"目标数据库不是有效的加密 WCDB: {probe_database}")
+        account_pages = read_account_probe_pages(probe_database)
         probe_page1_path = _write_probe_page1(debug_root, probe_page1)
 
         preflight_path = _breakpoint_preflight_path(debug_root)
         try:
             preflight = json.loads(preflight_path.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, ValueError):
-            preflight = {}
+            preflight = state.get("preflight") if isinstance(state.get("preflight"), dict) else {}
+        if not isinstance(preflight, dict) or not preflight:
+            raise MacOSDBKeyCaptureFailure("capture_preflight_required", "请先完成断点预检，再启动登录监测。")
+        transaction_id = str(state.get("transaction_id") or "")
+        if transaction_id and preflight.get("transaction_id") != transaction_id:
+            raise MacOSDBKeyCaptureFailure("capture_preflight_stale", "断点预检属于上一次操作，请重新开始本次获取。")
         preflight_pid = int(preflight.get("pid") or debug_pid)
         candidate_pids = _candidate_bundle_pids(wechat_app, debug_pid)
         if preflight_pid not in candidate_pids:
-            preflight_pid = candidate_pids[0] if candidate_pids else debug_pid
-
+            raise MacOSDBKeyCaptureFailure("capture_target_changed", "预检后的微信进程已更换，请重新开始并完成预检。")
+        backend = str(preflight.get("capture_backend") or state.get("capture_backend") or "native")
+        if backend not in {"native", "lldb"}:
+            raise MacOSDBKeyCaptureFailure("capture_backend_invalid", "预检记录的监测方案无效，请重新开始。")
+        state["stage"] = "capturing"
+        state["capture_phase"] = "waiting_authorization"
+        state["capture_backend"] = backend
+        state["preflight"] = preflight
+        _write_state(debug_root, state)
         ready_path = _prepare_native_capture_ready(debug_root)
-        capture = capture_native_wcdb_key(
-            pid=preflight_pid,
-            wechat_app=wechat_app,
-            probe_db_path=probe_database,
-            probe_page1_path=probe_page1_path,
-            ready_file=ready_path,
-            timeout=timeout,
-            debug_root=debug_root,
-        )
+
+        def run_software() -> dict[str, Any]:
+            details = capture_salt_matched_passphrase(
+                pid=preflight_pid,
+                expected_salts=[page[:16] for page in account_pages.values()],
+                probe_db_path=probe_database,
+                account_probe_pages=account_pages,
+                pbkdf_stub_plan=state["preflight"].get("pbkdf_stub_plan"),
+                return_details=True,
+                transaction_id=transaction_id,
+                ready_file=ready_path,
+                timeout=timeout,
+            )
+            return {**details, "db_key": details["passphrase"], "method": "macos_lldb_stub"}
+
+        if backend == "lldb":
+            capture = run_software()
+        else:
+            try:
+                capture = capture_native_wcdb_key(
+                    pid=preflight_pid, wechat_app=wechat_app, probe_db_path=probe_database,
+                    probe_page1_path=probe_page1_path, ready_file=ready_path,
+                    timeout=timeout, debug_root=debug_root, transaction_id=transaction_id,
+                )
+            except MacOSDBKeyCaptureFailure as native_error:
+                if _requires_fresh_software_transaction(native_error):
+                    _remember_software_backend(state, debug_root)
+                    raise MacOSDBKeyCaptureFailure(
+                        native_error.code,
+                        "原生捕获未能确认调试状态已清理，本次操作将结束并恢复微信；"
+                        "已记录下次使用 LLDB。请重新开始新事务，等待监测就绪后再登录。",
+                        process_attached=True,
+                    ) from native_error
+                if native_error.code == "native_capture_timeout":
+                    _remember_software_backend(state, debug_root)
+                    raise MacOSDBKeyCaptureFailure(
+                        native_error.code,
+                        f"{native_error}；已记录兼容方案，下次获取会改用 LLDB。请重新开始，等待监测就绪后再登录。",
+                        process_attached=True,
+                    ) from native_error
+                if not _can_use_software_backend(native_error):
+                    raise
+                _require_prepared_process(wechat_app, backup_root=backup_root, debug_root=debug_root)
+                _remove_native_capture_ready(debug_root)
+                result = _preflight_backend("lldb", preflight_pid, wechat_app, debug_root)
+                result["transaction_id"] = transaction_id
+                state["preflight"] = result
+                state["capture_backend"] = "lldb"
+                _write_state(debug_root, state)
+                _write_preflight_result(debug_root, result)
+                _remember_software_backend(state, debug_root)
+                ready_path = _prepare_native_capture_ready(debug_root)
+                capture = run_software()
         passphrase = str(capture.get("db_key") or "")
-        _validate_captured_passphrase(passphrase, probe_database)
-        if save_result:
-            cache_path = save_passphrase(passphrase)
+        _set_capture_phase(debug_root, state, "validating")
+        validation = validate_account_candidate(passphrase, account_pages)
+        _set_capture_phase(debug_root, state, "captured")
     except Exception as exc:
         if has_pending_in_place_capture(debug_root=debug_root):
+            _set_capture_phase(debug_root, state, "restoring")
             _restore_after_terminal_path(
                 wechat_app,
                 backup_root=backup_root,
@@ -701,11 +1148,14 @@ def capture_prepared_in_place(
             )
         raise
     else:
+        _set_capture_phase(debug_root, state, "restoring")
         recovery = _restore_after_terminal_path(
             wechat_app,
             backup_root=backup_root,
             debug_root=debug_root,
         )
+        if save_result:
+            cache_path = save_passphrase(passphrase)
     finally:
         _remove_native_capture_ready(debug_root)
         if probe_page1_path is not None:
@@ -718,6 +1168,11 @@ def capture_prepared_in_place(
         raise MacOSDBKeyCaptureFailure("passphrase_not_saved", "passphrase 未能安全保存")
     return {
         "method": str(capture.get("method") or "macos_native_mach"),
+        "key_mode": validation["key_mode"],
+        "account_roles_validated": True,
+        "validated_roles": validation["validated_roles"],
+        "validated": True,
+        "probe_db_path": str(probe_database),
         "db_key": passphrase,
         "cache_path": str(cache_path) if cache_path is not None else "",
         "wechat_modified": False,

--- a/src/wechat_decrypt_tool/macos_native_capture.py
+++ b/src/wechat_decrypt_tool/macos_native_capture.py
@@ -18,6 +18,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from .logging_config import get_logger
 from .macos_db_key_capture import (
     DEFAULT_DEBUG_ROOT,
     DEFAULT_WECHAT_APP,
@@ -37,6 +38,74 @@ _JSON_LIMIT = 128 * 1024
 _HELPER_TIMEOUT_PAD = 45
 _HELPER_NAME = "wcdb-native-capture"
 _HELPER_SOURCE = Path(__file__).resolve().parent / "native" / "macos" / "source" / "wcdb_native_capture.c"
+_TRANSACTION_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,128}\Z")
+_DIAGNOSTIC_COUNTERS = (
+    "pbkdf_calls", "wcdb_profile_hits", "rounds2_hits", "rounds256000_hits",
+    "salt_matches", "candidate_rejects", "salt_read_failures", "candidate_read_failures",
+)
+_DIAGNOSTIC_STAGES = frozenset({
+    "initializing", "read_page1", "attach", "resolve_breakpoint", "read_breakpoint",
+    "install_exception_port", "install_breakpoint", "write_ready", "waiting", "pbkdf_seen",
+    "profile_matched", "rounds2_seen", "rounds256000_seen", "salt_read_failed", "salt_mismatch",
+    "salt_matched", "candidate_read_failed", "candidate_rejected", "validated",
+})
+_NATIVE_FAILURE_MESSAGES = {
+    "native_capture_failed": "原生捕获器执行失败",
+    "native_invalid_arguments": "原生捕获器参数无效",
+    "native_attach_failed": "原生捕获器无法附加微信进程",
+    "native_image_not_found": "原生捕获器未找到微信原生模块",
+    "native_breakpoint_read_failed": "原生捕获器无法读取 PBKDF 断点指令",
+    "native_breakpoint_shape_mismatch": "微信 PBKDF 导入桩布局与原生捕获器不匹配",
+    "native_breakpoint_install_failed": "原生捕获器无法安装硬件断点",
+    "native_probe_database_unreadable": "原生捕获器无法读取数据库校验页",
+    "native_exception_port_failed": "原生捕获器无法安装断点异常端口",
+    "native_ready_signal_failed": "原生捕获器无法写入就绪信号",
+    "native_cleanup_failed": "原生捕获器无法确认调试状态已完整恢复，必须结束当前事务",
+    "native_capture_timeout": "原生捕获等待超时，未取得通过校验的账号密钥",
+    "native_capture_target_exited": "微信目标进程已退出，原生捕获提前结束",
+    "native_capture_interrupted": "原生捕获器收到终止信号，捕获已中断",
+    "native_capture_wait_failed": "原生捕获断点监听失败，捕获提前结束",
+    "native_capture_unvalidated": "原生捕获候选未通过数据库校验",
+}
+
+
+def _parse_capture_diagnostics(payload: dict[str, Any]) -> dict[str, Any]:
+    """Accept only bounded counters and fixed stages, never arbitrary helper data."""
+    raw = payload.get("diagnostics")
+    result: dict[str, Any] = {}
+    if not isinstance(raw, dict):
+        raw = {}
+    for name in _DIAGNOSTIC_COUNTERS:
+        value = raw.get(name)
+        if type(value) is int and 0 <= value <= (1 << 64) - 1:
+            result[name] = value
+    if "pbkdf_calls" not in result:
+        legacy_calls = payload.get("pbkdf_calls")
+        if type(legacy_calls) is int and 0 <= legacy_calls <= (1 << 64) - 1:
+            result["pbkdf_calls"] = legacy_calls
+    stage = raw.get("last_stage")
+    if isinstance(stage, str) and stage in _DIAGNOSTIC_STAGES:
+        result["last_stage"] = stage
+    return result
+
+
+def _diagnostic_failure_message(code: str, diagnostics: dict[str, Any]) -> str:
+    message = _NATIVE_FAILURE_MESSAGES[code]
+    if code == "native_capture_timeout":
+        if diagnostics.get("pbkdf_calls") == 0:
+            message += "；未命中 PBKDF 断点"
+        elif diagnostics.get("wcdb_profile_hits") == 0:
+            message += "；PBKDF 调用未匹配预期 WCDB 参数"
+        elif diagnostics.get("rounds256000_hits") == 0 and diagnostics.get("rounds2_hits", 0) > 0:
+            message += "；只命中 2 轮派生调用，不能将单库派生密钥作为账号密钥"
+        elif diagnostics.get("rounds256000_hits", 0) > 0 and diagnostics.get("salt_matches") == 0:
+            message += "；账号密钥派生调用未匹配校验库的盐"
+        elif diagnostics.get("candidate_rejects", 0) > 0:
+            message += "；候选账号密钥未通过校验"
+    if diagnostics:
+        summary = ", ".join(f"{name}={value}" for name, value in diagnostics.items())
+        message += f"（诊断：{summary}）"
+    return message
 
 
 def _resolve_wechat_dylib(wechat_app: Path) -> Path:
@@ -196,10 +265,13 @@ def _run_helper(
     probe_db_path: Path | None = None,
     probe_page1_path: Path | None = None,
     ready_file: Path | None = None,
+    transaction_id: str | None = None,
     timeout: int = 240,
 ) -> dict[str, Any]:
     if pid <= 0:
         raise MacOSDBKeyCaptureFailure("native_capture_invalid_pid", "微信调试进程 PID 无效")
+    if transaction_id and (not isinstance(transaction_id, str) or not _TRANSACTION_ID_RE.fullmatch(transaction_id)):
+        raise MacOSDBKeyCaptureFailure("native_capture_invalid_transaction", "原生捕获事务标识无效")
 
     helper_path = ensure_native_capture_helper(debug_root=debug_root)
     dylib = _resolve_wechat_dylib(wechat_app)
@@ -229,6 +301,8 @@ def _run_helper(
         command.extend(["--timeout", str(max(int(timeout), 30))])
     if ready_file is not None:
         command.extend(["--ready-file", str(ready_file.expanduser())])
+    if transaction_id:
+        command.extend(["--transaction-id", transaction_id])
 
     try:
         raw_output = _run_as_administrator(
@@ -238,7 +312,17 @@ def _run_helper(
     except MacOSDBKeyCaptureFailure as exc:
         embedded = _extract_embedded_json(str(exc))
         if embedded is None:
-            raise
+            # osascript can report the helper's termination without JSON.  Do
+            # not forward stderr: it may contain a partial secret-bearing result.
+            if exc.code == "administrator_cancelled":
+                raise MacOSDBKeyCaptureFailure("administrator_cancelled", "已取消管理员授权") from None
+            if exc.code == "administrator_timeout":
+                raise MacOSDBKeyCaptureFailure("administrator_timeout", "管理员授权或原生捕获等待超时") from None
+            if re.search(r"(?<!\d)1009(?!\d)|\bSIG(?:KILL|TERM|INT)\b|\bkilled(?::\s*9)?\b|\bterminated\b", str(exc), re.I):
+                raise MacOSDBKeyCaptureFailure(
+                    "native_capture_helper_terminated", "原生捕获器被系统终止，捕获提前结束",
+                ) from None
+            raise MacOSDBKeyCaptureFailure("administrator_failed", "管理员调用原生捕获器失败，未返回可解析结果") from None
         raw_output = embedded
     if not raw_output:
         raise MacOSDBKeyCaptureFailure("native_capture_empty", "原生捕获器没有返回结果")
@@ -251,24 +335,38 @@ def _run_helper(
     if not isinstance(payload, dict):
         raise MacOSDBKeyCaptureFailure("native_capture_invalid_payload", "原生捕获器返回结构无效")
 
+    diagnostics = _parse_capture_diagnostics(payload)
     status = str(payload.get("status") or "").strip().lower()
     if status != "ok":
-        code = str(payload.get("code") or "native_capture_failed").strip() or "native_capture_failed"
-        message = str(payload.get("message") or "原生捕获器执行失败").strip() or "原生捕获器执行失败"
+        raw_code = payload.get("code")
+        code = raw_code if isinstance(raw_code, str) and raw_code in _NATIVE_FAILURE_MESSAGES else "native_capture_failed"
+        get_logger(__name__).warning("native capture failed: code=%s diagnostics=%s", code, diagnostics)
+        message = _diagnostic_failure_message(code, diagnostics)
         raise MacOSDBKeyCaptureFailure(code, message, process_attached=True)
     if str(payload.get("mode") or "").strip().lower() != mode:
         raise MacOSDBKeyCaptureFailure("native_capture_mode_mismatch", "原生捕获器返回模式不匹配")
-    if int(payload.get("pid") or 0) != pid:
+    if type(payload.get("pid")) is not int or payload.get("pid") != pid:
         raise MacOSDBKeyCaptureFailure("native_capture_pid_mismatch", "原生捕获器返回的微信进程不匹配")
-    if int(payload.get("stub_file_address") or 0) != stub_address:
+    if type(payload.get("stub_file_address")) is not int or payload.get("stub_file_address") != stub_address:
         raise MacOSDBKeyCaptureFailure("native_capture_stub_mismatch", "原生捕获器返回的断点地址不匹配")
     if str(payload.get("method") or "") != "macos_native_mach":
         raise MacOSDBKeyCaptureFailure("native_capture_method_mismatch", "原生捕获器返回的方法标识无效")
-    return payload
+    # Success callers need the key, but must not inherit arbitrary helper fields
+    # that might later be copied into application state or diagnostics.
+    result = {name: payload[name] for name in ("status", "mode", "method", "pid", "stub_file_address")}
+    result["diagnostics"] = diagnostics
+    if "pbkdf_calls" in diagnostics:
+        result["pbkdf_calls"] = diagnostics["pbkdf_calls"]
+    if mode == "capture":
+        result["validated"] = payload.get("validated") is True
+        result["db_key"] = payload.get("db_key")
+    return result
 
 
 def _extract_embedded_json(message: str) -> str | None:
     raw = str(message or "").strip()
+    if len(raw) > _JSON_LIMIT:
+        return None
     start = raw.find("{")
     end = raw.rfind("}")
     if start < 0 or end <= start:
@@ -306,6 +404,7 @@ def capture_native_wcdb_key(
     probe_db_path: Path,
     probe_page1_path: Path | None = None,
     ready_file: Path | None = None,
+    transaction_id: str | None = None,
     timeout: int = 240,
     debug_root: Path = DEFAULT_DEBUG_ROOT,
 ) -> dict[str, Any]:
@@ -317,6 +416,7 @@ def capture_native_wcdb_key(
         probe_db_path=probe_db_path,
         probe_page1_path=probe_page1_path,
         ready_file=ready_file,
+        transaction_id=transaction_id,
         timeout=timeout,
     )
     if not bool(payload.get("validated")):

--- a/src/wechat_decrypt_tool/native/macos/source/wcdb_native_capture.c
+++ b/src/wechat_decrypt_tool/native/macos/source/wcdb_native_capture.c
@@ -43,6 +43,7 @@ typedef struct {
     char database_path[PATH_MAX];
     char page1_path[PATH_MAX];
     char ready_file[PATH_MAX];
+    char transaction_id[129];
     int timeout_seconds;
 } options_t;
 
@@ -60,17 +61,43 @@ typedef struct {
     thread_act_array_t debug_threads;
     mach_msg_type_number_t debug_thread_count;
     arm_debug_state64_t *saved_debug_states;
+    bool *saved_debug_valid;
+    bool *debug_state_modified;
     bool hw_breakpoints_installed;
+    bool cleanup_failed;
     uint8_t page1[PAGE_SIZE_BYTES];
     bool page1_loaded;
     bool captured;
     bool validated;
     char db_key_hex[65];
     uint64_t pbkdf_calls;
+    uint64_t wcdb_profile_hits;
+    uint64_t rounds2_hits;
+    uint64_t rounds256000_hits;
+    uint64_t salt_matches;
+    uint64_t candidate_rejects;
+    uint64_t salt_read_failures;
+    uint64_t candidate_read_failures;
+    const char *last_stage;
     volatile sig_atomic_t stop_requested;
 } capture_context_t;
 
 static capture_context_t g_ctx;
+
+/* Only fixed stage labels and counters belong in diagnostics; never key bytes,
+ * salts, addresses, page data, or arbitrary strings from the target process. */
+static void json_diagnostics(void) {
+    printf(
+        "\"diagnostics\":{\"pbkdf_calls\":%" PRIu64 ",\"wcdb_profile_hits\":%" PRIu64
+        ",\"rounds2_hits\":%" PRIu64 ",\"rounds256000_hits\":%" PRIu64
+        ",\"salt_matches\":%" PRIu64 ",\"candidate_rejects\":%" PRIu64
+        ",\"salt_read_failures\":%" PRIu64 ",\"candidate_read_failures\":%" PRIu64
+        ",\"last_stage\":\"%s\"}",
+        g_ctx.pbkdf_calls, g_ctx.wcdb_profile_hits, g_ctx.rounds2_hits, g_ctx.rounds256000_hits,
+        g_ctx.salt_matches, g_ctx.candidate_rejects, g_ctx.salt_read_failures,
+        g_ctx.candidate_read_failures, g_ctx.last_stage ? g_ctx.last_stage : "initializing"
+    );
+}
 
 static void json_success_preflight(const options_t *options) {
     printf(
@@ -86,21 +113,27 @@ static void json_success_capture(const options_t *options) {
     printf(
         "{\"status\":\"ok\",\"mode\":\"capture\",\"method\":\"macos_native_mach\","
         "\"pid\":%d,\"stub_file_address\":%" PRIu64 ",\"validated\":%s,"
-        "\"db_key\":\"%s\",\"pbkdf_calls\":%" PRIu64 "}\n",
+        "\"db_key\":\"%s\",\"pbkdf_calls\":%" PRIu64 ",",
         options->pid,
         options->stub_file_address,
         g_ctx.validated ? "true" : "false",
         g_ctx.db_key_hex,
         g_ctx.pbkdf_calls
     );
+    json_diagnostics();
+    printf("}\n");
 }
 
 static void json_error(const char *code, const char *message) {
     printf(
-        "{\"status\":\"error\",\"code\":\"%s\",\"message\":\"%s\"}\n",
+        "{\"status\":\"error\",\"code\":\"%s\",\"message\":\"%s\","
+        "\"method\":\"macos_native_mach\",\"pid\":%d,",
         code ? code : "native_capture_failed",
-        message ? message : "native capture failed"
+        message ? message : "native capture failed",
+        g_ctx.target_pid
     );
+    json_diagnostics();
+    printf("}\n");
 }
 
 static void on_signal(int signum) {
@@ -117,7 +150,7 @@ static void install_signal_handlers(void) {
     sigaction(SIGTERM, &action, NULL);
 }
 
-static bool write_ready_file(const char *path, pid_t pid) {
+static bool write_ready_file(const char *path, pid_t pid, const char *transaction_id) {
     if (!path || !*path) {
         return true;
     }
@@ -132,12 +165,15 @@ static bool write_ready_file(const char *path, pid_t pid) {
     if (descriptor < 0) {
         return false;
     }
-    char payload[128];
+    char payload[320];
     int length = snprintf(
         payload,
         sizeof(payload),
-        "{\"status\":\"ready\",\"method\":\"macos_native_mach\",\"pid\":%d}\n",
-        pid
+        "{\"status\":\"ready\",\"method\":\"macos_native_mach\",\"pid\":%d%s%s%s}\n",
+        pid,
+        transaction_id && *transaction_id ? ",\"transaction_id\":\"" : "",
+        transaction_id && *transaction_id ? transaction_id : "",
+        transaction_id && *transaction_id ? "\"" : ""
     );
     bool ok = length > 0 && (size_t)length < sizeof(payload)
         && write(descriptor, payload, (size_t)length) == length
@@ -178,6 +214,20 @@ static bool parse_int(const char *value, int *out) {
     return true;
 }
 
+static bool valid_transaction_id(const char *value) {
+    if (!value || !*value || strlen(value) > 128) {
+        return false;
+    }
+    /* This opaque correlation token is deliberately restricted for JSON. */
+    for (const char *cursor = value; *cursor; cursor++) {
+        if (!((*cursor >= 'a' && *cursor <= 'z') || (*cursor >= 'A' && *cursor <= 'Z') ||
+              (*cursor >= '0' && *cursor <= '9') || *cursor == '-' || *cursor == '_')) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool parse_args(int argc, char **argv, options_t *options) {
     if (!options) {
         return false;
@@ -209,6 +259,12 @@ static bool parse_args(int argc, char **argv, options_t *options) {
             strlcpy(options->page1_path, argv[++index], sizeof(options->page1_path));
         } else if (streq(arg, "--ready-file") && index + 1 < argc) {
             strlcpy(options->ready_file, argv[++index], sizeof(options->ready_file));
+        } else if (streq(arg, "--transaction-id") && index + 1 < argc) {
+            const char *value = argv[++index];
+            if (!valid_transaction_id(value)) {
+                return false;
+            }
+            strlcpy(options->transaction_id, value, sizeof(options->transaction_id));
         } else if (streq(arg, "--timeout") && index + 1 < argc) {
             if (!parse_int(argv[++index], &options->timeout_seconds)) {
                 return false;
@@ -325,14 +381,16 @@ static void bytes_to_hex(const uint8_t *bytes, size_t length, char *out_hex) {
     out_hex[length * 2] = '\0';
 }
 
-static bool breakpoint_operands_match(const arm_thread_state64_t *state) {
+static bool breakpoint_profile_matches(const arm_thread_state64_t *state) {
     uint64_t algorithm = state->__x[0];
     uint64_t password_len = state->__x[2];
     uint64_t salt_len = state->__x[4];
     uint64_t prf = state->__x[5];
-    uint64_t rounds = state->__x[6];
-    return algorithm == 2 && password_len == KEY_SIZE && salt_len == SALT_SIZE && prf == 5 &&
-           rounds == 256000;
+    return algorithm == 2 && password_len == KEY_SIZE && salt_len == SALT_SIZE && prf == 5;
+}
+
+static bool breakpoint_operands_match(const arm_thread_state64_t *state) {
+    return breakpoint_profile_matches(state) && state->__x[6] == 256000;
 }
 
 static bool salt_matches_expected(uint64_t rounds, const uint8_t *salt) {
@@ -487,6 +545,10 @@ static void release_debug_threads(void) {
     }
     free(g_ctx.saved_debug_states);
     g_ctx.saved_debug_states = NULL;
+    free(g_ctx.saved_debug_valid);
+    g_ctx.saved_debug_valid = NULL;
+    free(g_ctx.debug_state_modified);
+    g_ctx.debug_state_modified = NULL;
     g_ctx.debug_thread_count = 0;
     g_ctx.hw_breakpoints_installed = false;
 }
@@ -499,7 +561,7 @@ static kern_return_t restore_hardware_breakpoints(void) {
     kern_return_t first_error = KERN_SUCCESS;
     for (mach_msg_type_number_t index = 0; index < g_ctx.debug_thread_count; index++) {
         thread_t thread = g_ctx.debug_threads[index];
-        if (thread == MACH_PORT_NULL) {
+        if (thread == MACH_PORT_NULL || !g_ctx.saved_debug_valid[index] || !g_ctx.debug_state_modified[index]) {
             continue;
         }
         kern_return_t kr = thread_set_state(
@@ -516,6 +578,9 @@ static kern_return_t restore_hardware_breakpoints(void) {
         ) {
             first_error = kr;
         }
+    }
+    if (first_error != KERN_SUCCESS) {
+        g_ctx.cleanup_failed = true;
     }
     release_debug_threads();
     return first_error;
@@ -536,7 +601,12 @@ static kern_return_t install_hardware_breakpoints(task_t task) {
     }
 
     arm_debug_state64_t *saved_states = calloc(thread_count, sizeof(*saved_states));
-    if (!saved_states) {
+    bool *saved_valid = calloc(thread_count, sizeof(*saved_valid));
+    bool *modified = calloc(thread_count, sizeof(*modified));
+    if (!saved_states || !saved_valid || !modified) {
+        free(saved_states);
+        free(saved_valid);
+        free(modified);
         for (mach_msg_type_number_t index = 0; index < thread_count; index++) {
             if (threads[index] != MACH_PORT_NULL) {
                 (void)mach_port_deallocate(mach_task_self(), threads[index]);
@@ -553,6 +623,8 @@ static kern_return_t install_hardware_breakpoints(task_t task) {
     g_ctx.debug_threads = threads;
     g_ctx.debug_thread_count = thread_count;
     g_ctx.saved_debug_states = saved_states;
+    g_ctx.saved_debug_valid = saved_valid;
+    g_ctx.debug_state_modified = modified;
 
     const uint64_t control = HW_BREAKPOINT_CONTROL_EXEC_4BYTES;
     const uint64_t address = ((uint64_t)g_ctx.breakpoint_address) & ~0x3ull;
@@ -574,6 +646,7 @@ static kern_return_t install_hardware_breakpoints(task_t task) {
             return kr;
         }
         saved_states[index] = debug_state;
+        saved_valid[index] = true;
 
         bool installed = false;
         for (size_t slot = 0; slot < MAX_HW_BREAKPOINTS; slot++) {
@@ -597,6 +670,7 @@ static kern_return_t install_hardware_breakpoints(task_t task) {
             (void)restore_hardware_breakpoints();
             return kr;
         }
+        modified[index] = true;
     }
 
     g_ctx.hw_breakpoints_installed = true;
@@ -663,9 +737,15 @@ static kern_return_t refresh_hardware_breakpoints_if_needed(void) {
     if (kr != KERN_SUCCESS) {
         return kr;
     }
-    (void)restore_hardware_breakpoints();
-    kr = install_hardware_breakpoints(g_ctx.task);
-    (void)task_resume(g_ctx.task);
+    kr = restore_hardware_breakpoints();
+    if (kr == KERN_SUCCESS) {
+        kr = install_hardware_breakpoints(g_ctx.task);
+    }
+    kern_return_t resume_kr = task_resume(g_ctx.task);
+    if (resume_kr != KERN_SUCCESS) {
+        g_ctx.cleanup_failed = true;
+        return resume_kr;
+    }
     return kr;
 }
 
@@ -714,7 +794,10 @@ static void restore_exception_ports(task_t task) {
         if (g_ctx.masks[index] == 0) {
             continue;
         }
-        (void)task_set_exception_ports(task, g_ctx.masks[index], g_ctx.old_ports[index], g_ctx.old_behaviors[index], g_ctx.old_flavors[index]);
+        kern_return_t kr = task_set_exception_ports(task, g_ctx.masks[index], g_ctx.old_ports[index], g_ctx.old_behaviors[index], g_ctx.old_flavors[index]);
+        if (kr != KERN_SUCCESS && kr != KERN_TERMINATED && kr != MACH_SEND_INVALID_DEST) {
+            g_ctx.cleanup_failed = true;
+        }
     }
     if (g_ctx.exception_port != MACH_PORT_NULL) {
         mach_port_mod_refs(mach_task_self(), g_ctx.exception_port, MACH_PORT_RIGHT_RECEIVE, -1);
@@ -750,6 +833,19 @@ static kern_return_t handle_breakpoint(thread_t thread) {
     }
 
     g_ctx.pbkdf_calls += 1;
+    g_ctx.last_stage = "pbkdf_seen";
+    if (breakpoint_profile_matches(&state)) {
+        g_ctx.wcdb_profile_hits += 1;
+        g_ctx.last_stage = "profile_matched";
+        if (state.__x[6] == 2) {
+            /* Count this call without reading/accepting its per-database raw key. */
+            g_ctx.rounds2_hits += 1;
+            g_ctx.last_stage = "rounds2_seen";
+        } else if (state.__x[6] == 256000) {
+            g_ctx.rounds256000_hits += 1;
+            g_ctx.last_stage = "rounds256000_seen";
+        }
+    }
     if (!breakpoint_operands_match(&state) || !g_ctx.page1_loaded) {
         return continue_thread_at_x16(thread);
     }
@@ -758,19 +854,27 @@ static kern_return_t handle_breakpoint(thread_t thread) {
     uint8_t candidate[KEY_SIZE];
     kr = remote_read_exact(g_ctx.task, (mach_vm_address_t)state.__x[3], salt, sizeof(salt));
     if (kr != KERN_SUCCESS) {
+        g_ctx.salt_read_failures += 1;
+        g_ctx.last_stage = "salt_read_failed";
         return continue_thread_at_x16(thread);
     }
     if (!salt_matches_expected(state.__x[6], salt)) {
+        g_ctx.last_stage = "salt_mismatch";
         return continue_thread_at_x16(thread);
     }
+    g_ctx.salt_matches += 1;
+    g_ctx.last_stage = "salt_matched";
     kr = remote_read_exact(g_ctx.task, (mach_vm_address_t)state.__x[1], candidate, sizeof(candidate));
     if (kr != KERN_SUCCESS) {
+        g_ctx.candidate_read_failures += 1;
+        g_ctx.last_stage = "candidate_read_failed";
         return continue_thread_at_x16(thread);
     }
     if (candidate_matches_page1(candidate)) {
         bytes_to_hex(candidate, KEY_SIZE, g_ctx.db_key_hex);
         g_ctx.captured = true;
         g_ctx.validated = true;
+        g_ctx.last_stage = "validated";
         g_ctx.stop_requested = 1;
         /*
          * The candidate has already passed the encrypted page-1 HMAC check.
@@ -788,6 +892,8 @@ static kern_return_t handle_breakpoint(thread_t thread) {
         }
         return KERN_SUCCESS;
     }
+    g_ctx.candidate_rejects += 1;
+    g_ctx.last_stage = "candidate_rejected";
     return continue_thread_at_x16(thread);
 }
 
@@ -875,6 +981,13 @@ static kern_return_t wait_for_breakpoint(int timeout_seconds) {
     while (!g_ctx.stop_requested) {
         struct timeval now;
         gettimeofday(&now, NULL);
+        /* A dead task/PID is a terminal result, not another login timeout. */
+        mach_port_type_t port_type = 0;
+        kern_return_t port_kr = mach_port_type(mach_task_self(), g_ctx.task, &port_type);
+        if ((port_kr == KERN_SUCCESS && (port_type & MACH_PORT_TYPE_DEAD_NAME) != 0) ||
+            (g_ctx.target_pid > 0 && kill(g_ctx.target_pid, 0) < 0 && errno == ESRCH)) {
+            return KERN_TERMINATED;
+        }
         if ((now.tv_sec - start.tv_sec) >= timeout_seconds) {
             return KERN_OPERATION_TIMED_OUT;
         }
@@ -921,17 +1034,21 @@ static kern_return_t wait_for_breakpoint(int timeout_seconds) {
 
 static int run_preflight(const options_t *options) {
     memset(&g_ctx, 0, sizeof(g_ctx));
+    g_ctx.target_pid = options->pid;
+    g_ctx.last_stage = "attach";
     kern_return_t kr = attach_task(options->pid, &g_ctx.task);
     if (kr != KERN_SUCCESS) {
         json_error("native_attach_failed", "task_for_pid failed");
         return 1;
     }
+    g_ctx.last_stage = "resolve_breakpoint";
     kr = resolve_breakpoint_address(g_ctx.task, options, &g_ctx.breakpoint_address);
     if (kr != KERN_SUCCESS) {
         json_error("native_image_not_found", "wechat.dylib not found in target task");
         return 1;
     }
     uint32_t instruction = 0;
+    g_ctx.last_stage = "read_breakpoint";
     kr = read_instruction(g_ctx.task, g_ctx.breakpoint_address, &instruction);
     if (kr != KERN_SUCCESS) {
         json_error("native_breakpoint_read_failed", "cannot read PBKDF stub instruction");
@@ -941,12 +1058,19 @@ static int run_preflight(const options_t *options) {
         json_error("native_breakpoint_shape_mismatch", "PBKDF stub layout changed");
         return 1;
     }
-    task_suspend(g_ctx.task);
-    kr = install_hardware_breakpoints(g_ctx.task);
-    if (kr == KERN_SUCCESS) {
-        (void)restore_hardware_breakpoints();
+    g_ctx.last_stage = "install_breakpoint";
+    kr = task_suspend(g_ctx.task);
+    if (kr != KERN_SUCCESS) {
+        json_error("native_cleanup_failed", "cannot safely suspend target for preflight");
+        return 1;
     }
-    task_resume(g_ctx.task);
+    kr = install_hardware_breakpoints(g_ctx.task);
+    kern_return_t restore_kr = restore_hardware_breakpoints();
+    kern_return_t resume_kr = task_resume(g_ctx.task);
+    if (g_ctx.cleanup_failed || restore_kr != KERN_SUCCESS || resume_kr != KERN_SUCCESS) {
+        json_error("native_cleanup_failed", "preflight debug state cleanup failed");
+        return 1;
+    }
     if (kr != KERN_SUCCESS) {
         json_error("native_breakpoint_install_failed", "cannot install hardware breakpoint");
         return 1;
@@ -959,6 +1083,7 @@ static int run_capture(const options_t *options) {
     memset(&g_ctx, 0, sizeof(g_ctx));
     g_ctx.target_pid = options->pid;
     install_signal_handlers();
+    g_ctx.last_stage = "read_page1";
     const char *page1_source = options->page1_path[0] ? options->page1_path : options->database_path;
     if (!read_page1(page1_source, g_ctx.page1)) {
         json_error("native_probe_database_unreadable", "cannot read encrypted page1");
@@ -966,16 +1091,19 @@ static int run_capture(const options_t *options) {
     }
     g_ctx.page1_loaded = true;
 
+    g_ctx.last_stage = "attach";
     kern_return_t kr = attach_task(options->pid, &g_ctx.task);
     if (kr != KERN_SUCCESS) {
         json_error("native_attach_failed", "task_for_pid failed");
         return 1;
     }
+    g_ctx.last_stage = "resolve_breakpoint";
     kr = resolve_breakpoint_address(g_ctx.task, options, &g_ctx.breakpoint_address);
     if (kr != KERN_SUCCESS) {
         json_error("native_image_not_found", "wechat.dylib not found in target task");
         return 1;
     }
+    g_ctx.last_stage = "read_breakpoint";
     kr = read_instruction(g_ctx.task, g_ctx.breakpoint_address, &g_ctx.original_instruction);
     if (kr != KERN_SUCCESS) {
         json_error("native_breakpoint_read_failed", "cannot read PBKDF stub instruction");
@@ -985,29 +1113,53 @@ static int run_capture(const options_t *options) {
         json_error("native_breakpoint_shape_mismatch", "PBKDF stub layout changed");
         return 1;
     }
+    g_ctx.last_stage = "install_exception_port";
     kr = install_exception_port(g_ctx.task);
     if (kr != KERN_SUCCESS) {
         json_error("native_exception_port_failed", "cannot install breakpoint exception port");
         return 1;
     }
 
-    task_suspend(g_ctx.task);
-    kr = install_hardware_breakpoints(g_ctx.task);
-    task_resume(g_ctx.task);
+    g_ctx.last_stage = "install_breakpoint";
+    kr = task_suspend(g_ctx.task);
     if (kr != KERN_SUCCESS) {
         restore_exception_ports(g_ctx.task);
+        json_error("native_cleanup_failed", "cannot safely suspend target for capture");
+        return 1;
+    }
+    kr = install_hardware_breakpoints(g_ctx.task);
+    kern_return_t resume_kr = task_resume(g_ctx.task);
+    if (kr != KERN_SUCCESS || resume_kr != KERN_SUCCESS) {
+        (void)restore_hardware_breakpoints();
+        restore_exception_ports(g_ctx.task);
+        if (g_ctx.cleanup_failed || resume_kr != KERN_SUCCESS) {
+            json_error("native_cleanup_failed", "capture startup debug state cleanup failed");
+            return 1;
+        }
         json_error("native_breakpoint_install_failed", "cannot install hardware breakpoint");
         return 1;
     }
-    if (!write_ready_file(options->ready_file, options->pid)) {
-        task_suspend(g_ctx.task);
+    g_ctx.last_stage = "write_ready";
+    if (!write_ready_file(options->ready_file, options->pid, options->transaction_id)) {
+        kern_return_t suspend_kr = task_suspend(g_ctx.task);
         (void)restore_hardware_breakpoints();
         restore_exception_ports(g_ctx.task);
-        (void)task_resume(g_ctx.task);
+        if (suspend_kr == KERN_SUCCESS) {
+            if (task_resume(g_ctx.task) != KERN_SUCCESS) {
+                g_ctx.cleanup_failed = true;
+            }
+        } else {
+            g_ctx.cleanup_failed = true;
+        }
+        if (g_ctx.cleanup_failed) {
+            json_error("native_cleanup_failed", "readiness failure debug state cleanup failed");
+            return 1;
+        }
         json_error("native_ready_signal_failed", "cannot write monitor readiness signal");
         return 1;
     }
 
+    g_ctx.last_stage = "waiting";
     kr = wait_for_breakpoint(options->timeout_seconds);
 
     if (g_ctx.captured) {
@@ -1019,15 +1171,37 @@ static int run_capture(const options_t *options) {
         (void)restore_hardware_breakpoints();
         restore_exception_ports(g_ctx.task);
         if (suspend_kr == KERN_SUCCESS) {
-            (void)task_resume(g_ctx.task);
+            if (task_resume(g_ctx.task) != KERN_SUCCESS) {
+                g_ctx.cleanup_failed = true;
+            }
+        } else if (suspend_kr != KERN_TERMINATED && suspend_kr != MACH_SEND_INVALID_DEST) {
+            g_ctx.cleanup_failed = true;
         }
     }
 
+    if (kr == KERN_TERMINATED || kr == MACH_SEND_INVALID_DEST) {
+        json_error("native_capture_target_exited", "target process exited before capture completed");
+        return 1;
+    }
+    if (g_ctx.cleanup_failed && !g_ctx.captured) {
+        json_error("native_cleanup_failed", "capture debug state cleanup failed");
+        return 1;
+    }
+    /* Signals can interrupt mach_msg with MACH_RCV_INTERRUPTED instead of
+     * taking the ordinary loop exit; keep both paths explicitly classified. */
+    if (g_ctx.stop_requested && !g_ctx.captured) {
+        json_error("native_capture_interrupted", "capture helper was interrupted");
+        return 1;
+    }
     if (kr == KERN_OPERATION_TIMED_OUT) {
         json_error("native_capture_timeout", "timed out waiting for login-triggered PBKDF");
         return 1;
     }
-    if (kr != KERN_SUCCESS || !g_ctx.validated) {
+    if (kr != KERN_SUCCESS) {
+        json_error("native_capture_wait_failed", "breakpoint monitor failed");
+        return 1;
+    }
+    if (!g_ctx.validated) {
         json_error("native_capture_unvalidated", "captured candidate did not validate against page1");
         return 1;
     }

--- a/src/wechat_decrypt_tool/routers/keys.py
+++ b/src/wechat_decrypt_tool/routers/keys.py
@@ -640,7 +640,7 @@ async def get_macos_key_capture_status(request: Request):
             "errmsg": "实验性本机密钥捕获仅支持 macOS。",
             "data": {"platform": current_platform(), "error_code": "UNSUPPORTED_PLATFORM"},
         }
-    persisted = get_in_place_capture_status()
+    persisted = await asyncio.to_thread(get_in_place_capture_status)
     return {
         "status": 0,
         "errmsg": "ok",
@@ -718,6 +718,8 @@ async def preflight_macos_key_capture(request: Request, payload: MacosKeyCapture
             "data": {
                 "method": "macos_inplace_native",
                 "stage": "preflight_passed",
+                "transaction_id": str(result.get("transaction_id") or ""),
+                "capture_backend": result.get("capture_backend") if result.get("capture_backend") in {"native", "lldb"} else None,
                 "wechat_modified": bool(result.get("wechat_modified", True)),
                 "process_attached": bool(result.get("process_attached", False)),
             },

--- a/tests/macos-capture-progress.test.mjs
+++ b/tests/macos-capture-progress.test.mjs
@@ -1,0 +1,170 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import * as captureProgress from '../frontend/lib/macos-capture-progress.js'
+
+const { followMacosCapture } = captureProgress
+
+test('readiness from a previous transaction never enables login', async () => {
+  let finish
+  let polls = 0
+  const progress = []
+  const result = await followMacosCapture({
+    start: () => new Promise(resolve => { finish = resolve }),
+    transactionId: 'current',
+    isActive: () => true,
+    wait: () => new Promise(resolve => setImmediate(resolve)),
+    getStatus: async () => {
+      polls++
+      if (polls === 1) return { transaction_id: 'previous', monitor_ready: true }
+      if (polls === 2) return { transaction_id: 'current', monitor_ready: false }
+      if (polls === 3) return { transaction_id: 'current', monitor_ready: true }
+      finish({ status: 0 })
+      return { transaction_id: 'previous', monitor_ready: true }
+    },
+    onProgress: ready => progress.push(ready)
+  })
+  assert.deepEqual(progress, [false, true])
+  assert.equal(result.status, 0)
+})
+
+test('capture rejection stops status polling and is propagated', async () => {
+  let polls = 0
+  await assert.rejects(followMacosCapture({
+    start: async () => { throw new Error('fixture cancelled') },
+    transactionId: 'current',
+    isActive: () => true,
+    getStatus: async () => { polls++; return {} },
+    onProgress: () => assert.fail('must not report ready'),
+    wait: () => new Promise(resolve => setImmediate(resolve))
+  }), /fixture cancelled/)
+  assert.equal(polls, 0)
+})
+
+test('completion aborts an in-flight status request', async () => {
+  let finish
+  let aborted = false
+  const result = await followMacosCapture({
+    start: () => new Promise(resolve => { finish = resolve }),
+    transactionId: 'current',
+    isActive: () => true,
+    wait: () => new Promise(resolve => setImmediate(resolve)),
+    getStatus: ({ signal }) => new Promise((_, reject) => {
+      signal.addEventListener('abort', () => { aborted = true; reject(new Error('aborted')) })
+      finish('done')
+    }),
+    onProgress: () => assert.fail('capture is finished')
+  })
+  assert.equal(result, 'done')
+  assert.equal(aborted, true)
+})
+
+test('progress forwards only whitelisted phases with the compatible readiness boolean', async () => {
+  let finish
+  let index = 0
+  const phases = ['waiting_authorization', 'monitoring', 'captured', 'validating', 'restoring', null, undefined, 'complete', {}, true]
+  const progress = []
+  await followMacosCapture({
+    start: () => new Promise(resolve => { finish = resolve }),
+    transactionId: 'current',
+    isActive: () => true,
+    wait: () => new Promise(resolve => setImmediate(resolve)),
+    getStatus: async () => {
+      if (index === phases.length) finish('done')
+      return { transaction_id: 'current', monitor_ready: index === 1, capture_phase: phases[index++] }
+    },
+    onProgress: (ready, phase) => progress.push([ready, phase])
+  })
+  assert.deepEqual(progress, phases.map((phase, index) => [index === 1, index < 5 ? phase : null]))
+})
+
+test('post-capture progress remains bound to the active transaction', async () => {
+  let finish
+  let polls = 0
+  const progress = []
+  await followMacosCapture({
+    start: () => new Promise(resolve => { finish = resolve }),
+    transactionId: 'current',
+    isActive: () => true,
+    wait: () => new Promise(resolve => setImmediate(resolve)),
+    getStatus: async () => {
+      polls++
+      if (polls === 1) return { transaction_id: 'previous', monitor_ready: false, capture_phase: 'restoring' }
+      if (polls === 2) return { transaction_id: 'current', monitor_ready: false, capture_phase: 'captured' }
+      finish('done')
+      return { transaction_id: 'current', monitor_ready: false, capture_phase: 'validating' }
+    },
+    onProgress: (ready, phase) => progress.push([ready, phase])
+  })
+  assert.deepEqual(progress, [[false, 'captured']])
+})
+
+test('an inactive request cannot publish an in-flight progress response', async () => {
+  let finish
+  let active = true
+  const progress = []
+  const result = await followMacosCapture({
+    start: () => new Promise(resolve => { finish = resolve }),
+    transactionId: 'current',
+    isActive: () => active,
+    wait: () => new Promise(resolve => setImmediate(resolve)),
+    getStatus: async () => {
+      active = false
+      setImmediate(() => finish('cancelled'))
+      return { transaction_id: 'current', monitor_ready: false, capture_phase: 'restoring' }
+    },
+    onProgress: (...values) => progress.push(values)
+  })
+  assert.equal(result, 'cancelled')
+  assert.deepEqual(progress, [])
+})
+
+test('restoring is progress only and never replaces the completed request result', async () => {
+  let finish
+  let polls = 0
+  const expected = { status: 1, errmsg: 'fixture restore conflict' }
+  const progress = []
+  const result = await followMacosCapture({
+    start: () => new Promise(resolve => { finish = resolve }),
+    transactionId: 'current',
+    isActive: () => true,
+    wait: () => new Promise(resolve => setImmediate(resolve)),
+    getStatus: async () => {
+      if (++polls === 2) finish(expected)
+      return { transaction_id: 'current', monitor_ready: false, capture_phase: 'restoring' }
+    },
+    onProgress: (ready, phase) => progress.push([ready, phase])
+  })
+  assert.deepEqual(progress, [[false, 'restoring']])
+  assert.equal(result, expected)
+})
+
+test('post-capture messages never invite another login or report completion', () => {
+  for (const phase of ['captured', 'validating', 'restoring']) {
+    for (const ready of [false, true]) {
+      const message = captureProgress.macosCaptureProgressMessage(ready, phase)
+      assert.doesNotMatch(message, /可以重新登录|完成管理员授权|获取成功|已恢复/)
+      assert.match(message, /请勿再次登录/)
+      assert.match(message, /临时微信.*关闭|关闭临时微信/)
+      assert.match(message, /恢复腾讯原签名微信/)
+    }
+  }
+  assert.match(captureProgress.macosCaptureProgressMessage(false, 'captured'), /已捕获密钥并通过消息库与会话库校验，正在完成后续复核/)
+  assert.match(captureProgress.macosCaptureProgressMessage(false, 'validating'), /消息库与会话库校验/)
+  assert.match(captureProgress.macosCaptureProgressMessage(false, 'restoring'), /恢复尚未完成/)
+})
+
+test('login guidance still requires monitor readiness and respects authorization phase', () => {
+  assert.match(captureProgress.macosCaptureProgressMessage(true, 'monitoring'), /可以重新登录/)
+  assert.match(captureProgress.macosCaptureProgressMessage(true, null), /可以重新登录/)
+  assert.doesNotMatch(captureProgress.macosCaptureProgressMessage(false, 'monitoring'), /可以重新登录/)
+  assert.doesNotMatch(captureProgress.macosCaptureProgressMessage(true, 'waiting_authorization'), /可以重新登录/)
+  assert.match(captureProgress.macosCaptureProgressMessage(false, null), /完成管理员授权/)
+})
+
+test('decrypt page uses phase-aware messages and announces the temporary window closing', () => {
+  const page = readFileSync(new URL('../frontend/pages/decrypt.vue', import.meta.url), 'utf8')
+  assert.ok(/onProgress: \(ready, phase\) =>/.test(page), 'page must receive the transaction phase')
+  assert.ok(/warning\.value = macosCaptureProgressMessage\(ready, phase\)/.test(page), 'page must use phase-aware messages')
+  assert.ok(/捕获后临时微信窗口会关闭/.test(page), 'guide must announce temporary window closing')
+})

--- a/tests/test_macos_capture_api_progress.py
+++ b/tests/test_macos_capture_api_progress.py
@@ -1,0 +1,165 @@
+"""Public HTTP regressions: synthetic state, no WeChat process or real keys."""
+import asyncio
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from wechat_decrypt_tool import macos_inplace_capture, wechat_decrypt
+from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
+from wechat_decrypt_tool.routers import keys
+
+
+def local_request():
+    return SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+
+
+@pytest.fixture(autouse=True)
+def isolated_routes(monkeypatch):
+    monkeypatch.setattr(keys, "is_macos", lambda: True)
+    monkeypatch.setattr(keys, "_macos_capture_active_operation", "")
+
+
+def test_status_remains_readable_while_capture_waits(monkeypatch):
+    release, entered = threading.Event(), threading.Event()
+    event_loop_thread = threading.get_ident()
+
+    def capture(*args, **kwargs):
+        assert threading.get_ident() != event_loop_thread
+        assert kwargs["save_result"] is False
+        entered.set()
+        assert release.wait(3), "test never released simulated capture"
+        return {"db_key": "ab" * 32, "official_wechat_verified": True}
+
+    def status():
+        assert threading.get_ident() != event_loop_thread
+        return {"transaction_id": "current-test", "monitor_ready": True}
+
+    monkeypatch.setattr(keys, "capture_prepared_macos_passphrase", capture)
+    monkeypatch.setattr(keys, "_resolve_v4_probe_db_file", lambda path: Path("/tmp/fixture/message_0.db"))
+    monkeypatch.setattr(keys, "get_in_place_capture_status", status)
+    monkeypatch.setattr(keys, "save_passphrase", Mock())
+    monkeypatch.setattr(wechat_decrypt, "validate_realtime_database_key", lambda *args: {"valid": True})
+
+    async def exercise():
+        task = asyncio.create_task(keys.capture_macos_key(local_request(), keys.MacosKeyCaptureRequest()))
+        try:
+            for _ in range(100):
+                if entered.is_set():
+                    break
+                await asyncio.sleep(0.005)
+            assert entered.is_set()
+            result = await asyncio.wait_for(keys.get_macos_key_capture_status(local_request()), 0.2)
+            assert result["data"]["transaction_id"] == "current-test"
+            assert result["data"]["active_operation"] == "capture"
+            assert not task.done()
+        finally:
+            release.set()
+            result = await asyncio.wait_for(task, 3)
+        assert result["status"] == 0
+
+    asyncio.run(exercise())
+
+
+def test_status_never_returns_key_or_local_paths(monkeypatch):
+    state = {
+        "stage": "capturing", "transaction_id": "test-tx", "capture_backend": "lldb",
+        "db_key": "ab" * 32, "probe_db_path": "/private/account/message.db",
+        "backup_path": "/private/backup", "debug_pid": 4321,
+        "recovery_error_code": "ab" * 32,
+    }
+    monkeypatch.setattr(macos_inplace_capture, "has_pending_in_place_capture", lambda **kw: True)
+    monkeypatch.setattr(macos_inplace_capture, "_read_state", lambda root: state)
+    monkeypatch.setattr(macos_inplace_capture, "native_capture_monitor_ready", lambda **kw: True)
+    result = asyncio.run(keys.get_macos_key_capture_status(local_request()))["data"]
+    assert set(result) == {
+        "pending", "stage", "needs_cleanup", "monitor_ready", "capture_backend",
+        "capture_phase", "prepared_process_exited", "transaction_id", "recovery_error_code",
+        "method", "active_operation",
+    }
+    assert result["prepared_process_exited"] is None
+    assert result["transaction_id"] == "test-tx"
+    assert result["recovery_error_code"] is None
+    assert "ab" * 32 not in str(result)
+    assert "/private" not in str(result)
+
+
+@pytest.mark.parametrize("valid", [True, False])
+def test_capture_returns_only_fresh_account_validated_key(monkeypatch, valid):
+    fresh = "ab" * 32
+    monkeypatch.setattr(keys, "_resolve_v4_probe_db_file", lambda path: Path("/tmp/fixture/message_0.db"))
+    capture = Mock(return_value={"db_key": fresh, "official_wechat_verified": True})
+    monkeypatch.setattr(keys, "capture_prepared_macos_passphrase", capture)
+    validate = Mock(return_value={"valid": valid})
+    monkeypatch.setattr(wechat_decrypt, "validate_realtime_database_key", validate)
+    save = Mock()
+    monkeypatch.setattr(keys, "save_passphrase", save)
+    from wechat_decrypt_tool import macos_db_key_discovery
+    discover = Mock(side_effect=AssertionError("must not substitute cached key"))
+    monkeypatch.setattr(macos_db_key_discovery, "discover_macos_db_key", discover)
+    result = asyncio.run(keys.capture_macos_key(
+        local_request(), keys.MacosKeyCaptureRequest(db_storage_path="/tmp/fixture/db_storage"),
+    ))
+    assert capture.call_args.kwargs["save_result"] is False
+    validate.assert_called_once_with("/tmp/fixture/db_storage", fresh)
+    discover.assert_not_called()
+    if valid:
+        assert result["status"] == 0
+        assert result["data"]["db_key"] == fresh
+        save.assert_called_once_with(fresh)
+    else:
+        assert result["status"] == -1
+        assert fresh not in str(result)
+        save.assert_not_called()
+
+
+def test_preflight_returns_transaction_and_whitelisted_backend(monkeypatch):
+    monkeypatch.setattr(keys, "preflight_prepared_macos_passphrase", lambda *a, **kw: {
+        "transaction_id": "test-tx", "capture_backend": "lldb", "backup_path": "/private/backup",
+    })
+    result = asyncio.run(keys.preflight_macos_key_capture(local_request(), keys.MacosKeyCaptureRequest()))
+    assert result["data"]["transaction_id"] == "test-tx"
+    assert result["data"]["capture_backend"] == "lldb"
+    assert "/private" not in str(result)
+
+
+def test_concurrent_cancel_cannot_restore_under_active_capture(tmp_path, monkeypatch):
+    entered, release = threading.Event(), threading.Event()
+    app = tmp_path / "WeChat.app"
+    app.mkdir()
+    monkeypatch.setattr(macos_inplace_capture, "normalize_wechat_app_path", lambda value: app)
+    monkeypatch.setattr(macos_inplace_capture, "has_pending_in_place_capture", lambda **kw: False)
+    restore = Mock(side_effect=AssertionError("a concurrent request must not restore the app"))
+    monkeypatch.setattr(macos_inplace_capture, "_restore_after_terminal_path", restore)
+
+    def pause(*args, **kwargs):
+        entered.set()
+        assert release.wait(3)
+        raise MacOSDBKeyCaptureFailure("test_finished", "synthetic capture finished")
+
+    monkeypatch.setattr(macos_inplace_capture, "_require_prepared_process", pause)
+    failures = []
+
+    def worker():
+        try:
+            macos_inplace_capture.capture_prepared_in_place(
+                app, backup_root=tmp_path, probe_db_path=None, debug_root=tmp_path,
+            )
+        except MacOSDBKeyCaptureFailure as exc:
+            failures.append(exc.code)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    try:
+        assert entered.wait(1)
+        with pytest.raises(MacOSDBKeyCaptureFailure) as error:
+            macos_inplace_capture.cleanup_in_place_capture(app, backup_root=tmp_path, debug_root=tmp_path)
+        assert error.value.code == "in_place_capture_busy"
+        restore.assert_not_called()
+    finally:
+        release.set()
+        thread.join(timeout=3)
+    assert not thread.is_alive()
+    assert failures == ["test_finished"]

--- a/tests/test_macos_capture_backend_routing.py
+++ b/tests/test_macos_capture_backend_routing.py
@@ -1,0 +1,199 @@
+"""Isolated workflow checks: never attach to, launch, or restore a real app."""
+import json
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from wechat_decrypt_tool import macos_inplace_capture as workflow
+from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
+
+
+SYNTHETIC_PAGES = {"message": b"m" * 4096, "session": b"s" * 4096}
+
+
+@pytest.fixture
+def capture_case(tmp_path):
+    app = tmp_path / "WeChat.app"
+    (app / "Contents/Resources").mkdir(parents=True)
+    (app / "Contents/Resources/wechat.dylib").write_bytes(b"synthetic dylib marker; never executed")
+    state = {"transaction_id": "test-transaction", "version": "4.1.13", "build": "fixture", "official_cdhash": "fixture-hash"}
+    probe = tmp_path / "db_storage/message/message_0.db"
+    probe.parent.mkdir(parents=True)
+    probe.write_bytes(SYNTHETIC_PAGES["message"])
+    session = tmp_path / "db_storage/session/session.db"
+    session.parent.mkdir(parents=True)
+    session.write_bytes(SYNTHETIC_PAGES["session"])
+    with ExitStack() as stack:
+        # Real serialization stays enabled; OS/application side effects do not.
+        stack.enter_context(patch("subprocess.run", side_effect=AssertionError("external process execution is forbidden in routing tests")))
+        stack.enter_context(patch.object(workflow, "_acquire_installation_lock", return_value={"transaction_id": state["transaction_id"]}))
+        stack.enter_context(patch.object(workflow, "_release_installation_lock"))
+        stack.enter_context(patch.object(workflow.platform, "mac_ver", return_value=("26.0", (), "arm64")))
+        stack.enter_context(patch.object(workflow, "normalize_wechat_app_path", return_value=app))
+        stack.enter_context(patch.object(workflow, "_require_prepared_process", return_value=(state, 321)))
+        stack.enter_context(patch.object(workflow, "_candidate_bundle_pids", return_value=[321]))
+        restore = stack.enter_context(patch.object(workflow, "_restore_after_terminal_path", return_value={"official_wechat_verified": True, "official_wechat_restored": True}))
+        stack.enter_context(patch.object(workflow, "has_pending_in_place_capture", return_value=True))
+        yield app, state, probe, restore, stack
+
+
+def test_macos27_preflight_selects_software_without_running_native(tmp_path, capture_case):
+    app, state, _, _, stack = capture_case
+    stack.enter_context(patch.object(workflow.platform, "mac_ver", return_value=("27.0", (), "arm64")))
+    native = stack.enter_context(patch.object(workflow, "preflight_native_wcdb_capture"))
+    software = stack.enter_context(patch("wechat_decrypt_tool.macos_clone_capture.preflight_capture_breakpoints", return_value={"pid": 321, "pbkdf_locations": 1, "key_return_locations": 0}))
+    result = workflow.preflight_prepared_in_place_capture(app, backup_root=tmp_path, debug_root=tmp_path)
+    assert result["capture_backend"] == "lldb"
+    assert state["preflight"]["transaction_id"] == state["transaction_id"]
+    native.assert_not_called()
+    software.assert_called_once()
+
+
+def test_native_preflight_failure_routes_to_software(tmp_path, capture_case):
+    app, state, _, restore, stack = capture_case
+    stack.enter_context(patch.object(workflow, "_preferred_capture_backend", return_value="native"))
+    stack.enter_context(patch.object(workflow, "preflight_native_wcdb_capture", side_effect=MacOSDBKeyCaptureFailure("native_breakpoint_shape_mismatch", "fixture")))
+    software = stack.enter_context(patch("wechat_decrypt_tool.macos_clone_capture.preflight_capture_breakpoints", return_value={"pid": 321, "pbkdf_locations": 1}))
+    result = workflow.preflight_prepared_in_place_capture(app, backup_root=tmp_path, debug_root=tmp_path)
+    assert result["capture_backend"] == "lldb"
+    software.assert_called_once()
+    restore.assert_not_called()
+
+
+def test_cancelled_authorization_never_reprompts_via_fallback(tmp_path, capture_case):
+    app, _, _, restore, stack = capture_case
+    stack.enter_context(patch.object(workflow, "_preferred_capture_backend", return_value="native"))
+    stack.enter_context(patch.object(workflow, "preflight_native_wcdb_capture", side_effect=MacOSDBKeyCaptureFailure("administrator_cancelled", "cancelled")))
+    software = stack.enter_context(patch("wechat_decrypt_tool.macos_clone_capture.preflight_capture_breakpoints"))
+    with pytest.raises(MacOSDBKeyCaptureFailure, match="cancelled"):
+        workflow.preflight_prepared_in_place_capture(app, backup_root=tmp_path, debug_root=tmp_path)
+    software.assert_not_called()
+    restore.assert_called_once()
+
+
+def prepare_capture_mocks(stack, state, backend):
+    state["preflight"] = {"pid": 321, "capture_backend": backend, "transaction_id": state["transaction_id"]}
+    validate = stack.enter_context(patch("wechat_decrypt_tool.macos_capture_validation.validate_account_candidate", return_value={"key_mode": "sqlcipher_passphrase", "validated_roles": ["message", "session"]}))
+    save = stack.enter_context(patch.object(workflow, "save_passphrase", return_value=Path("/fixture/key.json")))
+    return SYNTHETIC_PAGES, validate, save
+
+
+def test_capture_uses_software_chosen_by_preflight(tmp_path, capture_case):
+    app, state, probe, restore, stack = capture_case
+    pages, validate, save = prepare_capture_mocks(stack, state, "lldb")
+    software = stack.enter_context(patch.object(workflow, "capture_salt_matched_passphrase", return_value={"passphrase": "ab" * 32, "key_mode": "sqlcipher_passphrase", "validated_roles": ["message", "session"]}))
+    native = stack.enter_context(patch.object(workflow, "capture_native_wcdb_key"))
+    result = workflow.capture_prepared_in_place(app, backup_root=tmp_path, probe_db_path=probe, debug_root=tmp_path)
+    native.assert_not_called()
+    assert software.call_args.kwargs["account_probe_pages"] == pages
+    assert software.call_args.kwargs["transaction_id"] == state["transaction_id"]
+    assert result["account_roles_validated"] is True
+    assert software.call_args.kwargs["expected_salts"] == [pages["message"][:16], pages["session"][:16]]
+    validate.assert_called_once_with("ab" * 32, pages)
+    save.assert_called_once_with("ab" * 32)
+    restore.assert_called_once()
+
+
+def test_native_partial_candidate_is_not_saved(tmp_path, capture_case):
+    app, state, probe, restore, stack = capture_case
+    pages, validate, save = prepare_capture_mocks(stack, state, "native")
+    validate.side_effect = MacOSDBKeyCaptureFailure("account_key_validation_failed", "partial fixture")
+    stack.enter_context(patch.object(workflow, "capture_native_wcdb_key", return_value={"db_key": "ab" * 32}))
+    with pytest.raises(MacOSDBKeyCaptureFailure, match="partial fixture"):
+        workflow.capture_prepared_in_place(app, backup_root=tmp_path, probe_db_path=probe, debug_root=tmp_path)
+    save.assert_not_called()
+    validate.assert_called_once_with("ab" * 32, pages)
+    restore.assert_called_once()
+
+
+def test_native_timeout_remembers_software_for_next_login_not_empty_wait(tmp_path, capture_case):
+    app, state, probe, restore, stack = capture_case
+    prepare_capture_mocks(stack, state, "native")
+    stack.enter_context(patch.object(workflow, "capture_native_wcdb_key", side_effect=MacOSDBKeyCaptureFailure("native_capture_timeout", "fixture timeout")))
+    software = stack.enter_context(patch.object(workflow, "capture_salt_matched_passphrase"))
+    with pytest.raises(MacOSDBKeyCaptureFailure) as error:
+        workflow.capture_prepared_in_place(app, backup_root=tmp_path, probe_db_path=probe, debug_root=tmp_path)
+    assert error.value.code == "native_capture_timeout"
+    assert "LLDB" in str(error.value)
+    software.assert_not_called()
+    restore.assert_called_once()
+    # This is an older OS with a present native dylib: the stored preference,
+    # not the macOS-27/missing-image default, must cause the next-run fallback.
+    remembered = json.loads((tmp_path / "capture-backend-preference.json").read_text(encoding="utf-8"))
+    assert remembered["backend"] == "lldb"
+    assert remembered["identity"] == workflow._backend_identity(state)
+    assert workflow._preferred_capture_backend(app, state, tmp_path) == "lldb"
+
+
+def test_stale_preflight_cannot_target_another_transaction(tmp_path, capture_case):
+    app, state, probe, _, stack = capture_case
+    prepare_capture_mocks(stack, state, "native")
+    state["preflight"]["transaction_id"] = "previous-transaction"
+    native = stack.enter_context(patch.object(workflow, "capture_native_wcdb_key"))
+    with pytest.raises(MacOSDBKeyCaptureFailure) as error:
+        workflow.capture_prepared_in_place(app, backup_root=tmp_path, probe_db_path=probe, debug_root=tmp_path)
+    assert error.value.code == "capture_preflight_stale"
+    native.assert_not_called()
+
+
+UNCONFIRMED_NATIVE_CLEANUP = [
+    ("native_cleanup_failed", "debug state cleanup failed"),
+    ("native_capture_helper_terminated", "helper terminated"),
+    ("native_breakpoint_install_failed", "partial breakpoint installation"),
+    ("native_exception_port_failed", "exception port installation failed"),
+    ("administrator_failed", "execution error (1009)"),
+    ("administrator_failed", "SIGKILL"),
+]
+
+
+@pytest.mark.parametrize("code,message", UNCONFIRMED_NATIVE_CLEANUP)
+def test_preflight_unconfirmed_cleanup_restores_without_attaching_lldb(tmp_path, capture_case, code, message):
+    app, state, _, restore, stack = capture_case
+    stack.enter_context(patch.object(workflow, "_preferred_capture_backend", return_value="native"))
+    native = stack.enter_context(patch.object(workflow, "preflight_native_wcdb_capture", side_effect=MacOSDBKeyCaptureFailure(code, message)))
+    software = stack.enter_context(patch("wechat_decrypt_tool.macos_clone_capture.preflight_capture_breakpoints"))
+    with pytest.raises(MacOSDBKeyCaptureFailure) as error:
+        workflow.preflight_prepared_in_place_capture(app, backup_root=tmp_path, debug_root=tmp_path)
+    assert error.value.code == code
+    assert "新事务" in str(error.value)
+    assert "LLDB" in str(error.value)
+    native.assert_called_once()
+    software.assert_not_called()
+    restore.assert_called_once()
+    remembered = json.loads((tmp_path / "capture-backend-preference.json").read_text(encoding="utf-8"))
+    assert remembered == {"backend": "lldb", "identity": workflow._backend_identity(state)}
+
+
+@pytest.mark.parametrize("code,message", UNCONFIRMED_NATIVE_CLEANUP)
+def test_capture_unconfirmed_cleanup_restores_without_attaching_lldb(tmp_path, capture_case, code, message):
+    app, state, probe, restore, stack = capture_case
+    _, validate, save = prepare_capture_mocks(stack, state, "native")
+    native = stack.enter_context(patch.object(workflow, "capture_native_wcdb_key", side_effect=MacOSDBKeyCaptureFailure(code, message)))
+    software = stack.enter_context(patch.object(workflow, "capture_salt_matched_passphrase"))
+    preflight = stack.enter_context(patch("wechat_decrypt_tool.macos_clone_capture.preflight_capture_breakpoints"))
+    with pytest.raises(MacOSDBKeyCaptureFailure) as error:
+        workflow.capture_prepared_in_place(app, backup_root=tmp_path, probe_db_path=probe, debug_root=tmp_path)
+    assert error.value.code == code
+    assert "新事务" in str(error.value)
+    assert "LLDB" in str(error.value)
+    native.assert_called_once()
+    software.assert_not_called()
+    preflight.assert_not_called()
+    validate.assert_not_called()
+    save.assert_not_called()
+    restore.assert_called_once()
+    assert workflow._preferred_capture_backend(app, state, tmp_path) == "lldb"
+
+
+def test_attach_denial_is_not_blindly_retried(tmp_path, capture_case):
+    app, _, _, restore, stack = capture_case
+    stack.enter_context(patch.object(workflow, "_preferred_capture_backend", return_value="native"))
+    stack.enter_context(patch.object(workflow, "preflight_native_wcdb_capture", side_effect=MacOSDBKeyCaptureFailure("native_attach_failed", "attach denied")))
+    software = stack.enter_context(patch("wechat_decrypt_tool.macos_clone_capture.preflight_capture_breakpoints"))
+    with pytest.raises(MacOSDBKeyCaptureFailure) as error:
+        workflow.preflight_prepared_in_place_capture(app, backup_root=tmp_path, debug_root=tmp_path)
+    assert error.value.code == "native_attach_failed"
+    software.assert_not_called()
+    restore.assert_called_once()

--- a/tests/test_macos_capture_diagnostics.py
+++ b/tests/test_macos_capture_diagnostics.py
@@ -1,0 +1,283 @@
+"""Capture diagnostics tests: mocked orchestration only, never attach to WeChat."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from wechat_decrypt_tool import macos_native_capture as native
+from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
+
+
+SOURCE = Path(native.__file__).parent / "native/macos/source/wcdb_native_capture.c"
+SECRET = "d9" * 32
+
+
+@pytest.fixture
+def helper_call(monkeypatch):
+    """Every operation that could build, inspect, authorize, or attach is mocked."""
+    monkeypatch.setattr(native, "ensure_native_capture_helper", Mock(return_value=Path("/mock/helper")))
+    monkeypatch.setattr(native, "_resolve_wechat_dylib", Mock(return_value=Path("/mock/wechat.dylib")))
+    monkeypatch.setattr(native, "_resolve_pbkdf_stub_address", Mock(return_value=4096))
+    monkeypatch.setattr(native, "_resolve_runtime_breakpoint_address", Mock(return_value=8192))
+    administrator = Mock()
+    monkeypatch.setattr(native, "_run_as_administrator", administrator)
+    monkeypatch.setattr(native, "get_logger", Mock(return_value=Mock()))
+
+    def invoke(payload=None, *, failure=None, **kwargs):
+        administrator.side_effect = failure
+        administrator.return_value = json.dumps(payload or {})
+        return native.capture_native_wcdb_key(
+            pid=123, wechat_app=Path("/mock/WeChat.app"),
+            debug_root=Path("/mock/debug"), probe_db_path=Path("/mock/encrypted.db"),
+            **kwargs,
+        )
+
+    return invoke, administrator
+
+
+def successful_payload(**extra):
+    return {
+        "status": "ok", "mode": "capture", "method": "macos_native_mach",
+        "pid": 123, "stub_file_address": 4096, "validated": True,
+        "db_key": SECRET, **extra,
+    }
+
+
+def test_diagnostics_accept_only_bounded_integer_counters_and_known_stages():
+    payload = {
+        "diagnostics": {
+            "pbkdf_calls": 7, "wcdb_profile_hits": True, "rounds2_hits": "3",
+            "rounds256000_hits": -1, "salt_matches": 2**64,
+            "candidate_rejects": 1.5, "salt_read_failures": [],
+            "candidate_read_failures": {"db_key": SECRET},
+            "last_stage": "rounds2_seen", "db_key": SECRET, "salt": SECRET,
+            "page1": SECRET, "raw_payload": SECRET,
+        }
+    }
+    assert native._parse_capture_diagnostics(payload) == {
+        "pbkdf_calls": 7, "last_stage": "rounds2_seen",
+    }
+    payload["diagnostics"]["last_stage"] = SECRET
+    assert native._parse_capture_diagnostics(payload) == {"pbkdf_calls": 7}
+
+
+@pytest.mark.parametrize("invalid", [None, [], SECRET, 5])
+def test_non_object_diagnostics_allow_only_legacy_counter(invalid):
+    assert native._parse_capture_diagnostics({"diagnostics": invalid, "pbkdf_calls": 9}) == {"pbkdf_calls": 9}
+
+
+def test_native_error_exposes_safe_counters_but_no_secret_or_raw_message(helper_call):
+    invoke, _ = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke({
+            "status": "error", "code": "native_capture_timeout", "message": SECRET,
+            "db_key": SECRET, "salt": SECRET, "page1": SECRET,
+            "diagnostics": {
+                "pbkdf_calls": 4, "wcdb_profile_hits": 4, "rounds2_hits": 4,
+                "rounds256000_hits": 0, "candidate_rejects": 0,
+                "last_stage": "rounds2_seen", "raw_payload": SECRET,
+            },
+        })
+    assert raised.value.code == "native_capture_timeout"
+    assert "rounds2_hits=4" in str(raised.value)
+    assert "last_stage=rounds2_seen" in str(raised.value)
+    assert "不能将单库派生密钥作为账号密钥" in str(raised.value)
+    assert SECRET not in str(raised.value)
+
+
+def test_unknown_code_and_stage_are_not_echoed(helper_call):
+    invoke, _ = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke({"status": "error", "code": SECRET, "message": SECRET, "diagnostics": {"last_stage": SECRET}})
+    assert raised.value.code == "native_capture_failed"
+    assert SECRET not in str(raised.value)
+
+
+def test_failure_logger_receives_only_fixed_code_and_whitelisted_diagnostics(helper_call):
+    invoke, _ = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure):
+        invoke({
+            "status": "error", "code": "native_capture_timeout", "message": SECRET,
+            "db_key": SECRET, "salt": SECRET, "page1": SECRET, "path": "/private/secret-account",
+            "diagnostics": {"pbkdf_calls": 3, "rounds2_hits": 3, "last_stage": "rounds2_seen", "payload": SECRET},
+        })
+    native.get_logger.assert_called_once_with(native.__name__)
+    warning = native.get_logger.return_value.warning
+    warning.assert_called_once_with(
+        "native capture failed: code=%s diagnostics=%s", "native_capture_timeout",
+        {"pbkdf_calls": 3, "rounds2_hits": 3, "last_stage": "rounds2_seen"},
+    )
+    assert SECRET not in str(warning.call_args)
+    assert "/private/secret-account" not in str(warning.call_args)
+
+
+@pytest.mark.parametrize("code", [
+    "native_capture_target_exited", "native_capture_interrupted", "native_capture_wait_failed", "native_cleanup_failed",
+])
+def test_early_terminal_results_are_not_reported_as_timeouts(helper_call, code):
+    invoke, administrator = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke({"status": "error", "code": code, "diagnostics": {"pbkdf_calls": 2}})
+    assert raised.value.code == code
+    assert "超时" not in str(raised.value)
+    assert "pbkdf_calls=2" in str(raised.value)
+    administrator.assert_called_once()
+
+
+def test_embedded_administrator_error_preserves_safe_diagnostics(helper_call):
+    invoke, _ = helper_call
+    payload = {"status": "error", "code": "native_capture_timeout", "message": SECRET, "diagnostics": {"pbkdf_calls": 0}}
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke(failure=MacOSDBKeyCaptureFailure("administrator_failed", f"admin error: {json.dumps(payload)} (1)"))
+    assert raised.value.code == "native_capture_timeout"
+    assert "未命中 PBKDF 断点" in str(raised.value)
+    assert SECRET not in str(raised.value)
+
+
+@pytest.mark.parametrize("error", ["execution error (1009)", "Killed: 9", "SIGKILL", "terminated"])
+def test_helper_termination_without_json_is_explicit_and_redacted(helper_call, error):
+    invoke, _ = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke(failure=MacOSDBKeyCaptureFailure("administrator_failed", f"{error} {SECRET}"))
+    assert raised.value.code == "native_capture_helper_terminated"
+    assert SECRET not in str(raised.value)
+
+
+@pytest.mark.parametrize("code", ["administrator_cancelled", "administrator_timeout", "administrator_failed"])
+def test_administrator_failures_are_redacted_and_not_retried(helper_call, code):
+    invoke, administrator = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke(failure=MacOSDBKeyCaptureFailure(code, SECRET))
+    assert raised.value.code == code
+    assert SECRET not in str(raised.value)
+    administrator.assert_called_once()
+
+
+def test_success_returns_only_expected_fields_and_filtered_diagnostics(helper_call):
+    invoke, _ = helper_call
+    payload = invoke(successful_payload(
+        salt=SECRET, page1=SECRET, raw_payload=SECRET,
+        diagnostics={"pbkdf_calls": 3, "last_stage": "validated", "salt": SECRET},
+    ))
+    assert payload["db_key"] == SECRET
+    assert payload["diagnostics"] == {"pbkdf_calls": 3, "last_stage": "validated"}
+    assert payload["pbkdf_calls"] == 3
+    assert not {"salt", "page1", "raw_payload"} & payload.keys()
+
+
+@pytest.mark.parametrize("validated", ["true", "false", 1, None])
+def test_validation_requires_a_real_boolean(helper_call, validated):
+    invoke, _ = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke(successful_payload(validated=validated))
+    assert raised.value.code == "native_capture_unvalidated"
+
+
+def test_transaction_id_is_forwarded_to_native_ready_protocol(helper_call):
+    invoke, administrator = helper_call
+    invoke(successful_payload(), ready_file=Path("/mock/ready.json"), transaction_id="tx-123_abc")
+    command = shlex.split(administrator.call_args.args[0])
+    assert command[command.index("--transaction-id") + 1] == "tx-123_abc"
+    assert command[command.index("--ready-file") + 1] == "/mock/ready.json"
+
+
+@pytest.mark.parametrize("transaction_id", [None, ""])
+def test_missing_transaction_id_is_backward_compatible(helper_call, transaction_id):
+    invoke, administrator = helper_call
+    invoke(successful_payload(), transaction_id=transaction_id)
+    assert "--transaction-id" not in shlex.split(administrator.call_args.args[0])
+
+
+@pytest.mark.parametrize("transaction_id", ['tx"bad', "x" * 129, "a/b", "line\n"])
+def test_invalid_transaction_never_starts_helper(helper_call, transaction_id):
+    invoke, administrator = helper_call
+    with pytest.raises(MacOSDBKeyCaptureFailure) as raised:
+        invoke(successful_payload(), transaction_id=transaction_id)
+    assert raised.value.code == "native_capture_invalid_transaction"
+    administrator.assert_not_called()
+
+
+def test_native_source_emits_diagnostics_on_error_and_keeps_account_key_gate():
+    source = SOURCE.read_text(encoding="utf-8")
+    error = source[source.index("static void json_error"):source.index("static void on_signal")]
+    assert "json_diagnostics();" in error
+    diagnostics = source[source.index("static void json_diagnostics"):source.index("static void json_success_preflight")]
+    for name in native._DIAGNOSTIC_COUNTERS:
+        assert name in diagnostics
+    assert "db_key_hex" not in diagnostics
+    assert "g_ctx.page1" not in diagnostics
+    operands = source[source.index("static bool breakpoint_operands_match"):source.index("static bool salt_matches_expected")]
+    assert "state->__x[6] == 256000" in operands
+    callback = source[source.index("static kern_return_t handle_breakpoint"):source.index("kern_return_t catch_exception_raise(")]
+    assert callback.index("g_ctx.rounds2_hits += 1") < callback.index("!breakpoint_operands_match(&state)")
+    assert callback.index("!breakpoint_operands_match(&state)") < callback.index("uint8_t candidate[KEY_SIZE]")
+    # The existing successful disposal strategy remains unchanged.
+    assert "(void)kill(g_ctx.target_pid, SIGKILL);" in callback
+
+
+def test_native_source_checks_dead_target_before_timeout_and_marks_ready_transaction():
+    source = SOURCE.read_text(encoding="utf-8")
+    wait = source[source.index("static kern_return_t wait_for_breakpoint"):source.index("static int run_preflight")]
+    assert wait.index("MACH_PORT_TYPE_DEAD_NAME") < wait.index("return KERN_OPERATION_TIMED_OUT")
+    assert "kill(g_ctx.target_pid, 0)" in wait
+    ready = source[source.index("static bool write_ready_file"):source.index("static bool streq")]
+    assert 'transaction_id\\\":\\\"' in ready
+    assert "macos_native_mach" in ready
+    assert 'pid\\\":%d' in ready
+
+
+def test_native_preflight_requires_suspend_install_rollback_and_resume_success():
+    source = SOURCE.read_text(encoding="utf-8")
+    preflight = source[source.index("static int run_preflight"):source.index("static int run_capture")]
+    suspend = preflight.index("kr = task_suspend(g_ctx.task);")
+    install = preflight.index("kr = install_hardware_breakpoints(g_ctx.task);")
+    restore = preflight.index("kern_return_t restore_kr = restore_hardware_breakpoints();")
+    resume = preflight.index("kern_return_t resume_kr = task_resume(g_ctx.task);")
+    gate = preflight.index("if (g_ctx.cleanup_failed || restore_kr != KERN_SUCCESS || resume_kr != KERN_SUCCESS)")
+    success = preflight.index("json_success_preflight(options);")
+    assert suspend < install < restore < resume < gate < success
+    assert 'json_error("native_cleanup_failed"' in preflight[suspend:install]
+    assert "return 1;" in preflight[suspend:install]
+    assert 'json_error("native_cleanup_failed"' in preflight[gate:success]
+    assert 'json_error("native_breakpoint_install_failed"' in preflight[gate:success]
+    assert "(void)restore_hardware_breakpoints();" not in preflight
+    assert "(void)task_resume(g_ctx.task);" not in preflight
+
+
+def test_native_rollback_only_writes_valid_states_that_were_modified():
+    source = SOURCE.read_text(encoding="utf-8")
+    restore = source[source.index("static kern_return_t restore_hardware_breakpoints"):source.index("static kern_return_t install_hardware_breakpoints")]
+    install = source[source.index("static kern_return_t install_hardware_breakpoints"):source.index("static bool thread_set_matches")]
+    guard = "if (thread == MACH_PORT_NULL || !g_ctx.saved_debug_valid[index] || !g_ctx.debug_state_modified[index])"
+    assert restore.index(guard) < restore.index("kern_return_t kr = thread_set_state(")
+    assert "continue;" in restore[restore.index(guard):restore.index("kern_return_t kr = thread_set_state(")]
+    assert install.index("saved_states[index] = debug_state;") < install.index("saved_valid[index] = true;")
+    set_state = install.index("kr = thread_set_state(")
+    mark_modified = install.index("modified[index] = true;")
+    assert set_state < mark_modified
+    # Both read and write failures must leave the current/unvisited entry false.
+    assert "return kr;" in install[install.index("kr = thread_get_state("):install.index("saved_valid[index] = true;")]
+    assert "return kr;" in install[set_state:mark_modified]
+    assert "bool *saved_valid = calloc(thread_count, sizeof(*saved_valid));" in install
+    assert "bool *modified = calloc(thread_count, sizeof(*modified));" in install
+
+
+def test_native_cleanup_failure_survives_state_release_and_stops_capture():
+    source = SOURCE.read_text(encoding="utf-8")
+    release = source[source.index("static void release_debug_threads"):source.index("static kern_return_t restore_hardware_breakpoints")]
+    restore = source[source.index("static kern_return_t restore_hardware_breakpoints"):source.index("static kern_return_t install_hardware_breakpoints")]
+    refresh = source[source.index("static kern_return_t refresh_hardware_breakpoints_if_needed"):source.index("static kern_return_t install_exception_port")]
+    capture = source[source.index("static int run_capture"):source.index("int main(")]
+    assert "cleanup_failed = false" not in release
+    assert "free(g_ctx.saved_debug_valid);" in release
+    assert "free(g_ctx.debug_state_modified);" in release
+    assert "g_ctx.cleanup_failed = true;" in restore
+    assert restore.index("g_ctx.cleanup_failed = true;") < restore.index("    release_debug_threads();", restore.index("g_ctx.cleanup_failed = true;"))
+    assert "if (kr == KERN_SUCCESS) {\n        kr = install_hardware_breakpoints(g_ctx.task);" in refresh
+    assert 'if (g_ctx.cleanup_failed && !g_ctx.captured) {\n        json_error("native_cleanup_failed"' in capture
+    assert capture.index("if (g_ctx.cleanup_failed && !g_ctx.captured)") < capture.index("json_success_capture(options);")

--- a/tests/test_macos_capture_phases.py
+++ b/tests/test_macos_capture_phases.py
@@ -1,0 +1,163 @@
+"""Progress-only fixtures: no debugger, real database, or application mutation."""
+import json
+import sys
+import types
+from unittest.mock import Mock
+
+import pytest
+
+from wechat_decrypt_tool import macos_inplace_capture as workflow
+from wechat_decrypt_tool import macos_capture_validation as validation
+from wechat_decrypt_tool.macos_clone_capture import build_lldb_salt_capture_script
+from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
+
+
+def write_progress(tmp_path, *, phase="waiting_authorization", status="ready", **marker_overrides):
+    state = {
+        "schema_version": 2, "stage": "capturing", "transaction_id": "fixture-tx",
+        "debug_pid": 123, "capture_backend": "lldb", "capture_phase": phase,
+    }
+    workflow._write_state(tmp_path, state)
+    marker = {"transaction_id": "fixture-tx", "pid": 123, "method": "macos_lldb_stub", "status": status}
+    marker.update(marker_overrides)
+    workflow._native_capture_ready_path(tmp_path).write_text(json.dumps(marker))
+    return state
+
+
+@pytest.mark.parametrize("status,phase,ready", [("ready", "monitoring", True), ("captured", "captured", False)])
+def test_progress_tracks_validated_capture_without_exposing_result(tmp_path, status, phase, ready):
+    write_progress(tmp_path, status=status, db_key="ab" * 32, path="/private/fixture")
+    result = workflow.get_in_place_capture_status(debug_root=tmp_path)
+    assert result["capture_phase"] == phase
+    assert result["monitor_ready"] is ready
+    assert "ab" * 32 not in str(result)
+    assert "/private" not in str(result)
+
+
+@pytest.mark.parametrize("overrides", [{"pid": 999}, {"transaction_id": "old-tx"}, {"method": "untrusted"}])
+def test_stale_or_unbound_captured_marker_cannot_advance_progress(tmp_path, overrides):
+    write_progress(tmp_path, status="captured", **overrides)
+    result = workflow.get_in_place_capture_status(debug_root=tmp_path)
+    assert result["capture_phase"] == "waiting_authorization"
+    assert result["monitor_ready"] is False
+
+
+@pytest.mark.parametrize("phase", ["validating", "captured", "restoring"])
+def test_post_capture_phase_wins_over_old_ready_file(tmp_path, phase):
+    write_progress(tmp_path, phase=phase)
+    result = workflow.get_in_place_capture_status(debug_root=tmp_path)
+    assert result["capture_phase"] == phase
+    assert result["monitor_ready"] is False
+
+
+def test_phase_is_whitelisted_and_idle_has_no_success_claim(tmp_path):
+    state = write_progress(tmp_path, phase="ab" * 32, status="untrusted")
+    result = workflow.get_in_place_capture_status(debug_root=tmp_path)
+    assert result["capture_phase"] is None
+    assert "ab" * 32 not in str(result)
+    state["stage"] = "recovery_blocked"
+    state["capture_phase"] = "captured"
+    workflow._write_state(tmp_path, state)
+    assert workflow.get_in_place_capture_status(debug_root=tmp_path)["capture_phase"] is None
+    workflow._remove_state(tmp_path)
+    assert workflow.get_in_place_capture_status(debug_root=tmp_path)["capture_phase"] is None
+
+
+def test_stored_monitoring_phase_is_not_a_substitute_for_armed_signal(tmp_path):
+    write_progress(tmp_path, phase="monitoring", status="untrusted")
+    result = workflow.get_in_place_capture_status(debug_root=tmp_path)
+    assert result["capture_phase"] == "waiting_authorization"
+    assert result["monitor_ready"] is False
+
+
+def test_progress_write_failure_keeps_recovery_state_and_allows_retry(tmp_path, monkeypatch):
+    state = write_progress(tmp_path)
+    before = workflow._state_path(tmp_path).read_bytes()
+    with monkeypatch.context() as patcher:
+        patcher.setattr(workflow.os, "write", Mock(side_effect=OSError("fixture disk error")))
+        workflow._set_capture_phase(tmp_path, state, "validating")
+    assert workflow._state_path(tmp_path).read_bytes() == before
+    assert not list(tmp_path.glob(".prepared-in-place-capture.*.tmp"))
+    workflow._set_capture_phase(tmp_path, state, "restoring")
+    assert workflow.get_in_place_capture_status(debug_root=tmp_path)["capture_phase"] == "restoring"
+
+
+class ScriptExit(Exception):
+    pass
+
+
+@pytest.mark.parametrize("marker_fails", [False, True])
+def test_success_announces_capture_before_expected_shutdown(tmp_path, monkeypatch, marker_fails):
+    script = build_lldb_salt_capture_script(tmp_path / "result.json", [b"s" * 16], transaction_id="fixture-tx")
+    namespace = {"__name__": "fixture_callback"}
+    monkeypatch.setitem(sys.modules, "lldb", types.SimpleNamespace())
+    exec(compile(script, "<synthetic-callback>", "exec"), namespace)
+    namespace["ACCOUNT_PROBE_PAGES"] = {"message": b"m" * 4096, "session": b"s" * 4096}
+    namespace["_candidate_page1_mode"] = lambda *args: "sqlcipher_passphrase"
+    events = []
+    namespace["_write_result"] = lambda payload: events.append("validated_result") or True
+
+    def progress(payload):
+        events.append("captured_notice")
+        assert payload == {"status": "captured", "method": "macos_lldb_stub", "pid": 123}
+        if marker_fails:
+            raise OSError("fixture progress file unavailable")
+        return True
+
+    namespace["_write_ready"] = progress
+    namespace["os"] = types.SimpleNamespace(_exit=Mock(side_effect=ScriptExit))
+    process = types.SimpleNamespace(GetProcessID=lambda: 123, Kill=lambda: events.append("planned_shutdown"))
+    with pytest.raises(ScriptExit):
+        namespace["_save_valid_candidate"](b"k" * 32, "s", "fixture", process)
+    assert events == ["validated_result", "captured_notice", "planned_shutdown"]
+
+
+@pytest.mark.parametrize("capture_fails", [False, True])
+def test_workflow_reports_validation_and_restoration_without_leaking_key(tmp_path, monkeypatch, capture_fails):
+    app = tmp_path / "WeChat.app"
+    app.mkdir()
+    probe = tmp_path / "message_0.db"
+    probe.write_bytes(b"m" * 4096)
+    state = {
+        "schema_version": 2, "stage": "preflight_passed", "transaction_id": "fixture-tx",
+        "debug_pid": 123,
+        "preflight": {"pid": 123, "capture_backend": "lldb", "transaction_id": "fixture-tx"},
+    }
+    monkeypatch.setattr(workflow, "normalize_wechat_app_path", lambda *a: app)
+    monkeypatch.setattr(workflow, "_require_prepared_process", lambda *a, **kw: (state, 123))
+    monkeypatch.setattr(workflow, "_candidate_bundle_pids", lambda *a: [123])
+    monkeypatch.setattr(validation, "read_account_probe_pages", lambda *a: {"message": b"m" * 4096, "session": b"s" * 4096})
+    events = []
+
+    def capture(**kwargs):
+        assert workflow.get_in_place_capture_status(debug_root=tmp_path)["capture_phase"] == "waiting_authorization"
+        if capture_fails:
+            raise MacOSDBKeyCaptureFailure("fixture_failure", "fixture failure")
+        return {"passphrase": "ab" * 32}
+
+    def validate(*args):
+        events.append("validate")
+        assert workflow.get_in_place_capture_status(debug_root=tmp_path)["capture_phase"] == "validating"
+        return {"key_mode": "sqlcipher_passphrase", "validated_roles": ["message", "session"]}
+
+    def restore(*args, **kwargs):
+        events.append("restore")
+        status = workflow.get_in_place_capture_status(debug_root=tmp_path)
+        assert status["capture_phase"] == "restoring"
+        assert status["monitor_ready"] is False
+        assert "ab" * 32 not in workflow._state_path(tmp_path).read_text()
+        workflow._remove_state(tmp_path)
+        return {"official_wechat_verified": True, "official_wechat_restored": True}
+
+    monkeypatch.setattr(workflow, "capture_salt_matched_passphrase", capture)
+    monkeypatch.setattr(validation, "validate_account_candidate", validate)
+    monkeypatch.setattr(workflow, "_restore_after_terminal_path", restore)
+    if capture_fails:
+        with pytest.raises(MacOSDBKeyCaptureFailure, match="fixture failure"):
+            workflow.capture_prepared_in_place(app, backup_root=tmp_path, probe_db_path=probe, debug_root=tmp_path, save_result=False)
+        assert events == ["restore"]
+    else:
+        result = workflow.capture_prepared_in_place(app, backup_root=tmp_path, probe_db_path=probe, debug_root=tmp_path, save_result=False)
+        assert result["validated"] is True
+        assert events == ["validate", "restore"]
+    assert not workflow.has_pending_in_place_capture(debug_root=tmp_path)

--- a/tests/test_macos_capture_validation.py
+++ b/tests/test_macos_capture_validation.py
@@ -1,0 +1,331 @@
+"""Synthetic encrypted pages and fake LLDB only; never touches WeChat."""
+
+import hashlib
+import hmac
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from wechat_decrypt_tool.macos_clone_capture import build_lldb_salt_capture_script
+from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
+from wechat_decrypt_tool.macos_capture_validation import (
+    normalize_account_probe_pages,
+    read_account_probe_pages,
+    resolve_account_probe_paths,
+    validate_account_candidate,
+)
+from wechat_decrypt_tool.wechat_decrypt import validate_realtime_database_key
+
+
+def encrypted_page(candidate, salt, *, raw=False):
+    enc_key = candidate if raw else hashlib.pbkdf2_hmac("sha512", candidate, salt, 256000, 32)
+    mac_salt = bytes(value ^ 0x3A for value in salt)
+    mac_key = hashlib.pbkdf2_hmac("sha512", enc_key, mac_salt, 2, 32)
+    page = bytearray(salt + b"\x5a" * (4096 - 16))
+    page[4032:] = hmac.new(mac_key, page[16:4032] + b"\x01\x00\x00\x00", hashlib.sha512).digest()
+    return bytes(page)
+
+
+class TestMacOSCaptureValidation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.passphrase = bytes(range(32))
+        cls.message_salt = bytes(range(16))
+        cls.session_salt = bytes(range(16, 32))
+        cls.pages = {
+            "message": encrypted_page(cls.passphrase, cls.message_salt),
+            "session": encrypted_page(cls.passphrase, cls.session_salt),
+        }
+        cls.message_raw = hashlib.pbkdf2_hmac("sha512", cls.passphrase, cls.message_salt, 256000, 32)
+
+    def namespace(self, **kwargs):
+        script = build_lldb_salt_capture_script(
+            Path("/tmp/synthetic-unused-result.json"),
+            [self.message_salt, self.session_salt],
+            probe_page1=self.pages["message"],
+            **kwargs,
+        )
+        namespace = {"__name__": "synthetic_wedata_capture"}
+        with patch.dict(sys.modules, {"lldb": types.SimpleNamespace()}):
+            exec(compile(script, "<synthetic-capture>", "exec"), namespace)
+        return namespace
+
+    def test_single_database_raw_candidate_cannot_end_account_capture(self):
+        namespace = self.namespace()
+        # Establish the legacy failure: this raw key passes the message page,
+        # but cannot validate the independently salted session database.
+        self.assertTrue(namespace["_candidate_matches_page1"](self.message_raw))
+        namespace["ACCOUNT_PROBE_PAGES"] = self.pages
+        writes = []
+        namespace["_write_result"] = lambda payload: writes.append(payload) or True
+        process = types.SimpleNamespace(Kill=Mock())
+        with patch.object(namespace["os"], "_exit") as exit_process:
+            result = namespace["_save_valid_candidate"](
+                self.message_raw, self.message_salt.hex(), "pbkdf_hmac_password", process
+            )
+        self.assertIs(result, False)
+        process.Kill.assert_not_called()
+        exit_process.assert_not_called()
+        self.assertFalse(any("passphrase" in payload for payload in writes))
+        self.assertEqual(namespace["DIAGNOSTICS"]["partial_candidates"], 1)
+
+    def test_account_callback_keeps_waiting_until_shared_passphrase_arrives(self):
+        namespace = self.namespace(account_probe_pages=self.pages)
+        writes = []
+        namespace["_write_result"] = lambda payload: writes.append(payload) or True
+        process = types.SimpleNamespace(Kill=Mock())
+        with patch.object(namespace["os"], "_exit") as exit_process:
+            namespace["_save_valid_candidate"](
+                self.message_raw, self.message_salt.hex(), "pbkdf_hmac_password", process
+            )
+            process.Kill.assert_not_called()
+            namespace["_save_valid_candidate"](
+                self.passphrase, self.session_salt.hex(), "pbkdf_database_password", process
+            )
+        process.Kill.assert_called_once()
+        exit_process.assert_called_once_with(0)
+        self.assertEqual(writes[-1]["passphrase"], self.passphrase.hex())
+        self.assertEqual(writes[-1]["key_mode"], "sqlcipher_passphrase")
+        self.assertEqual(writes[-1]["validated_roles"], ["message", "session"])
+        self.assertEqual(writes[-1]["diagnostics"]["partial_candidates"], 1)
+        diagnostics = json.dumps(writes[-1]["diagnostics"])
+        self.assertNotIn(self.passphrase.hex(), diagnostics)
+        self.assertNotIn(self.message_raw.hex(), diagnostics)
+
+    def test_pbkdf_callback_ignores_single_role_raw_then_accepts_hex_passphrase(self):
+        namespace = self.namespace(account_probe_pages=self.pages)
+        namespace["lldb"] = types.SimpleNamespace(SBError=lambda: types.SimpleNamespace(Success=lambda: True))
+        candidate = self.message_raw
+        salt = bytes(value ^ 0x3A for value in self.message_salt)
+        process = types.SimpleNamespace(
+            ReadMemory=lambda address, length, error: (candidate if address == 100 else salt)[:length],
+            Kill=Mock(),
+        )
+        registers = {"x0": 2, "x1": 100, "x2": 32, "x3": 200, "x4": 16, "x5": 5, "x6": 2}
+        frame = types.SimpleNamespace(
+            GetThread=lambda: types.SimpleNamespace(GetProcess=lambda: process),
+            FindRegister=lambda name: types.SimpleNamespace(GetValueAsUnsigned=lambda: registers[name]),
+        )
+        writes = []
+        namespace["_write_result"] = lambda payload: writes.append(payload) or True
+        with patch.object(namespace["os"], "_exit") as exit_process:
+            self.assertFalse(namespace["_pbkdf_callback"](frame, None, None))
+            process.Kill.assert_not_called()
+            self.assertEqual(namespace["DIAGNOSTICS"]["partial_candidates"], 1)
+            candidate = self.passphrase.hex().encode("ascii")
+            salt = self.session_salt
+            registers.update(x2=64, x6=256000)
+            namespace["_pbkdf_callback"](frame, None, None)
+        process.Kill.assert_called_once()
+        exit_process.assert_called_once_with(0)
+        self.assertEqual(writes[-1]["validated_roles"], ["message", "session"])
+        self.assertEqual(writes[-1]["passphrase"], self.passphrase.hex())
+
+    def test_callback_does_not_kill_process_when_result_write_fails(self):
+        namespace = self.namespace(account_probe_pages=self.pages)
+        namespace["_write_result"] = lambda payload: False
+        process = types.SimpleNamespace(Kill=Mock())
+        with patch.object(namespace["os"], "_exit") as exit_process:
+            self.assertFalse(namespace["_save_valid_candidate"](
+                self.passphrase, self.message_salt.hex(), "pbkdf_database_password", process
+            ))
+        process.Kill.assert_not_called()
+        exit_process.assert_not_called()
+
+    def test_ready_and_result_include_transaction_id_without_secret_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            ready = Path(temp_dir) / "ready.json"
+            ready.touch(mode=0o600)
+            result = Path(temp_dir) / "result.json"
+            result.touch(mode=0o600)
+            namespace = self.namespace(account_probe_pages=self.pages, ready_path=ready, transaction_id="synthetic-tx")
+            namespace["RESULT_PATH"] = str(result)
+            namespace["_write_ready"]({"status": "ready", "pid": 123})
+            namespace["_write_result"]({"diagnostics": {"partial_candidates": 1}})
+            self.assertEqual(json.loads(ready.read_text())["transaction_id"], "synthetic-tx")
+            self.assertEqual(json.loads(result.read_text())["transaction_id"], "synthetic-tx")
+            self.assertNotIn(self.passphrase.hex(), ready.read_text())
+
+    def test_validator_rejects_per_database_raw_key_without_disclosing_it(self):
+        with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+            validate_account_candidate(self.message_raw.hex(), self.pages)
+        self.assertEqual(failure.exception.code, "account_key_validation_failed")
+        self.assertIn("session", str(failure.exception))
+        self.assertNotIn(self.message_raw.hex(), str(failure.exception))
+
+    def test_validator_accepts_shared_passphrase(self):
+        result = validate_account_candidate(self.passphrase.hex(), self.pages)
+        self.assertEqual(result["key_mode"], "sqlcipher_passphrase")
+        self.assertEqual(result["validated_roles"], ["message", "session"])
+        self.assertNotIn(self.passphrase.hex(), json.dumps(result))
+
+    def test_shared_raw_key_is_accepted_only_if_it_verifies_both_roles(self):
+        pages = {
+            "message": encrypted_page(self.passphrase, self.message_salt, raw=True),
+            "session": encrypted_page(self.passphrase, self.session_salt, raw=True),
+        }
+        result = validate_account_candidate(self.passphrase.hex(), pages)
+        self.assertEqual(result["key_mode"], "raw_enc_key")
+        namespace = self.namespace(account_probe_pages=pages)
+        for role in pages:
+            self.assertEqual(namespace["_candidate_page1_mode"](self.passphrase, pages[role]), "raw_enc_key")
+
+    def test_missing_short_and_plaintext_role_snapshots_fail_closed(self):
+        for invalid_pages in (
+            {},
+            {"message": self.pages["message"]},
+            {**self.pages, "session": b"short"},
+            {**self.pages, "session": b"SQLite format 3\x00" + b"\0" * 4080},
+        ):
+            with self.subTest(roles=list(invalid_pages)):
+                with self.assertRaises(MacOSDBKeyCaptureFailure):
+                    normalize_account_probe_pages(invalid_pages)
+                with self.assertRaises(MacOSDBKeyCaptureFailure):
+                    self.namespace(account_probe_pages=invalid_pages)
+
+    def test_invalid_candidate_errors_do_not_echo_input(self):
+        for candidate in ("secret-invalid-key-text", "aa" * 31, b"tiny"):
+            with self.subTest(candidate_type=type(candidate).__name__):
+                with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                    validate_account_candidate(candidate, self.pages)
+                self.assertEqual(failure.exception.code, "account_key_invalid")
+                self.assertNotIn(str(candidate), str(failure.exception))
+
+    def test_read_account_snapshots_follow_realtime_layout_and_survive_changes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "db_storage"
+            message = root / "message/message_0.db"
+            session = root / "session/session.db"
+            message.parent.mkdir(parents=True)
+            session.parent.mkdir(parents=True)
+            message.write_bytes(self.pages["message"])
+            session.write_bytes(self.pages["session"])
+            pages = read_account_probe_pages(message)
+            self.assertEqual(pages, self.pages)
+            self.assertTrue(validate_realtime_database_key(root, self.passphrase.hex())["valid"])
+            self.assertEqual(validate_account_candidate(self.passphrase.hex(), pages)["modes"],
+                             validate_realtime_database_key(root, self.passphrase.hex())["modes"])
+            session.write_bytes(b"changed during relogin")
+            self.assertEqual(pages, self.pages)
+            self.assertTrue(validate_account_candidate(self.passphrase.hex(), pages)["valid"])
+
+    def test_read_account_does_not_pick_a_neighbouring_accounts_session(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            selected = Path(temp_dir) / "account-a/db_storage/message/message_0.db"
+            other = Path(temp_dir) / "account-b/db_storage/session/session.db"
+            selected.parent.mkdir(parents=True)
+            other.parent.mkdir(parents=True)
+            selected.write_bytes(self.pages["message"])
+            other.write_bytes(self.pages["session"])
+            with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                read_account_probe_pages(selected)
+            self.assertEqual(failure.exception.code, "account_probe_missing")
+
+    def test_read_account_rejects_symlink_to_another_accounts_database(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "selected"
+            root.mkdir()
+            message = root / "message_0.db"
+            message.write_bytes(self.pages["message"])
+            other = Path(temp_dir) / "other-session.db"
+            other.write_bytes(self.pages["session"])
+            (root / "session.db").symlink_to(other)
+            with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                read_account_probe_pages(message)
+            self.assertEqual(failure.exception.code, "account_probe_path_invalid")
+
+    def test_selected_probe_symlink_cannot_silently_select_another_account(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "selected/db_storage"
+            other = Path(temp_dir) / "other/db_storage"
+            root.mkdir(parents=True)
+            other.mkdir(parents=True)
+            (other / "message_0.db").write_bytes(self.pages["message"])
+            (other / "session.db").write_bytes(self.pages["session"])
+            selected = root / "message_0.db"
+            selected.symlink_to(other / "message_0.db")
+            with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                read_account_probe_pages(selected)
+            self.assertEqual(failure.exception.code, "account_probe_path_invalid")
+
+    def test_legacy_flat_and_combined_roles_follow_realtime_rules(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            message = root / "msg0.db"
+            message.write_bytes(self.pages["message"])
+            (root / "Session.db").write_bytes(self.pages["session"])
+            self.assertEqual(read_account_probe_pages(message, account_root=root), self.pages)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            combined = root / "MicroMsg.db"
+            combined.write_bytes(self.pages["message"])
+            paths = resolve_account_probe_paths(combined)
+            self.assertEqual(paths, {"message": combined.resolve(), "session": combined.resolve()})
+
+    def test_capture_wrapper_uses_snapshots_and_revalidates_structured_result(self):
+        from wechat_decrypt_tool.macos_clone_capture import capture_salt_matched_passphrase
+
+        def fake_lldb(command, *, timeout):
+            command_path = Path(command)
+            result_path = command_path.parent / "result.json"
+            script_path = command_path.parent / "capture_callback.py"
+            self.assertIn("ACCOUNT_PROBE_PAGES", script_path.read_text())
+            result_path.write_text(json.dumps({
+                "passphrase": self.passphrase.hex(), "salt": self.message_salt.hex(),
+                "transaction_id": "synthetic-tx", "diagnostics": {"partial_candidates": 1},
+            }))
+            return ""
+
+        with (
+            patch("wechat_decrypt_tool.macos_clone_capture.platform.machine", return_value="arm64"),
+            patch("wechat_decrypt_tool.macos_clone_capture.shutil.which", return_value="/fake/lldb"),
+            patch("wechat_decrypt_tool.macos_clone_capture._build_lldb_capture_command", side_effect=lambda path, timeout: str(path)),
+            patch("wechat_decrypt_tool.macos_clone_capture._run_as_administrator", side_effect=fake_lldb),
+        ):
+            result = capture_salt_matched_passphrase(
+                pid=123, expected_salts=[self.message_salt], probe_db_path="/nonexistent/not-read.db",
+                account_probe_pages=self.pages, return_details=True, transaction_id="synthetic-tx",
+            )
+        self.assertEqual(result["passphrase"], self.passphrase.hex())
+        self.assertEqual(result["key_mode"], "sqlcipher_passphrase")
+        self.assertEqual(result["validated_roles"], ["message", "session"])
+
+    def test_capture_wrapper_does_not_trust_raw_or_stale_lldb_result(self):
+        from wechat_decrypt_tool.macos_clone_capture import capture_salt_matched_passphrase
+
+        for candidate, transaction, expected_code in (
+            (self.message_raw, "synthetic-tx", "account_key_validation_failed"),
+            (self.passphrase, "stale-tx", "capture_transaction_mismatch"),
+        ):
+            def fake_lldb(command, *, timeout):
+                (Path(command).parent / "result.json").write_text(json.dumps({
+                    "passphrase": candidate.hex(), "salt": self.message_salt.hex(),
+                    "transaction_id": transaction,
+                }))
+                return ""
+
+            with (
+                self.subTest(expected_code=expected_code),
+                patch("wechat_decrypt_tool.macos_clone_capture.platform.machine", return_value="arm64"),
+                patch("wechat_decrypt_tool.macos_clone_capture.shutil.which", return_value="/fake/lldb"),
+                patch("wechat_decrypt_tool.macos_clone_capture._build_lldb_capture_command", side_effect=lambda path, timeout: str(path)),
+                patch("wechat_decrypt_tool.macos_clone_capture._run_as_administrator", side_effect=fake_lldb),
+            ):
+                with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                    capture_salt_matched_passphrase(
+                        pid=123, expected_salts=[self.message_salt], probe_db_path="/nonexistent/not-read.db",
+                        account_probe_pages=self.pages, return_details=True, transaction_id="synthetic-tx",
+                    )
+            self.assertEqual(failure.exception.code, expected_code)
+            self.assertNotIn(candidate.hex(), str(failure.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_clone_capture.py
+++ b/tests/test_macos_clone_capture.py
@@ -181,7 +181,7 @@ class TestMacOSCloneCapture(unittest.TestCase):
             debug_root = Path(temporary_dir)
 
             def write_preflight(_command, *, timeout):
-                self.assertEqual(timeout, 90)
+                self.assertEqual(timeout, 180)
                 (debug_root / "breakpoint-preflight.json").write_text(
                     json.dumps(
                         {
@@ -239,6 +239,80 @@ class TestMacOSCloneCapture(unittest.TestCase):
             self.assertEqual(context.exception.code, "capture_breakpoints_unavailable")
             self.assertFalse((debug_root / "breakpoint-preflight.json").exists())
 
+    def test_breakpoint_preflight_rejects_deferred_system_symbol_location(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            debug_root = Path(temporary_dir)
+
+            def write_preflight(_command, *, timeout):
+                self.assertEqual(timeout, 180)
+                (debug_root / "breakpoint-preflight.json").write_text(
+                    json.dumps(
+                        {
+                            "pid": 321,
+                            "pbkdf_locations": 0,
+                            "pbkdf_total_locations": 1,
+                            "pbkdf_deferred": True,
+                            "key_return_locations": 0,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                return "WEDATA_BREAKPOINT_PREFLIGHT 0 1 0"
+
+            with (
+                patch("wechat_decrypt_tool.macos_clone_capture.platform.machine", return_value="arm64"),
+                patch("wechat_decrypt_tool.macos_clone_capture.shutil.which", return_value="/usr/bin/lldb"),
+                patch(
+                    "wechat_decrypt_tool.macos_clone_capture._run_as_administrator",
+                    side_effect=write_preflight,
+                ),
+            ):
+                with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                    preflight_capture_breakpoints(pid=321, debug_root=debug_root)
+
+            self.assertEqual(failure.exception.code, "capture_breakpoints_unavailable")
+            self.assertFalse((debug_root / "breakpoint-preflight.json").exists())
+
+    def test_breakpoint_preflight_rejects_verified_binary_import_when_lldb_reports_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            debug_root = Path(temporary_dir)
+
+            def write_preflight(_command, *, timeout):
+                (debug_root / "breakpoint-preflight.json").write_text(
+                    json.dumps(
+                        {
+                            "pid": 321,
+                            "pbkdf_locations": 0,
+                            "pbkdf_total_locations": 0,
+                            "key_return_locations": 0,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                return "WEDATA_BREAKPOINT_PREFLIGHT 0 0 0"
+
+            with (
+                patch("wechat_decrypt_tool.macos_clone_capture.platform.machine", return_value="arm64"),
+                patch("wechat_decrypt_tool.macos_clone_capture.shutil.which", return_value="/usr/bin/lldb"),
+                patch(
+                    "wechat_decrypt_tool.macos_clone_capture._run_as_administrator",
+                    side_effect=write_preflight,
+                ),
+                patch(
+                    "wechat_decrypt_tool.macos_clone_capture._wechat_binary_imports_pbkdf",
+                    return_value=True,
+                ),
+            ):
+                with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                    preflight_capture_breakpoints(
+                        pid=321,
+                        debug_root=debug_root,
+                        wechat_app=debug_root / "synthetic-missing-WeChat.app",
+                    )
+
+            self.assertEqual(failure.exception.code, "capture_breakpoints_unavailable")
+            self.assertFalse((debug_root / "breakpoint-preflight.json").exists())
+
     def test_prepared_preflight_cleans_private_clone_after_failure(self) -> None:
         debug_root = Path("/tmp/wcda-test-debug")
         debug_app = debug_root / "WeChat-Debug.app"
@@ -277,14 +351,12 @@ class TestMacOSCloneCapture(unittest.TestCase):
         )
 
         ast.parse(script)
-        self.assertIn("algorithm != 2", script)
-        self.assertIn("password_len != 32", script)
+        self.assertIn("password_len not in (32, 64)", script)
         self.assertIn("salt_len != 16", script)
-        self.assertIn("prf != 5", script)
-        self.assertIn("rounds not in (2, 256000)", script)
+        self.assertIn("pbkdf_profiles", script)
         self.assertIn("EXPECTED_HMAC_SALTS", script)
-        self.assertIn('source = "pbkdf2_hmac_password"', script)
-        self.assertIn('source = "pbkdf2_passphrase"', script)
+        self.assertIn('source = "pbkdf_hmac_password"', script)
+        self.assertIn('source = "pbkdf_database_password"', script)
         self.assertIn(salt, script)
         self.assertIn("database_salt = EXPECTED_HMAC_SALTS.get", script)
         self.assertIn("os.fsync", script)
@@ -348,16 +420,22 @@ class TestMacOSCloneCapture(unittest.TestCase):
                 return types.SimpleNamespace(GetValueAsUnsigned=lambda: registers[name])
 
         captured = []
+        namespace["_write_result"] = lambda _payload: True
         namespace["_record_diagnostic"] = lambda _name: None
         namespace["_save_valid_candidate"] = lambda candidate, database_salt, source, _process: captured.append(
             (candidate, database_salt, source)
         )
         namespace["_pbkdf_callback"](FakeFrame(), None, None)
 
-        self.assertEqual(captured, [(encryption_key, salt.hex(), "pbkdf2_hmac_password")])
+        self.assertEqual(captured, [(encryption_key, salt.hex(), "pbkdf_hmac_password")])
+        registers["x0"] = 99
+        registers["x5"] = 99
         registers["x6"] = 3
         namespace["_pbkdf_callback"](FakeFrame(), None, None)
-        self.assertEqual(len(captured), 1)
+        self.assertEqual(len(captured), 2)
+        registers["x2"] = 31
+        namespace["_pbkdf_callback"](FakeFrame(), None, None)
+        self.assertEqual(len(captured), 2)
 
     def test_capture_reports_debug_process_exit_without_waiting_for_generic_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_dir:

--- a/tests/test_macos_db_key_capture.py
+++ b/tests/test_macos_db_key_capture.py
@@ -46,6 +46,9 @@ DEBUG_SIGNATURE = {
     "identifier": "com.tencent.xinWeChat",
     "cdhash": "debug123",
 }
+DEBUG_IDENTITY = {
+    "version": "4.1.12", "build": "269341", "cdhash": "debug123", "device": 1, "inode": 2,
+}
 
 
 class TestMacOSDBKeyCapture(unittest.TestCase):
@@ -56,6 +59,8 @@ class TestMacOSDBKeyCapture(unittest.TestCase):
 
         def record(payload):
             self.assertEqual(payload["backup_path"], str(backup))
+            if events:
+                self.assertEqual(payload["debug_identity"], DEBUG_IDENTITY)
             events.append("state")
 
         sign_commands: list[list[str]] = []
@@ -69,9 +74,10 @@ class TestMacOSDBKeyCapture(unittest.TestCase):
         with (
             patch(
                 "wechat_decrypt_tool.macos_db_key_capture.inspect_wechat_signature",
-                side_effect=[OFFICIAL_SIGNATURE, DEBUG_SIGNATURE, DEBUG_SIGNATURE],
+                side_effect=[OFFICIAL_SIGNATURE, DEBUG_SIGNATURE, OFFICIAL_SIGNATURE, DEBUG_SIGNATURE, OFFICIAL_SIGNATURE],
             ),
             patch("wechat_decrypt_tool.macos_db_key_capture.os.access", return_value=True),
+            patch("wechat_decrypt_tool.macos_db_key_capture.os.path.lexists", return_value=False),
             patch("wechat_decrypt_tool.macos_db_key_capture.backup_original_wechat", return_value=(backup, False)),
             patch(
                 "wechat_decrypt_tool.macos_db_key_capture.verify_original_wechat_backup",
@@ -84,18 +90,21 @@ class TestMacOSDBKeyCapture(unittest.TestCase):
                 return_value=Path("/tmp/staged.app"),
             ),
             patch("wechat_decrypt_tool.macos_db_key_capture._has_compatible_in_place_signature", return_value=True),
+            patch("wechat_decrypt_tool.macos_db_key_capture._wechat_bundle_identity", return_value=DEBUG_IDENTITY),
+            patch("wechat_decrypt_tool.macos_db_key_capture._debug_identity_matches", return_value=True),
             patch("wechat_decrypt_tool.macos_db_key_capture._atomic_swap_paths") as swap,
             patch("wechat_decrypt_tool.macos_db_key_capture._run", side_effect=run),
         ):
             result = ensure_wechat_in_place_debuggable(official, backup.parent, before_resign=record)
 
-        self.assertEqual(events, ["state", "sign"])
+        self.assertEqual(events, ["state", "sign", "state"])
         self.assertNotIn("--deep", sign_commands[0])
         self.assertIn("--preserve-metadata=entitlements", sign_commands[0])
         self.assertEqual(sign_commands[0][-1], "/tmp/staged.app")
         swap.assert_called_once_with(official, Path("/tmp/staged.app"))
         self.assertTrue(result["wechat_resigned"])
         self.assertTrue(result["backup_verified"])
+        self.assertEqual(result["debug_identity"], DEBUG_IDENTITY)
 
     def test_in_place_preparation_rejects_backup_identity_mismatch_before_mutation(self) -> None:
         official = Path("/tmp/WeChat.app")
@@ -124,6 +133,7 @@ class TestMacOSDBKeyCapture(unittest.TestCase):
         with (
             patch("wechat_decrypt_tool.macos_db_key_capture.inspect_wechat_signature", return_value=OFFICIAL_SIGNATURE),
             patch("wechat_decrypt_tool.macos_db_key_capture.os.access", return_value=True),
+            patch("wechat_decrypt_tool.macos_db_key_capture.os.path.lexists", return_value=False),
             patch("wechat_decrypt_tool.macos_db_key_capture.backup_original_wechat", return_value=(backup, False)),
             patch(
                 "wechat_decrypt_tool.macos_db_key_capture.verify_original_wechat_backup",

--- a/tests/test_macos_inplace_capture.py
+++ b/tests/test_macos_inplace_capture.py
@@ -1,5 +1,8 @@
+"""Workflow contracts with synthetic pages and a temporary, fake application."""
+
 import json
 import os
+import plistlib
 import sys
 import tempfile
 import unittest
@@ -9,214 +12,196 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
+from wechat_decrypt_tool import macos_inplace_capture as workflow
 from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
-from wechat_decrypt_tool.macos_inplace_capture import (
-    _read_state,
-    _safe_backup_from_state,
-    _write_state,
-    capture_prepared_in_place,
-    cleanup_in_place_capture,
-    native_capture_monitor_ready,
-    recover_stale_in_place_capture,
-)
 
 OFFICIAL_SIGNATURE = {
-    "valid": True,
-    "ad_hoc": False,
-    "team_identifier": "5A4RE8SF68",
-    "identifier": "com.tencent.xinWeChat",
+    "valid": True, "ad_hoc": False, "team_identifier": "5A4RE8SF68",
+    "identifier": "com.tencent.xinWeChat", "cdhash": "abc123",
 }
+SYNTHETIC_PAGES = {"message": b"m" * 4096, "session": b"s" * 4096}
+VALIDATION = {"key_mode": "sqlcipher_passphrase", "validated_roles": ["message", "session"]}
+RECOVERY = {"official_wechat_verified": True, "official_wechat_restored": True}
 
 
 class TestMacOSInPlaceCapture(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.app = self.root / "WeChat.app"
+        (self.app / "Contents").mkdir(parents=True)
+        (self.app / "Contents/Info.plist").write_bytes(plistlib.dumps({
+            "CFBundleShortVersionString": "4.1.12", "CFBundleVersion": "269341",
+        }))
+        self.debug = self.root / "debug"
+        self.debug.mkdir()
+        self.backups = self.root / "backups"
+        self.backups.mkdir()
+        self.enterContext(patch.object(workflow, "normalize_wechat_app_path", return_value=self.app))
+        self.acquire = self.enterContext(patch.object(workflow, "_acquire_installation_lock", return_value={"transaction_id": "test-transaction"}))
+        self.release = self.enterContext(patch.object(workflow, "_release_installation_lock"))
+        self.terminate = self.enterContext(patch.object(workflow, "_terminate_native_capture_processes"))
+        self.enterContext(patch.object(workflow, "_candidate_bundle_pids", return_value=[321]))
+        # A missed mock must fail here, never inspect/launch/sign/attach a real app.
+        self.enterContext(patch("subprocess.run", side_effect=AssertionError("external process execution is forbidden in workflow tests")))
+        self.enterContext(patch.object(workflow, "capture_native_wcdb_key", side_effect=AssertionError("native capture must be mocked")))
+        self.enterContext(patch.object(workflow, "capture_salt_matched_passphrase", side_effect=AssertionError("LLDB capture must be mocked")))
+        self.enterContext(patch.object(workflow, "save_passphrase", side_effect=AssertionError("credential persistence must be mocked")))
+
+    def write_probes(self) -> Path:
+        account = self.root / "db_storage"
+        for role, page in SYNTHETIC_PAGES.items():
+            directory = account / role
+            directory.mkdir(parents=True)
+            (directory / ("message_0.db" if role == "message" else "session.db")).write_bytes(page)
+        return account / "message/message_0.db"
+
+    def capture_state(self, *, sidecar: bool = True) -> dict:
+        preflight = {
+            "pid": 321, "pbkdf_locations": 1, "key_return_locations": 0,
+            "capture_backend": "native", "transaction_id": "test-transaction",
+        }
+        if sidecar:
+            (self.debug / "breakpoint-preflight.json").write_text(json.dumps(preflight), encoding="utf-8")
+        return {"transaction_id": "test-transaction", "preflight": preflight}
+
     def test_state_is_atomic_private_and_non_secret(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            root = Path(temp_dir)
-            target = _write_state(
-                root,
-                {
-                    "schema_version": 1,
-                    "wechat_app_path": "/Applications/WeChat.app",
-                    "backup_path": "/Volumes/BackupVolume/backups/WeChat-original.zip",
-                },
-            )
-            payload = json.loads(target.read_text(encoding="utf-8"))
-            self.assertNotIn("passphrase", payload)
-            self.assertNotIn("key", payload)
-            self.assertEqual(os.stat(target).st_mode & 0o777, 0o600)
-            self.assertEqual(_read_state(root), payload)
+        target = workflow._write_state(self.debug, {
+            "schema_version": 1, "wechat_app_path": str(self.app),
+            "backup_path": str(self.backups / "WeChat-original.zip"),
+        })
+        payload = json.loads(target.read_text(encoding="utf-8"))
+        self.assertNotIn("passphrase", payload)
+        self.assertNotIn("key", payload)
+        self.assertEqual(os.stat(target).st_mode & 0o777, 0o600)
+        self.assertEqual(workflow._read_state(self.debug), payload)
 
     def test_backup_path_validation_does_not_require_nas_online(self) -> None:
-        root = Path("/Volumes/BackupVolume/WCDA/output/wechat-app-backups")
-        expected = root / "WeChat-4.1.12-269341-original.zip"
-        self.assertEqual(_safe_backup_from_state({"backup_path": str(expected)}, root), expected)
+        offline = self.root / "offline-volume/backups"
+        expected = offline / "WeChat-4.1.12-269341-original.zip"
+        self.assertFalse(offline.exists())
+        self.assertEqual(workflow._safe_backup_from_state({"backup_path": str(expected)}, offline), expected)
 
     def test_backup_path_escape_is_rejected(self) -> None:
-        root = Path("/Volumes/BackupVolume/WCDA/output/wechat-app-backups")
         with self.assertRaises(MacOSDBKeyCaptureFailure) as context:
-            _safe_backup_from_state({"backup_path": "/tmp/WeChat-original.zip"}, root)
+            workflow._safe_backup_from_state({"backup_path": str(self.root / "WeChat-original.zip")}, self.backups)
         self.assertEqual(context.exception.code, "official_backup_path_unsafe")
 
     def test_stale_state_restores_then_removes_state(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            debug_root = Path(temp_dir)
-            backup_root = debug_root / "backups"
-            backup_root.mkdir()
-            backup = backup_root / "WeChat-4.1.12-original.zip"
-            backup.touch()
-            _write_state(
-                debug_root,
-                {
-                    "schema_version": 1,
-                    "wechat_app_path": "/Applications/WeChat.app",
-                    "backup_path": str(backup),
-                    "version": "4.1.12",
-                    "build": "269341",
-                    "official_cdhash": "abc123",
-                },
-            )
-            with (
-                patch("wechat_decrypt_tool.macos_inplace_capture.normalize_wechat_app_path", return_value=Path("/Applications/WeChat.app")),
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture.restore_official_wechat_if_needed",
-                    return_value={"official_wechat_verified": True, "official_wechat_restored": True},
-                ) as restore,
-                patch("wechat_decrypt_tool.macos_inplace_capture.inspect_wechat_signature", return_value=OFFICIAL_SIGNATURE),
-            ):
-                result = recover_stale_in_place_capture(
-                    "/Applications/WeChat.app", backup_root=backup_root, debug_root=debug_root
-                )
-            self.assertTrue(result["official_wechat_restored"])
-            self.assertFalse((debug_root / "prepared-in-place-capture.json").exists())
-            restore.assert_called_once()
+        backup = self.backups / "WeChat-4.1.12-original.zip"
+        backup.touch()
+        workflow._write_state(self.debug, {
+            "schema_version": 1, "wechat_app_path": str(self.app), "backup_path": str(backup),
+            "version": "4.1.12", "build": "269341", "official_cdhash": "abc123",
+        })
+        with (
+            patch.object(workflow, "restore_official_wechat_if_needed", return_value=RECOVERY) as restore,
+            patch.object(workflow, "inspect_wechat_signature", return_value=OFFICIAL_SIGNATURE),
+        ):
+            result = workflow.recover_stale_in_place_capture(self.app, backup_root=self.backups, debug_root=self.debug)
+        self.assertTrue(result["official_wechat_restored"])
+        self.assertFalse((self.debug / "prepared-in-place-capture.json").exists())
+        restore.assert_called_once_with(self.app, backup, expected_version=("4.1.12", "269341"), expected_cdhash="abc123", expected_debug_identity=None)
+        self.acquire.assert_called_once_with(self.app, self.debug)
+        self.release.assert_called_once_with(self.app, self.debug)
+        self.terminate.assert_called_once_with(self.debug)
 
     def test_cancel_without_state_verifies_official_without_mutation(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir, patch(
-            "wechat_decrypt_tool.macos_inplace_capture.normalize_wechat_app_path", return_value=Path("/Applications/WeChat.app")
-        ), patch("wechat_decrypt_tool.macos_inplace_capture.inspect_wechat_signature", return_value=OFFICIAL_SIGNATURE):
-            result = cleanup_in_place_capture(
-                "/Applications/WeChat.app", backup_root=Path(temp_dir) / "backups", debug_root=Path(temp_dir)
-            )
+        with (
+            patch.object(workflow, "inspect_wechat_signature", return_value=OFFICIAL_SIGNATURE),
+            patch.object(workflow, "restore_official_wechat_if_needed") as restore,
+        ):
+            result = workflow.cleanup_in_place_capture(self.app, backup_root=self.backups, debug_root=self.debug)
         self.assertTrue(result["official_wechat_verified"])
         self.assertFalse(result["official_wechat_restored"])
+        restore.assert_not_called()
+        self.acquire.assert_not_called()
+        self.release.assert_called_once_with(self.app, self.debug)
 
     def test_capture_failure_always_requests_restore(self) -> None:
-        debug_root = Path("/tmp/wcda-inplace-test")
-        official = Path("/Applications/WeChat.app")
         failure = MacOSDBKeyCaptureFailure("debug_wechat_not_running", "closed", wechat_modified=True)
         with (
-            patch("wechat_decrypt_tool.macos_inplace_capture.normalize_wechat_app_path", return_value=official),
-            patch("wechat_decrypt_tool.macos_inplace_capture._require_prepared_process", side_effect=failure),
-            patch("wechat_decrypt_tool.macos_inplace_capture.has_pending_in_place_capture", return_value=True),
-            patch("wechat_decrypt_tool.macos_inplace_capture._restore_after_terminal_path") as restore,
+            patch.object(workflow, "_require_prepared_process", side_effect=failure),
+            patch.object(workflow, "has_pending_in_place_capture", return_value=True),
+            patch.object(workflow, "_restore_after_terminal_path") as restore,
         ):
-            with self.assertRaises(MacOSDBKeyCaptureFailure):
-                result = capture_prepared_in_place(
-                    official,
-                    backup_root=Path("/Volumes/BackupVolume/backups"),
-                    probe_db_path=Path("/tmp/message_0.db"),
-                    debug_root=debug_root,
-                )
-        restore.assert_called_once()
+            with self.assertRaises(MacOSDBKeyCaptureFailure) as error:
+                workflow.capture_prepared_in_place(self.app, backup_root=self.backups, probe_db_path=self.root / "message_0.db", debug_root=self.debug)
+        self.assertEqual(error.exception.code, "debug_wechat_not_running")
+        restore.assert_called_once_with(self.app, backup_root=self.backups, debug_root=self.debug, original_error=failure)
 
-    def test_native_monitor_ready_requires_valid_private_status(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            debug_root = Path(temp_dir)
-            ready = debug_root / "native-capture-ready.json"
-            ready.write_text(
-                json.dumps({"status": "ready", "method": "macos_native_mach", "pid": 321}),
-                encoding="utf-8",
-            )
-            self.assertTrue(native_capture_monitor_ready(debug_root=debug_root))
-            ready.write_text(json.dumps({"status": "ready", "pid": 321}), encoding="utf-8")
-            self.assertFalse(native_capture_monitor_ready(debug_root=debug_root))
-
-    def test_capture_uses_native_monitor_and_removes_probe_copy(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            debug_root = Path(temp_dir)
-            probe = debug_root / "message_0.db"
-            probe.write_bytes(bytes(range(256)) * 16)
-            (debug_root / "breakpoint-preflight.json").write_text(
-                json.dumps({"pid": 222, "stub_file_address": 4096}),
-                encoding="utf-8",
-            )
-            with (
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture.normalize_wechat_app_path",
-                    return_value=Path("/Applications/WeChat.app"),
-                ),
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture._require_prepared_process",
-                    return_value=({}, 321),
-                ),
-                patch("wechat_decrypt_tool.macos_inplace_capture._candidate_bundle_pids", return_value=[654, 321]),
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture.capture_native_wcdb_key",
-                    return_value={"db_key": "ab" * 32, "method": "macos_native_mach", "validated": True},
-                ) as capture,
-                patch("wechat_decrypt_tool.macos_inplace_capture._validate_captured_passphrase"),
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture.save_passphrase",
-                    return_value=debug_root / "key.json",
-                ),
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture._restore_after_terminal_path",
-                    return_value={"official_wechat_verified": True, "official_wechat_restored": True},
-                ),
-            ):
-                result = capture_prepared_in_place(
-                    "/Applications/WeChat.app",
-                    backup_root=debug_root / "backups",
-                    probe_db_path=probe,
-                    debug_root=debug_root,
-                )
-
-            self.assertEqual(result["method"], "macos_native_mach")
-            self.assertEqual(capture.call_args.kwargs["pid"], 654)
-            self.assertFalse(capture.call_args.kwargs["probe_page1_path"].exists())
-            self.assertFalse((debug_root / "native-capture-ready.json").exists())
+    def test_capture_uses_preflight_target_validates_both_roles_and_restores_before_save(self) -> None:
+        probe = self.write_probes()
+        state = self.capture_state()
+        events = []
+        with (
+            patch.object(workflow, "_require_prepared_process", return_value=(state, 321)),
+            patch.object(workflow, "capture_native_wcdb_key", return_value={"db_key": "ab" * 32, "method": "macos_native_mach"}) as capture,
+            patch("wechat_decrypt_tool.macos_capture_validation.validate_account_candidate", side_effect=lambda *_: events.append("validate") or VALIDATION) as validate,
+            patch.object(workflow, "_restore_after_terminal_path", side_effect=lambda *a, **kw: events.append("restore") or RECOVERY),
+            patch.object(workflow, "save_passphrase", side_effect=lambda *_: events.append("save") or self.debug / "key.json") as save,
+        ):
+            result = workflow.capture_prepared_in_place(self.app, backup_root=self.backups, probe_db_path=probe, debug_root=self.debug)
+        self.assertEqual(events, ["validate", "restore", "save"])
+        self.assertEqual(capture.call_args.kwargs["pid"], 321)
+        self.assertEqual(capture.call_args.kwargs["transaction_id"], "test-transaction")
+        validate.assert_called_once_with("ab" * 32, SYNTHETIC_PAGES)
+        save.assert_called_once_with("ab" * 32)
+        self.assertTrue(result["account_roles_validated"])
+        self.assertEqual(result["validated_roles"], ["message", "session"])
 
     def test_capture_can_defer_cache_until_full_account_validation(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            debug_root = Path(temp_dir)
-            probe = debug_root / "message_0.db"
-            probe.write_bytes(bytes(range(256)) * 16)
-            (debug_root / "breakpoint-preflight.json").write_text(
-                json.dumps({"pid": 321, "stub_file_address": 4096}),
-                encoding="utf-8",
-            )
-            with (
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture.normalize_wechat_app_path",
-                    return_value=Path("/Applications/WeChat.app"),
-                ),
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture._require_prepared_process",
-                    return_value=({}, 321),
-                ),
-                patch("wechat_decrypt_tool.macos_inplace_capture._candidate_bundle_pids", return_value=[321]),
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture.capture_native_wcdb_key",
-                    return_value={"db_key": "ab" * 32, "method": "macos_native_mach", "validated": True},
-                ),
-                patch("wechat_decrypt_tool.macos_inplace_capture._validate_captured_passphrase"),
-                patch("wechat_decrypt_tool.macos_inplace_capture.save_passphrase") as save,
-                patch(
-                    "wechat_decrypt_tool.macos_inplace_capture._restore_after_terminal_path",
-                    return_value={"official_wechat_verified": True, "official_wechat_restored": True},
-                ),
-            ):
-                result = capture_prepared_in_place(
-                    "/Applications/WeChat.app",
-                    backup_root=debug_root / "backups",
-                    probe_db_path=probe,
-                    save_result=False,
-                    debug_root=debug_root,
-                )
+        probe = self.write_probes()
+        state = self.capture_state()
+        with (
+            patch.object(workflow, "_require_prepared_process", return_value=(state, 321)),
+            patch.object(workflow, "capture_native_wcdb_key", return_value={"db_key": "ab" * 32, "method": "macos_native_mach"}),
+            patch("wechat_decrypt_tool.macos_capture_validation.validate_account_candidate", return_value=VALIDATION) as validate,
+            patch.object(workflow, "save_passphrase") as save,
+            patch.object(workflow, "_restore_after_terminal_path", return_value=RECOVERY) as restore,
+        ):
+            result = workflow.capture_prepared_in_place(self.app, backup_root=self.backups, probe_db_path=probe, save_result=False, debug_root=self.debug)
+        self.assertEqual(result["db_key"], "ab" * 32)
+        self.assertEqual(result["cache_path"], "")
+        validate.assert_called_once_with("ab" * 32, SYNTHETIC_PAGES)
+        restore.assert_called_once()
+        save.assert_not_called()
 
-            self.assertEqual(result["db_key"], "ab" * 32)
-            self.assertEqual(result["cache_path"], "")
-            save.assert_not_called()
+    def test_capture_uses_preflight_metadata_from_recovery_state_when_sidecar_file_is_missing(self) -> None:
+        probe = self.write_probes()
+        state = self.capture_state(sidecar=False)
+        with (
+            patch.object(workflow, "_require_prepared_process", return_value=(state, 321)),
+            patch.object(workflow, "capture_native_wcdb_key", return_value={"db_key": "ab" * 32, "method": "macos_native_mach"}) as capture,
+            patch("wechat_decrypt_tool.macos_capture_validation.validate_account_candidate", return_value=VALIDATION) as validate,
+            patch.object(workflow, "save_passphrase") as save,
+            patch.object(workflow, "_restore_after_terminal_path", return_value=RECOVERY),
+        ):
+            result = workflow.capture_prepared_in_place(self.app, backup_root=self.backups, probe_db_path=probe, save_result=False, debug_root=self.debug)
+        self.assertEqual(result["db_key"], "ab" * 32)
+        self.assertEqual(result["cache_path"], "")
+        self.assertFalse((self.debug / "breakpoint-preflight.json").exists())
+        self.assertEqual(capture.call_args.kwargs["pid"], 321)
+        self.assertEqual(capture.call_args.kwargs["transaction_id"], state["transaction_id"])
+        validate.assert_called_once_with("ab" * 32, SYNTHETIC_PAGES)
+        save.assert_not_called()
+
+    def test_missing_session_snapshot_never_starts_capture(self) -> None:
+        probe = self.root / "message_0.db"
+        probe.write_bytes(SYNTHETIC_PAGES["message"])
+        state = self.capture_state()
+        with (
+            patch.object(workflow, "_require_prepared_process", return_value=(state, 321)),
+            patch.object(workflow, "capture_native_wcdb_key") as capture,
+            patch.object(workflow, "save_passphrase") as save,
+            patch.object(workflow, "has_pending_in_place_capture", return_value=True),
+            patch.object(workflow, "_restore_after_terminal_path", return_value=RECOVERY) as restore,
+        ):
+            with self.assertRaises(MacOSDBKeyCaptureFailure) as error:
+                workflow.capture_prepared_in_place(self.app, backup_root=self.backups, probe_db_path=probe, debug_root=self.debug)
+        self.assertEqual(error.exception.code, "account_probe_missing")
+        capture.assert_not_called()
+        save.assert_not_called()
+        restore.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_macos_lldb_breakpoint_plan.py
+++ b/tests/test_macos_lldb_breakpoint_plan.py
@@ -1,0 +1,250 @@
+"""Read-only synthetic Mach-O output and fake LLDB; no real debugger attach."""
+
+import ast
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from wechat_decrypt_tool.macos_clone_capture import (
+    WECHAT_PBKDF_STUB_POINTS,
+    build_lldb_breakpoint_preflight_script,
+    build_lldb_salt_capture_script,
+    capture_salt_matched_passphrase,
+    preflight_capture_breakpoints,
+    resolve_lldb_pbkdf_stub_plan,
+)
+from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
+
+SYNTHETIC_UUID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+STUB_OFFSET = 0x1234
+LOAD_COMMANDS = f"Load command 15\n     cmd LC_UUID\n cmdsize 24\n    uuid {SYNTHETIC_UUID}\n"
+IMPORTS = f"Indirect symbols for (__TEXT,__stubs) 1 entries\naddress index name\n0x{STUB_OFFSET:x} 6 _CCKeyDerivationPBKDF\n"
+
+
+class FakeAddress:
+    def __init__(self, *, valid=True, executable=True, loaded=True):
+        self.valid, self.executable, self.loaded = valid, executable, loaded
+
+    def IsValid(self):
+        return self.valid
+
+    def GetSection(self):
+        return types.SimpleNamespace(IsValid=lambda: True, GetPermissions=lambda: 4 if self.executable else 0, GetName=lambda: "__stubs")
+
+    def GetLoadAddress(self, target):
+        return 0x12345000 if self.loaded else -1
+
+
+class FakeBreakpoint:
+    def __init__(self, address, *, resolved=True):
+        self.address, self.resolved = address, resolved
+
+    def GetNumLocations(self):
+        return 1
+
+    def GetLocationAtIndex(self, index):
+        return types.SimpleNamespace(IsResolved=lambda: self.resolved, GetAddress=lambda: self.address)
+
+    def SetEnabled(self, enabled):
+        pass
+
+    def SetScriptCallbackFunction(self, name):
+        pass
+
+    def SetAutoContinue(self, enabled):
+        pass
+
+
+class TestMacOSLLDBBreakpointPlan(unittest.TestCase):
+    def namespace(self, script):
+        ast.parse(script)
+        namespace = {"__name__": "synthetic_breakpoints"}
+        fake_lldb = types.SimpleNamespace(LLDB_INVALID_ADDRESS=-1, ePermissionsExecutable=4, SBSection=lambda: types.SimpleNamespace(IsValid=lambda: False))
+        with patch.dict(sys.modules, {"lldb": fake_lldb}):
+            exec(compile(script, "<synthetic-lldb>", "exec"), namespace)
+        return namespace
+
+    def scripts(self, plan=None):
+        plan = plan if plan is not None else {SYNTHETIC_UUID: STUB_OFFSET}
+        return (
+            build_lldb_breakpoint_preflight_script(Path("/synthetic/preflight.json"), pbkdf_stub_plan=plan),
+            build_lldb_salt_capture_script(Path("/synthetic/result.json"), [b"x" * 16], probe_page1=b"x" * 4096, pbkdf_stub_plan=plan),
+        )
+
+    def target(self, *, address=None, uuid=SYNTHETIC_UUID, stub_resolved=True, name_resolved=False):
+        address = address or FakeAddress()
+        process = types.SimpleNamespace(GetProcessID=lambda: 123, Detach=Mock(return_value=types.SimpleNamespace(Success=lambda: True)))
+        module = types.SimpleNamespace(
+            GetUUIDString=lambda: uuid, ResolveFileAddress=Mock(return_value=address),
+            GetFileSpec=lambda: types.SimpleNamespace(GetFilename=lambda: "wechat.dylib"),
+        )
+        target = types.SimpleNamespace(
+            GetProcess=lambda: process,
+            module_iter=lambda: iter([module]),
+            BreakpointCreateByName=lambda name: FakeBreakpoint(address, resolved=name_resolved),
+            BreakpointCreateBySBAddress=Mock(side_effect=lambda address: FakeBreakpoint(address, resolved=stub_resolved)),
+        )
+        return target, module, process
+
+    def test_resolver_binds_unknown_build_to_arm64_uuid_and_exact_import_stub(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app = Path(temp_dir) / "Synthetic.app"
+            dylib = app / "Contents/Resources/wechat.dylib"
+            dylib.parent.mkdir(parents=True)
+            dylib.write_bytes(b"synthetic Mach-O placeholder")
+            with patch("wechat_decrypt_tool.macos_clone_capture._run", side_effect=[types.SimpleNamespace(stdout=LOAD_COMMANDS), types.SimpleNamespace(stdout=IMPORTS)]) as run:
+                plan = resolve_lldb_pbkdf_stub_plan(app)
+            self.assertEqual(plan[SYNTHETIC_UUID], STUB_OFFSET)
+            self.assertEqual(run.call_count, 2)
+            for call in run.call_args_list:
+                self.assertEqual(call.args[0][:3], ["/usr/bin/otool", "-arch", "arm64"])
+                self.assertEqual(call.args[0][-1], str(dylib))
+            for script in self.scripts(plan):
+                self.assertEqual(self.namespace(script)["PBKDF_STUB_POINTS"], plan)
+
+    def test_missing_uuid_nonstub_import_or_failed_inspection_never_guesses_offset(self):
+        cases = (
+            [types.SimpleNamespace(stdout="cmd LC_VERSION_MIN_MACOSX\n version 27.0\n")],
+            [types.SimpleNamespace(stdout=LOAD_COMMANDS * 2)],
+            [types.SimpleNamespace(stdout=LOAD_COMMANDS), types.SimpleNamespace(stdout="Indirect symbols for (__DATA,__got)\n0x1234 6 _CCKeyDerivationPBKDF\n")],
+            [MacOSDBKeyCaptureFailure("command_failed", "synthetic otool unavailable")],
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app = Path(temp_dir) / "Synthetic.app"
+            dylib = app / "Contents/Resources/wechat.dylib"
+            dylib.parent.mkdir(parents=True)
+            dylib.write_bytes(b"synthetic")
+            for outputs in cases:
+                with self.subTest(output_count=len(outputs)), patch("wechat_decrypt_tool.macos_clone_capture._run", side_effect=outputs):
+                    self.assertEqual(resolve_lldb_pbkdf_stub_plan(app), WECHAT_PBKDF_STUB_POINTS)
+
+    def test_unknown_uuid_resolved_plan_arms_identical_executable_stub_in_both_stages(self):
+        for stage, script in enumerate(self.scripts()):
+            with self.subTest(stage=stage):
+                namespace = self.namespace(script)
+                target, module, process = self.target()
+                writes = []
+                namespace["_write_result"] = lambda payload: writes.append(payload) or True
+                namespace["_write_ready"] = lambda payload: writes.append(payload) or True
+                namespace["_setup"](types.SimpleNamespace(GetSelectedTarget=lambda: target), None, None, None)
+                module.ResolveFileAddress.assert_called_once_with(STUB_OFFSET)
+                self.assertEqual(writes[-1]["pbkdf_locations"], 1)
+                if stage == 1:
+                    self.assertEqual(writes[-1]["status"], "ready")
+                    process.Detach.assert_not_called()
+
+    def test_unresolved_nonexecutable_unloaded_or_wrong_uuid_never_becomes_ready(self):
+        scenarios = (
+            {"address": FakeAddress(valid=False)},
+            {"address": FakeAddress(executable=False), "name_resolved": True},
+            {"address": FakeAddress(loaded=False), "name_resolved": True},
+            {"stub_resolved": False},
+            {"uuid": "FFFFFFFF-BBBB-CCCC-DDDD-EEEEEEEEEEEE"},
+        )
+        class ScriptExit(Exception):
+            pass
+        for scenario in scenarios:
+            for stage, script in enumerate(self.scripts()):
+                with self.subTest(stage=stage, scenario=list(scenario)):
+                    namespace = self.namespace(script)
+                    target, module, process = self.target(**scenario)
+                    writes = []
+                    namespace["_write_result"] = lambda payload: writes.append(payload) or True
+                    namespace["_write_ready"] = lambda payload: writes.append(payload) or True
+                    debugger = types.SimpleNamespace(GetSelectedTarget=lambda: target)
+                    if stage == 0:
+                        namespace["_setup"](debugger, None, None, None)
+                        self.assertEqual(writes[-1]["pbkdf_locations"], 0)
+                    else:
+                        with patch.object(namespace["os"], "_exit", side_effect=ScriptExit) as exit_script:
+                            with self.assertRaises(ScriptExit):
+                                namespace["_setup"](debugger, None, None, None)
+                        exit_script.assert_called_once_with(24)
+                        self.assertEqual(writes, [])
+                        process.Detach.assert_called_once()
+
+    def test_preflight_persists_the_same_resolver_plan_it_passes_to_lldb(self):
+        plan = {**WECHAT_PBKDF_STUB_POINTS, SYNTHETIC_UUID: STUB_OFFSET}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            def fake_lldb(command, *, timeout):
+                script_path = Path(command).parent / "preflight_callback.py"
+                self.assertEqual(self.namespace(script_path.read_text())["PBKDF_STUB_POINTS"], plan)
+                (root / "breakpoint-preflight.json").write_text(json.dumps({"pid": 123, "pbkdf_locations": 1, "key_return_locations": 0}))
+                return ""
+            with (
+                patch("wechat_decrypt_tool.macos_clone_capture.platform.machine", return_value="arm64"),
+                patch("wechat_decrypt_tool.macos_clone_capture.shutil.which", return_value="/fake/lldb"),
+                patch("wechat_decrypt_tool.macos_clone_capture.resolve_lldb_pbkdf_stub_plan", return_value=plan),
+                patch("wechat_decrypt_tool.macos_clone_capture._build_lldb_capture_command", side_effect=lambda path, timeout: str(path)),
+                patch("wechat_decrypt_tool.macos_clone_capture._run_as_administrator", side_effect=fake_lldb),
+            ):
+                result = preflight_capture_breakpoints(pid=123, debug_root=root, wechat_app=root / "Synthetic.app")
+            self.assertEqual(result["pbkdf_stub_plan"], plan)
+            self.assertEqual(json.loads((root / "breakpoint-preflight.json").read_text())["pbkdf_stub_plan"], plan)
+
+    def test_invalid_plan_is_rejected_before_it_can_become_debugger_code(self):
+        for plan in ({"bad uuid": 4}, {SYNTHETIC_UUID: -4}, {SYNTHETIC_UUID: 3}, {SYNTHETIC_UUID: "4096"}):
+            with self.subTest(value_type=type(next(iter(plan.values()))).__name__):
+                with self.assertRaises(MacOSDBKeyCaptureFailure):
+                    self.scripts(plan)
+
+    def test_capture_wrapper_forwards_the_persisted_plan_without_resolving_again(self):
+        plan = {**WECHAT_PBKDF_STUB_POINTS, SYNTHETIC_UUID: STUB_OFFSET}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            probe = Path(temp_dir) / "synthetic.db"
+            probe.write_bytes(b"x" * 4096)
+            def fake_lldb(command, *, timeout):
+                root = Path(command).parent
+                self.assertEqual(self.namespace((root / "capture_callback.py").read_text())["PBKDF_STUB_POINTS"], plan)
+                (root / "result.json").write_text(json.dumps({"passphrase": "ab" * 32, "salt": (b"x" * 16).hex()}))
+                return ""
+            with (
+                patch("wechat_decrypt_tool.macos_clone_capture.platform.machine", return_value="arm64"),
+                patch("wechat_decrypt_tool.macos_clone_capture.shutil.which", return_value="/fake/lldb"),
+                patch("wechat_decrypt_tool.macos_clone_capture.resolve_lldb_pbkdf_stub_plan") as resolve,
+                patch("wechat_decrypt_tool.macos_clone_capture._build_lldb_capture_command", side_effect=lambda path, timeout: str(path)),
+                patch("wechat_decrypt_tool.macos_clone_capture._run_as_administrator", side_effect=fake_lldb),
+            ):
+                result = capture_salt_matched_passphrase(pid=123, expected_salts=[b"x" * 16], probe_db_path=probe, pbkdf_stub_plan=plan)
+            self.assertEqual(result, "ab" * 32)
+            resolve.assert_not_called()
+
+    def test_failed_detach_never_publishes_success_or_raw_debugger_errors(self):
+        namespace = self.namespace(self.scripts()[0])
+        target, module, process = self.target()
+        process.Detach.return_value = types.SimpleNamespace(Success=lambda: False, GetCString=lambda: "sensitive-debugger-details")
+        writes = []
+        namespace["_write_result"] = lambda payload: writes.append(payload) or True
+        namespace["_setup"](types.SimpleNamespace(GetSelectedTarget=lambda: target), None, None, None)
+        self.assertEqual(writes, [{"status": "error", "code": "capture_preflight_detach_failed"}])
+        self.assertNotIn("sensitive-debugger-details", json.dumps(writes))
+
+    def test_wrapper_rejects_failed_detach_even_with_resolved_locations(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            def fake_lldb(command, *, timeout):
+                (root / "breakpoint-preflight.json").write_text(json.dumps({
+                    "status": "error", "code": "capture_preflight_detach_failed", "pbkdf_locations": 1,
+                }))
+                return "WEDATA_BREAKPOINT_PREFLIGHT_DETACH_FAILED"
+            with (
+                patch("wechat_decrypt_tool.macos_clone_capture.platform.machine", return_value="arm64"),
+                patch("wechat_decrypt_tool.macos_clone_capture.shutil.which", return_value="/fake/lldb"),
+                patch("wechat_decrypt_tool.macos_clone_capture._run_as_administrator", side_effect=fake_lldb),
+            ):
+                with self.assertRaises(MacOSDBKeyCaptureFailure) as failure:
+                    preflight_capture_breakpoints(pid=123, debug_root=root)
+            self.assertEqual(failure.exception.code, "capture_preflight_detach_failed")
+            self.assertFalse((root / "breakpoint-preflight.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_lldb_command_lifecycle.py
+++ b/tests/test_macos_lldb_command_lifecycle.py
@@ -1,0 +1,105 @@
+"""Exercise the real shell wrapper without LLDB, WeChat, or authorization."""
+
+import os
+from pathlib import Path
+import select
+import shlex
+import signal
+import subprocess
+import sys
+import time
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from wechat_decrypt_tool.macos_db_key_capture import _build_lldb_capture_command
+
+
+@unittest.skipUnless(os.name == "posix" and Path("/bin/bash").is_file(), "requires POSIX bash")
+class TestLLDBCommandLifecycle(unittest.TestCase):
+    def command(self, stub: str, timeout: int = 3) -> list[str]:
+        args = shlex.split(_build_lldb_capture_command(Path("/dev/null"), timeout))
+        self.assertEqual(args[:2], ["/bin/bash", "-c"])
+        launcher = "/usr/bin/env TERM=dumb /usr/bin/lldb"
+        self.assertEqual(args[2].count(launcher), 1)
+        args[2] = args[2].replace(launcher, stub)
+        self.assertNotIn("/usr/bin/lldb", args[2])
+        self.assertNotIn("osascript", args[2])
+        self.assertIn("/bin/cat /dev/null;", args[2])
+        # Report only this test's private directory and child IDs. This also
+        # gives signal tests a readiness barrier before interrupting the shell.
+        marker = "watchdog_pid=$!\n"
+        self.assertEqual(args[2].count(marker), 1)
+        args[2] = args[2].replace(
+            marker,
+            marker + 'printf "WEDATA_TEST_SCOPE %s %s %s %s\\n" '
+            '"$capture_dir" "$producer_pid" "$lldb_pid" "$watchdog_pid"\n',
+        )
+        return args
+
+    def run_wrapper(self, stub: str, interrupt: int | None = None) -> tuple[str, int, float]:
+        started = time.monotonic()
+        process = subprocess.Popen(
+            self.command(stub), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, start_new_session=True,
+        )
+        try:
+            self.assertTrue(select.select([process.stdout], [], [], 2)[0], "wrapper did not start")
+            scope = process.stdout.readline().strip().split()
+            self.assertEqual(scope[0], "WEDATA_TEST_SCOPE")
+            capture_dir = Path(scope[1])
+            self.assertEqual(capture_dir.parent.resolve(), Path("/tmp").resolve())
+            self.assertTrue(capture_dir.name.startswith("wedata-lldb."))
+            if interrupt is not None:
+                # Allow the watchdog to enter its timer wait, not just fork.
+                time.sleep(0.1)
+                process.send_signal(interrupt)
+            stdout, _stderr = process.communicate(timeout=6)
+            elapsed = time.monotonic() - started
+            self.assertFalse(capture_dir.exists(), "private FIFO directory was not cleaned")
+            for raw_pid in scope[2:]:
+                with self.assertRaises(ProcessLookupError, msg=f"child {raw_pid} was not reaped"):
+                    os.kill(int(raw_pid), 0)
+            with self.assertRaises(ProcessLookupError, msg="wrapper left a descendant in its private process group"):
+                os.killpg(process.pid, 0)
+            return stdout, process.returncode, elapsed
+        finally:
+            # A failed regression must not leave its synthetic sleep children.
+            # The group belongs solely to Popen(start_new_session=True) above.
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.communicate(timeout=6)
+
+    def test_success_returns_without_waiting_for_watchdog(self) -> None:
+        stdout, returncode, elapsed = self.run_wrapper("/bin/sleep 0.2")
+        self.assertEqual(returncode, 0)
+        self.assertIn("WEDATA_LLDB_EXIT=0", stdout)
+        self.assertLess(elapsed, 2.0, "successful capture waited for the 3-second watchdog")
+
+    def test_debugger_failure_returns_without_waiting_for_watchdog(self) -> None:
+        stdout, returncode, elapsed = self.run_wrapper("/bin/sh -c 'exit 24'")
+        self.assertEqual(returncode, 0)
+        self.assertIn("WEDATA_LLDB_EXIT=24", stdout)
+        self.assertLess(elapsed, 2.0, "failed capture waited for the 3-second watchdog")
+
+    def test_watchdog_still_terminates_a_long_running_debugger(self) -> None:
+        stdout, returncode, elapsed = self.run_wrapper("/bin/sleep 10")
+        self.assertEqual(returncode, 0)
+        self.assertIn("WEDATA_LLDB_EXIT=143", stdout)
+        self.assertGreaterEqual(elapsed, 2.6, "watchdog fired before its configured deadline")
+        self.assertLess(elapsed, 4.5, "watchdog did not terminate the synthetic debugger")
+
+    def test_signals_clean_children_and_return_promptly(self) -> None:
+        for interrupt in (signal.SIGTERM, signal.SIGHUP, signal.SIGINT):
+            with self.subTest(signal=interrupt):
+                _stdout, returncode, elapsed = self.run_wrapper("/bin/sleep 10", interrupt)
+                self.assertEqual(returncode, 128 + interrupt)
+                self.assertLess(elapsed, 2.0, "interrupted capture left a timer holding output open")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_manual_launch.py
+++ b/tests/test_macos_manual_launch.py
@@ -1,0 +1,123 @@
+"""Manual launch authorization uses fake bundles only; no OS policy changes."""
+from pathlib import Path
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from wechat_decrypt_tool import macos_inplace_capture as workflow
+from wechat_decrypt_tool.macos_db_key_capture import MacOSDBKeyCaptureFailure
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "macos-key-extractor"))
+from key_extractor.app import KeyExtractorApp
+from key_extractor.core import prepare_capture
+
+
+@pytest.fixture
+def prepared(tmp_path, monkeypatch):
+    app, debug, backup = tmp_path / "WeChat.app", tmp_path / "debug", tmp_path / "backups"
+    app.mkdir()
+    monkeypatch.setattr(workflow, "DEFAULT_WECHAT_APP", app)
+    monkeypatch.setattr(workflow, "normalize_wechat_app_path", lambda _: app)
+    monkeypatch.setattr(workflow, "_acquire_installation_lock", lambda *a: {"transaction_id": "fixture-tx"})
+    monkeypatch.setattr(workflow, "_release_installation_lock", Mock())
+    monkeypatch.setattr(workflow, "inspect_wechat_signature", Mock(return_value={}))
+    monkeypatch.setattr(workflow, "_is_tencent_official_signature", lambda _: True)
+    monkeypatch.setattr(workflow, "_transaction_is_active", lambda *a: True)
+    monkeypatch.setattr(workflow, "_prepared_signature_is_valid", lambda *a: True)
+    monkeypatch.setattr(workflow, "_debug_identity_matches", lambda *a: True)
+    monkeypatch.setattr(workflow.time, "sleep", Mock())
+    monkeypatch.setattr("subprocess.run", Mock(side_effect=AssertionError("No external processes allowed")))
+
+    def prepare(*args, before_resign):
+        before_resign({"wechat_app_path": str(app), "backup_path": str(backup / "WeChat-fixture.zip"),
+                       "debug_identity": {"fixture": True}})
+        return {}
+
+    monkeypatch.setattr(workflow, "ensure_wechat_in_place_debuggable", prepare)
+    launch = Mock(side_effect=AssertionError("manual mode must not launch"))
+    monkeypatch.setattr(workflow, "_launch_wechat", launch)
+    result = workflow.prepare_in_place_capture(app, backup_root=backup, debug_root=debug, defer_launch=True)
+    return app, debug, backup, result
+
+
+def test_manual_prepare_is_not_reported_as_running(prepared):
+    app, debug, backup, result = prepared
+    assert result["requires_manual_launch"] is True
+    assert result["ready_for_preflight"] is False
+    assert result["debug_pid"] is None
+    assert workflow.get_in_place_capture_status(debug_root=debug)["stage"] == "awaiting_manual_launch"
+
+
+@pytest.mark.parametrize("pids,ready", [([123, 123], True), ([None], False), ([123, None], False), ([123, 456], False)])
+def test_only_stable_user_started_process_can_continue(prepared, monkeypatch, pids, ready):
+    app, debug, backup, result = prepared
+    monkeypatch.setattr(workflow, "_find_wechat_main_pid", Mock(side_effect=pids))
+    resumed = workflow.confirm_manual_in_place_launch(app, backup_root=backup, debug_root=debug,
+                                                     transaction_id=result["transaction_id"])
+    assert resumed["ready_for_preflight"] is ready
+    assert workflow._read_state(debug)["stage"] == ("launched" if ready else "awaiting_manual_launch")
+
+
+@pytest.mark.parametrize("cause", ["transaction", "owner", "signature", "identity"])
+def test_manual_confirmation_cannot_adopt_another_app_or_transaction(prepared, monkeypatch, cause):
+    app, debug, backup, result = prepared
+    transaction = result["transaction_id"]
+    if cause == "transaction":
+        transaction = "old-transaction"
+    else:
+        function = {"owner": "_transaction_is_active", "signature": "_prepared_signature_is_valid",
+                    "identity": "_debug_identity_matches"}[cause]
+        monkeypatch.setattr(workflow, function, lambda *a: False)
+    probe = Mock(side_effect=AssertionError("must reject before checking processes"))
+    monkeypatch.setattr(workflow, "_find_wechat_main_pid", probe)
+    with pytest.raises(MacOSDBKeyCaptureFailure):
+        workflow.confirm_manual_in_place_launch(app, backup_root=backup, debug_root=debug, transaction_id=transaction)
+    probe.assert_not_called()
+
+
+def ui():
+    app = KeyExtractorApp.__new__(KeyExtractorApp)
+    app.root = Mock()
+    app.status_var, app.detail_var = Mock(), Mock()
+    app.primary_button, app.cancel_button, app.progress = Mock(), Mock(), Mock()
+    app._handle_error = Mock()
+    return app
+
+
+def test_standalone_opts_into_deferred_launch(monkeypatch):
+    prepare = Mock(return_value={})
+    monkeypatch.setattr(workflow, "prepare_in_place_capture", prepare)
+    prepare_capture("/fixture/WeChat.app", "/fixture/work")
+    assert prepare.call_args.kwargs["defer_launch"] is True
+
+
+def test_waiting_ui_never_opens_app_or_enables_preflight_automatically():
+    app = ui()
+    app._prepared({"transaction_id": "fixture-tx", "requires_manual_launch": True})
+    assert app.stage == "system_approval"
+    app.root.after.assert_not_called()
+    text = app.detail_var.set.call_args.args[0]
+    assert "不是 Apple 公证" in text and "请取消并恢复" in text
+    app._set_busy(False)
+    app.cancel_button.configure.assert_called_with(state="normal")
+    app._manual_launch_checked({"transaction_id": "fixture-tx", "ready_for_preflight": False})
+    assert app.stage == "system_approval"
+    app.root.after.assert_not_called()
+    app._manual_launch_checked({"transaction_id": "fixture-tx", "ready_for_preflight": True})
+    assert app.stage == "prepared"
+
+
+def test_stale_confirmation_cannot_advance_ui():
+    app = ui()
+    app._prepared({"transaction_id": "fixture-tx", "requires_manual_launch": True})
+    app._manual_launch_checked({"transaction_id": "old-tx", "ready_for_preflight": True})
+    assert app.stage == "system_approval"
+    app._handle_error.assert_called_once()
+
+
+def test_settings_button_only_opens_settings_app(monkeypatch):
+    popen = Mock()
+    monkeypatch.setattr("key_extractor.app.subprocess.Popen", popen)
+    KeyExtractorApp._open_security_settings()
+    popen.assert_called_once_with(["/usr/bin/open", "-b", "com.apple.systempreferences"])

--- a/tests/test_macos_native_capture_source.py
+++ b/tests/test_macos_native_capture_source.py
@@ -18,11 +18,11 @@ def test_validated_capture_terminates_disposable_process_before_returning() -> N
 
 def test_monitor_reports_ready_only_after_breakpoint_installation() -> None:
     source = SOURCE.read_text(encoding="utf-8")
-    start = source.index("static int run_capture")
-    install = source.index("kr = install_hardware_breakpoints(g_ctx.task);", start)
-    ready = source.index("write_ready_file(options->ready_file, options->pid)", install)
-
-    assert install < ready
+    capture = source.index("static int run_capture")
+    restore_debug = source.index("(void)restore_hardware_breakpoints();", capture)
+    restore_port = source.index("restore_exception_ports(g_ctx.task);", restore_debug)
+    resume = source.index("if (task_resume(g_ctx.task) != KERN_SUCCESS)", restore_port)
+    assert restore_debug < restore_port < resume
 
 
 def test_helper_source_contains_no_environment_specific_paths() -> None:

--- a/tests/test_macos_prepared_lifecycle.py
+++ b/tests/test_macos_prepared_lifecycle.py
@@ -1,0 +1,149 @@
+"""No real applications, signing, debugger, or databases are used here."""
+import sys
+import queue
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from wechat_decrypt_tool import macos_db_key_capture as capture
+from wechat_decrypt_tool import macos_inplace_capture as workflow
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "macos-key-extractor"))
+from key_extractor.app import KeyExtractorApp
+
+
+@pytest.mark.parametrize("second_pid", [None, 456])
+def test_launch_does_not_accept_exit_or_replacement(monkeypatch, second_pid):
+    monkeypatch.setattr(capture, "_run", Mock())
+    monkeypatch.setattr(capture.time, "sleep", Mock())
+    monkeypatch.setattr(capture, "_find_wechat_main_pid", Mock(side_effect=[123, second_pid]))
+    with pytest.raises(capture.MacOSDBKeyCaptureFailure) as error:
+        capture._launch_wechat(Path("/fixture/WeChat.app"))
+    assert error.value.code == "wechat_launch_exited"
+
+
+def test_launch_failure_enters_existing_transactional_recovery(tmp_path, monkeypatch):
+    app = tmp_path / "WeChat.app"
+    app.mkdir()
+    debug = tmp_path / "debug"
+    monkeypatch.setattr(workflow, "DEFAULT_WECHAT_APP", app)
+    monkeypatch.setattr(workflow, "normalize_wechat_app_path", lambda path: app)
+    monkeypatch.setattr(workflow, "_acquire_installation_lock", lambda *a: {"transaction_id": "fixture-tx"})
+    monkeypatch.setattr(workflow, "_release_installation_lock", Mock())
+    monkeypatch.setattr(workflow, "inspect_wechat_signature", Mock(return_value={}))
+    monkeypatch.setattr(workflow, "_is_tencent_official_signature", lambda signature: True)
+
+    def prepare(*args, before_resign):
+        before_resign({"wechat_app_path": str(app), "debug_identity": {"fixture": True}})
+        return {}
+
+    monkeypatch.setattr(workflow, "ensure_wechat_in_place_debuggable", prepare)
+    error = capture.MacOSDBKeyCaptureFailure("wechat_launch_exited", "synthetic exit")
+    monkeypatch.setattr(workflow, "_launch_wechat", Mock(side_effect=error))
+    recover = Mock()
+    monkeypatch.setattr(workflow, "_restore_after_terminal_path", recover)
+    with pytest.raises(capture.MacOSDBKeyCaptureFailure):
+        workflow.prepare_in_place_capture(app, backup_root=tmp_path / "backups", debug_root=debug)
+    recover.assert_called_once_with(app, backup_root=tmp_path / "backups", debug_root=debug, original_error=error)
+    assert workflow._read_state(debug)["stage"] != "launched"
+
+
+@pytest.mark.parametrize("stage", ["launched", "preflight_passed"])
+@pytest.mark.parametrize("pid,exited", [(123, False), (None, True), (456, True)])
+def test_prepared_status_reports_liveness_without_restoring(tmp_path, monkeypatch, stage, pid, exited):
+    workflow._write_state(tmp_path, {
+        "schema_version": 2, "stage": stage, "transaction_id": "fixture-tx",
+        "wechat_app_path": "/Applications/WeChat.app", "debug_pid": 123,
+    })
+    monkeypatch.setattr(workflow, "_find_wechat_main_pid", Mock(return_value=pid))
+    restore = Mock(side_effect=AssertionError("status must remain read-only"))
+    monkeypatch.setattr(workflow, "restore_official_wechat_if_needed", restore)
+    assert workflow.get_in_place_capture_status(debug_root=tmp_path)["prepared_process_exited"] is exited
+    restore.assert_not_called()
+
+
+def test_capture_or_unknown_probe_is_not_treated_as_idle_exit(tmp_path, monkeypatch):
+    state = {"schema_version": 2, "stage": "capturing", "transaction_id": "fixture-tx",
+             "wechat_app_path": "/Applications/WeChat.app", "debug_pid": 123}
+    workflow._write_state(tmp_path, state)
+    probe = Mock(side_effect=OSError("process list unavailable"))
+    monkeypatch.setattr(workflow, "_find_wechat_main_pid", probe)
+    assert workflow.get_in_place_capture_status(debug_root=tmp_path).get("prepared_process_exited") is None
+    probe.assert_not_called()
+    state["stage"] = "launched"
+    workflow._write_state(tmp_path, state)
+    assert workflow.get_in_place_capture_status(debug_root=tmp_path).get("prepared_process_exited") is None
+
+
+def fake_ui():
+    app = KeyExtractorApp.__new__(KeyExtractorApp)
+    app._closed = app._busy = app._closing_after_cleanup = False
+    app.stage = "prepared"
+    app._capture_transaction_id = "fixture-tx"
+    app._prepared_exit_attempted_transaction = ""
+    app.detail_var = Mock()
+    app.wechat_var = Mock(get=lambda: "/fixture/WeChat.app")
+    app.work_root_var = Mock(get=lambda: "/fixture/work")
+    app._run_task = Mock()
+    return app
+
+
+def test_idle_exit_requests_existing_recovery_once(monkeypatch):
+    app = fake_ui()
+    cancel = Mock(return_value={"official_wechat_verified": True})
+    monkeypatch.setattr("key_extractor.app.cancel_capture", cancel)
+    status = {"transaction_id": "fixture-tx", "stage": "launched", "prepared_process_exited": True}
+    app._apply_prepared_health("fixture-tx", status)
+    app._run_task.assert_called_once()
+    cancel.assert_not_called()  # Must run on the existing background task queue.
+    operation, callback = app._run_task.call_args.args
+    operation()
+    cancel.assert_called_once_with("/fixture/WeChat.app", "/fixture/work")
+    assert callback == app._prepared_exit_recovered
+    app._apply_prepared_health("fixture-tx", status)
+    app._run_task.assert_called_once()  # No endless recovery/authorization loop.
+
+
+@pytest.mark.parametrize("change", ["busy", "closed", "capturing", "stale", "unknown", "restoring"])
+def test_idle_recovery_ignores_active_capture_and_stale_or_unknown_state(change):
+    app = fake_ui()
+    status = {"transaction_id": "fixture-tx", "stage": "launched", "prepared_process_exited": True}
+    if change == "busy":
+        app._busy = True
+    elif change == "closed":
+        app._closed = True
+    elif change == "capturing":
+        app.stage = "capturing"
+    elif change == "stale":
+        status["transaction_id"] = "old-tx"
+    elif change == "unknown":
+        status["prepared_process_exited"] = None
+    else:
+        status["stage"] = "capturing"
+        status["capture_phase"] = "restoring"
+    app._apply_prepared_health("fixture-tx", status)
+    app._run_task.assert_not_called()
+
+
+def test_idle_health_reader_is_async_single_flight_and_stops_when_closed(monkeypatch):
+    app = fake_ui()
+    app._prepared_health_results = queue.Queue()
+    app._prepared_health_inflight = False
+    app.root = Mock()
+    workers = []
+    monkeypatch.setattr("key_extractor.app.threading.Thread", lambda target, **kw: Mock(start=lambda: workers.append(target)))
+    reader = Mock(return_value={"transaction_id": "fixture-tx", "stage": "launched", "prepared_process_exited": False})
+    monkeypatch.setattr("key_extractor.app.capture_status", reader)
+    app._poll_prepared_health()
+    app._poll_prepared_health()
+    reader.assert_not_called()
+    assert len(workers) == 1
+    workers.pop()()
+    reader.assert_called_once()
+    app._poll_prepared_health()
+    assert len(workers) == 1
+    app._closed = True
+    app.root.reset_mock()
+    app._poll_prepared_health()
+    app.root.after.assert_not_called()

--- a/tests/test_macos_restore_identity.py
+++ b/tests/test_macos_restore_identity.py
@@ -1,0 +1,304 @@
+"""Synthetic bundles only: never inspect or operate on the installed WeChat."""
+
+import tempfile
+import json
+import os
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from wechat_decrypt_tool import macos_db_key_capture as capture
+from wechat_decrypt_tool import macos_inplace_capture as inplace
+
+
+OFFICIAL = {
+    "valid": True, "ad_hoc": False, "hardened_runtime": True,
+    "team_identifier": "5A4RE8SF68", "identifier": "com.tencent.xinWeChat", "cdhash": "old",
+}
+DEBUG = {**OFFICIAL, "ad_hoc": True, "hardened_runtime": False, "cdhash": "debug"}
+
+
+class TestRestoreIdentity(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.app = self.root / "WeChat.app"
+        self.app.mkdir()
+        self.staged = self.root / capture.LOCAL_RESTORE_STAGING_NAME
+        self.staged.mkdir()
+        self.backup = self.root / "WeChat-original.zip"
+        self.addCleanup(patch.stopall)
+        patch.object(capture, "DEFAULT_DEBUG_ROOT", self.root / "work").start()
+        patch.object(inplace, "DEFAULT_CAPTURE_LOCK_ROOT", self.root / "user-locks").start()
+        patch.object(capture, "_run", side_effect=AssertionError("external command forbidden in synthetic regression")).start()
+
+    def identity(self, path=None):
+        stat = (path or self.app).stat()
+        return {"version": "4.1.7", "build": "100", "cdhash": "debug", "device": stat.st_dev, "inode": stat.st_ino}
+
+    def test_other_official_version_is_conflict_and_preserves_staging(self):
+        with (
+            patch.object(capture, "inspect_wechat_signature", return_value={**OFFICIAL, "cdhash": "new"}),
+            patch.object(capture, "_wechat_version", return_value=("4.1.13", "200")),
+            patch.object(capture, "_remove_local_restore_staging") as remove,
+            patch.object(capture, "_atomic_swap_paths") as swap,
+        ):
+            with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+                capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old")
+        self.assertEqual(error.exception.code, "external_install_conflict")
+        remove.assert_not_called()
+        swap.assert_not_called()
+
+    def test_same_version_different_cdhash_is_conflict(self):
+        with patch.object(capture, "inspect_wechat_signature", return_value={**OFFICIAL, "cdhash": "new"}), patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")):
+            with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+                capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old")
+        self.assertEqual(error.exception.code, "external_install_conflict")
+
+    def test_matching_official_does_not_delete_unidentified_staging(self):
+        with patch.object(capture, "inspect_wechat_signature", return_value=OFFICIAL), patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")), patch.object(capture, "_remove_local_restore_staging") as remove:
+            result = capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old")
+        self.assertTrue(result["original_identity_verified"])
+        remove.assert_not_called()
+
+    def test_unidentified_nonofficial_app_is_not_overwritten(self):
+        with patch.object(capture, "inspect_wechat_signature", return_value=DEBUG), patch.object(capture, "_quit_wechat") as quit_app, patch.object(capture, "_atomic_swap_paths") as swap:
+            with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+                capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old")
+        self.assertEqual(error.exception.code, "in_place_debug_identity_unknown")
+        quit_app.assert_not_called()
+        swap.assert_not_called()
+
+    def test_debug_identity_must_match_inode_not_just_adhoc_hash(self):
+        identity = {**self.identity(), "inode": -1}
+        with patch.object(capture, "inspect_wechat_signature", return_value=DEBUG), patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")), patch.object(capture, "_atomic_swap_paths") as swap:
+            with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+                capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old", expected_debug_identity=identity)
+        self.assertEqual(error.exception.code, "in_place_debug_identity_unknown")
+        swap.assert_not_called()
+
+    def test_identity_checked_again_after_restore_swap(self):
+        def signature(path):
+            if path == self.app:
+                return {**OFFICIAL, "cdhash": "changed"} if swapped[0] else DEBUG
+            return OFFICIAL
+        swapped = [False]
+        def swap(*_):
+            swapped[0] = not swapped[0]
+        with patch.object(capture, "inspect_wechat_signature", side_effect=signature), patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")), patch.object(capture, "_quit_wechat"), patch.object(capture, "_atomic_swap_paths", side_effect=swap) as exchange:
+            with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+                capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old", expected_debug_identity=self.identity())
+        self.assertEqual(error.exception.code, "external_install_conflict")
+        self.assertEqual(exchange.call_count, 1)
+        self.assertTrue(self.staged.exists())
+
+    def test_installation_lock_excludes_other_debug_roots(self):
+        first = self.root / "one"
+        second = self.root / "two"
+        inplace._acquire_installation_lock(self.app, first)
+        self.addCleanup(inplace._release_installation_lock, self.app, first)
+        with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+            inplace._acquire_installation_lock(self.app, second)
+        self.assertEqual(error.exception.code, "in_place_capture_busy")
+        inplace._release_installation_lock(self.app, first)
+        inplace._acquire_installation_lock(self.app, second)
+        inplace._release_installation_lock(self.app, second)
+
+    def test_lock_needs_no_write_to_installation_directory(self):
+        applications = self.root / "Applications"
+        applications.mkdir()
+        app = applications / "WeChat.app"
+        app.mkdir()
+        applications.chmod(0o555)
+        self.addCleanup(applications.chmod, 0o700)
+        debug_root = self.root / "debug"
+        inplace._acquire_installation_lock(app, debug_root)
+        self.addCleanup(inplace._release_installation_lock, app, debug_root)
+        locks = list((self.root / "user-locks").glob("*.lock"))
+        self.assertEqual(len(locks), 1)
+        self.assertEqual((self.root / "user-locks").stat().st_mode & 0o777, 0o700)
+        self.assertEqual(locks[0].stat().st_mode & 0o777, 0o600)
+        self.assertEqual(list(applications.iterdir()), [app])
+
+    def test_legacy_state_remains_readable(self):
+        inplace._write_state(self.root, {"schema_version": 1, "stage": "launched"})
+        self.assertEqual(inplace._read_state(self.root)["schema_version"], 1)
+
+    def prepare_fixture(self, state):
+        debug_root = self.root / "debug"
+        backup_root = self.root / "backups"
+        backup_root.mkdir(exist_ok=True)
+        state = {
+            "schema_version": 1, "wechat_app_path": str(self.app),
+            "backup_path": str(backup_root / "WeChat-4.1.13-original.zip"),
+            "version": "4.1.13", "build": "200", "official_cdhash": "new", **state,
+        }
+        inplace._write_state(debug_root, state)
+        self.addCleanup(inplace._release_installation_lock, self.app, debug_root)
+        def ensure(app, backup_root, *, before_resign):
+            before_resign({
+                "wechat_app_path": str(app), "backup_path": str(backup_root / "WeChat-4.1.7-original.zip"),
+                "version": "4.1.7", "build": "100", "official_cdhash": "old", "debug_identity": self.identity(),
+            })
+            return {"debug_identity": self.identity()}
+        patch.object(inplace, "normalize_wechat_app_path", return_value=self.app).start()
+        patch.object(inplace, "DEFAULT_WECHAT_APP", self.app).start()
+        patch.object(inplace.platform, "system", return_value="darwin").start()
+        patch.object(inplace, "inspect_wechat_signature", return_value=OFFICIAL).start()
+        patch.object(capture, "inspect_wechat_signature", return_value=OFFICIAL).start()
+        patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")).start()
+        patch.object(inplace, "_terminate_native_capture_processes").start()
+        patch.object(inplace, "_launch_wechat", return_value=123).start()
+        prepared = patch.object(inplace, "ensure_wechat_in_place_debuggable", side_effect=ensure).start()
+        return debug_root, backup_root, state, prepared
+
+    def test_user_downgrade_before_new_transaction_supersedes_old_state_without_overwrite(self):
+        debug_root, backup_root, _, prepared = self.prepare_fixture({})
+        result = inplace.prepare_in_place_capture(self.app, backup_root=backup_root, debug_root=debug_root)
+        self.assertTrue(result["previous_transaction_superseded"])
+        current = inplace._read_state(debug_root)
+        self.assertEqual(current["version"], "4.1.7")
+        self.assertEqual(current["schema_version"], 2)
+        self.assertTrue(current["transaction_id"])
+        self.assertEqual(current["debug_identity"], self.identity())
+        archives = list((debug_root / "recovery-history").glob("*/prepared-in-place-capture.json"))
+        self.assertEqual(len(archives), 1)
+        archived = json.loads(archives[0].read_text())
+        self.assertEqual(archived["version"], "4.1.13")
+        self.assertTrue(Path(archived["preserved_staging_path"]).is_dir())
+        prepared.assert_called_once()
+
+    def test_active_official_change_stops_then_next_explicit_retry_can_supersede(self):
+        debug_root, backup_root, state, prepared = self.prepare_fixture({})
+        lease = inplace._acquire_installation_lock(self.app, debug_root)
+        state.update(schema_version=2, transaction_id=lease["transaction_id"], owner_pid=os.getpid(), owner_session=inplace._OWNER_SESSION)
+        inplace._write_state(debug_root, state)
+        with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+            inplace.prepare_in_place_capture(self.app, backup_root=backup_root, debug_root=debug_root)
+        self.assertEqual(error.exception.code, "external_install_conflict")
+        self.assertTrue(self.staged.exists())
+        self.assertEqual(inplace._read_state(debug_root)["stage"], "external_install_conflict")
+        prepared.assert_not_called()
+        result = inplace.prepare_in_place_capture(self.app, backup_root=backup_root, debug_root=debug_root)
+        self.assertTrue(result["previous_transaction_superseded"])
+        prepared.assert_called_once()
+
+    def test_legacy_unknown_debug_is_preserved_not_restored(self):
+        debug_root, backup_root, _, prepared = self.prepare_fixture({})
+        patch.object(inplace, "inspect_wechat_signature", return_value=DEBUG).start()
+        patch.object(capture, "inspect_wechat_signature", return_value=DEBUG).start()
+        with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+            inplace.prepare_in_place_capture(self.app, backup_root=backup_root, debug_root=debug_root)
+        self.assertEqual(error.exception.code, "in_place_debug_identity_unknown")
+        self.assertTrue(self.staged.exists())
+        self.assertTrue(inplace._state_path(debug_root).exists())
+        prepared.assert_not_called()
+
+    def test_ready_requires_current_transaction_and_capturing_stage(self):
+        state = {"schema_version": 2, "transaction_id": "current", "stage": "capturing", "capture_backend": "macos_native_mach", "debug_pid": 100, "preflight": {"pid": 123}}
+        inplace._write_state(self.root, state)
+        ready = {"status": "ready", "method": "macos_native_mach", "pid": 123, "transaction_id": "previous"}
+        inplace._native_capture_ready_path(self.root).write_text(json.dumps(ready))
+        self.assertFalse(inplace.native_capture_monitor_ready(debug_root=self.root))
+        ready["transaction_id"] = "current"
+        inplace._native_capture_ready_path(self.root).write_text(json.dumps(ready))
+        self.assertTrue(inplace.native_capture_monitor_ready(debug_root=self.root))
+        self.assertTrue(inplace.get_in_place_capture_status(debug_root=self.root)["monitor_ready"])
+        state["stage"] = "launched"
+        inplace._write_state(self.root, state)
+        self.assertFalse(inplace.native_capture_monitor_ready(debug_root=self.root))
+
+    def test_operation_mutex_rejects_other_thread_but_releases_for_next_request(self):
+        patch.object(inplace, "normalize_wechat_app_path", return_value=self.app).start()
+        entered, finish = threading.Event(), threading.Event()
+        @inplace._serialized_installation_operation
+        def operation(app, block=False):
+            if block:
+                entered.set()
+                self.assertTrue(finish.wait(2))
+            return "ok"
+        worker = threading.Thread(target=operation, args=(self.app, True))
+        worker.start()
+        try:
+            self.assertTrue(entered.wait(2))
+            with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+                operation(self.app)
+            self.assertEqual(error.exception.code, "in_place_capture_busy")
+        finally:
+            finish.set()
+            worker.join(2)
+        self.assertEqual(operation(self.app), "ok")
+
+    def test_successful_exact_debug_restore_is_verified_and_cleans_owned_staging(self):
+        (self.app / "identity").write_text("debug")
+        (self.staged / "identity").write_text("official")
+        def signature(path):
+            return DEBUG if (path / "identity").read_text() == "debug" else OFFICIAL
+        def swap(first, second):
+            temporary = self.root / "swap"
+            first.rename(temporary)
+            second.rename(first)
+            temporary.rename(second)
+        with patch.object(capture, "inspect_wechat_signature", side_effect=signature), patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")), patch.object(capture, "_quit_wechat"), patch.object(capture, "_atomic_swap_paths", side_effect=swap):
+            result = capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old", expected_debug_identity=self.identity())
+        self.assertTrue(result["original_identity_verified"])
+        self.assertTrue(result["official_wechat_restored"])
+        self.assertFalse(self.staged.exists())
+        self.assertEqual((self.app / "identity").read_text(), "official")
+
+    def test_prepare_records_exact_debug_identity_before_atomic_install(self):
+        self.staged.rmdir()
+        (self.app / "identity").write_text("official")
+        records = []
+        def signature(path):
+            return DEBUG if (path / "identity").read_text() == "debug" else OFFICIAL
+        def clone(*_, **__):
+            self.staged.mkdir()
+            (self.staged / "identity").write_text("official")
+            return self.staged
+        def sign(*_, **__):
+            (self.staged / "identity").write_text("debug")
+        def swap(first, second):
+            self.assertEqual(len(records), 2)
+            self.assertEqual(records[-1]["debug_identity"], self.identity(self.staged))
+            temporary = self.root / "swap"
+            first.rename(temporary)
+            second.rename(first)
+            temporary.rename(second)
+        with (
+            patch.object(capture, "inspect_wechat_signature", side_effect=signature),
+            patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")),
+            patch.object(capture, "backup_original_wechat", return_value=(self.backup, True)),
+            patch.object(capture, "verify_original_wechat_backup", return_value={"version": "4.1.7", "build": "100", "cdhash": "old"}),
+            patch.object(capture, "_quit_wechat"),
+            patch.object(capture, "_prepare_local_restore_staging", side_effect=clone),
+            patch.object(capture, "_run", side_effect=sign),
+            patch.object(capture, "_has_compatible_in_place_signature", return_value=True),
+            patch.object(capture, "_atomic_swap_paths", side_effect=swap),
+        ):
+            result = capture.ensure_wechat_in_place_debuggable(self.app, self.root, before_resign=records.append)
+        self.assertEqual(result["debug_identity"], self.identity())
+        self.assertEqual((self.staged / "identity").read_text(), "official")
+
+    def test_wrong_original_staging_is_preserved_before_any_restore_mutation(self):
+        def signature(path):
+            return DEBUG if path == self.app else {**OFFICIAL, "cdhash": "other"}
+        with patch.object(capture, "inspect_wechat_signature", side_effect=signature), patch.object(capture, "_wechat_version", return_value=("4.1.7", "100")), patch.object(capture, "_atomic_swap_paths") as swap:
+            with self.assertRaises(capture.MacOSDBKeyCaptureFailure) as error:
+                capture.restore_official_wechat_if_needed(self.app, self.backup, expected_version=("4.1.7", "100"), expected_cdhash="old", expected_debug_identity=self.identity())
+        self.assertEqual(error.exception.code, "official_restore_staging_conflict")
+        self.assertTrue(self.staged.exists())
+        swap.assert_not_called()
+
+    def test_ready_wrong_pid_and_legacy_transaction_are_not_ready(self):
+        inplace._write_state(self.root, {"schema_version": 2, "stage": "capturing", "transaction_id": "current", "debug_pid": 100, "preflight": {"pid": 123}})
+        inplace._native_capture_ready_path(self.root).write_text(json.dumps({"status": "ready", "method": "macos_native_mach", "pid": 100, "transaction_id": "current"}))
+        self.assertFalse(inplace.native_capture_monitor_ready(debug_root=self.root))
+        inplace._write_state(self.root, {"schema_version": 1, "stage": "capturing", "debug_pid": 100})
+        self.assertFalse(inplace.native_capture_monitor_ready(debug_root=self.root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standalone_macos_key_extractor.py
+++ b/tests/test_standalone_macos_key_extractor.py
@@ -1,0 +1,686 @@
+from __future__ import annotations
+
+import sys
+import plistlib
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+TOOL_ROOT = Path(__file__).resolve().parents[1] / "macos-key-extractor"
+if str(TOOL_ROOT) not in sys.path:
+    sys.path.insert(0, str(TOOL_ROOT))
+
+from key_extractor.core import (  # noqa: E402
+    default_work_root,
+    default_backup_root,
+    capture_status,
+    discover_default_probe_databases,
+    mask_database_key,
+    merge_fresh_capture_result,
+    prefer_active_probe_database,
+    resolve_probe_database,
+)
+from key_extractor.app import KeyExtractorApp  # noqa: E402
+from release_audit import audit_directory, audit_zip  # noqa: E402
+
+
+def test_login_instructions_require_actual_readiness_not_a_fixed_delay() -> None:
+    source = (TOOL_ROOT / "key_extractor/app.py").read_text(encoding="utf-8")
+    capture_dialog = source[source.index("    def _run_capture("):source.index("    def _wait_for_monitor_ready(")]
+    assert "等待约 5 秒" not in capture_dialog
+    assert "监测已就绪，可以重新登录" in capture_dialog
+
+
+def test_build_includes_native_capture_source_and_uses_separate_test_output() -> None:
+    script = (TOOL_ROOT / "build-macos.sh").read_text(encoding="utf-8")
+    assert 'wcdb_native_capture.c:wechat_decrypt_tool/native/macos/source' in script
+    assert 'WEDATA_KEY_EXTRACTOR_DIST_DIR' in script
+
+
+def test_resolve_probe_database_prefers_message_database(tmp_path: Path) -> None:
+    storage = tmp_path / "wxid_demo" / "db_storage"
+    storage.mkdir(parents=True)
+    (storage / "session.db").write_bytes(b"s" * 4096)
+    (storage / "message_0.db").write_bytes(b"m" * 4096)
+    (storage / "msg0.db").write_bytes(b"p" * 4096)
+
+    assert resolve_probe_database(storage) == storage / "msg0.db"
+
+
+def test_resolve_probe_database_accepts_a_database_file(tmp_path: Path) -> None:
+    database = tmp_path / "contact.db"
+    database.write_bytes(b"x" * 4096)
+
+    assert resolve_probe_database(database) == database
+
+
+def test_discover_default_probe_databases_finds_each_account(tmp_path: Path) -> None:
+    base = (
+        tmp_path
+        / "Library"
+        / "Containers"
+        / "com.tencent.xinWeChat"
+        / "Data"
+        / "Documents"
+        / "app_data"
+        / "xwechat_files"
+    )
+    first = base / "wxid_first_ab12" / "db_storage"
+    second = base / "wxid_second_cd34" / "db_storage"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "message_0.db").write_bytes(b"a" * 4096)
+    (second / "session.db").write_bytes(b"b" * 4096)
+
+    discovered = discover_default_probe_databases(home=tmp_path)
+
+    assert discovered == [first / "message_0.db", second / "session.db"]
+
+
+def test_discover_default_probe_databases_supports_legacy_documents_layout(tmp_path: Path) -> None:
+    storage = tmp_path / "Documents" / "xwechat_files" / "wxid_legacy" / "db_storage"
+    storage.mkdir(parents=True)
+    database = storage / "message_0.db"
+    database.write_bytes(b"d" * 4096)
+
+    assert discover_default_probe_databases(home=tmp_path) == [database]
+
+
+def test_active_app_data_database_wins_over_legacy_duplicate(tmp_path: Path) -> None:
+    documents = tmp_path / "Library/Containers/com.tencent.xinWeChat/Data/Documents"
+    active = documents / "app_data/xwechat_files/wxid_same/db_storage/message/message_0.db"
+    legacy = documents / "xwechat_files/wxid_same/db_storage/message/message_0.db"
+    active.parent.mkdir(parents=True)
+    legacy.parent.mkdir(parents=True)
+    active.write_bytes(b"a" * 4096)
+    legacy.write_bytes(b"b" * 4096)
+
+    assert discover_default_probe_databases(home=tmp_path) == [active]
+    assert prefer_active_probe_database(legacy, home=tmp_path) == active
+
+
+def test_wechat_v4_never_falls_back_to_visible_legacy_database(tmp_path: Path) -> None:
+    wechat = tmp_path / "WeChat.app"
+    info_plist = wechat / "Contents/Info.plist"
+    info_plist.parent.mkdir(parents=True)
+    with info_plist.open("wb") as handle:
+        plistlib.dump({"CFBundleShortVersionString": "4.1.12"}, handle)
+    documents = tmp_path / "Library/Containers/com.tencent.xinWeChat/Data/Documents"
+    legacy = documents / "xwechat_files/wxid_same/db_storage/message/message_0.db"
+    active = documents / "app_data/xwechat_files/wxid_same/db_storage/message/message_0.db"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_bytes(b"b" * 4096)
+
+    assert prefer_active_probe_database(legacy, home=tmp_path, wechat_app=wechat) == active
+
+
+def test_active_selected_database_does_not_rescan_all_accounts(tmp_path: Path) -> None:
+    active = (
+        tmp_path
+        / "Library/Containers/com.tencent.xinWeChat/Data/Documents/app_data/xwechat_files"
+        / "wxid_same/db_storage/message/message_0.db"
+    )
+    active.parent.mkdir(parents=True)
+    active.write_bytes(b"a" * 4096)
+
+    with patch(
+        "key_extractor.core.discover_default_probe_databases",
+        side_effect=AssertionError("active database must not trigger a recursive account rescan"),
+    ):
+        assert prefer_active_probe_database(active, home=tmp_path) == active
+
+
+def test_database_key_is_masked_until_user_copies_it() -> None:
+    key = "ab" * 32
+
+    assert mask_database_key(key) == "abababab……abababab"
+    assert mask_database_key("") == "尚未提取"
+
+
+def test_default_backup_root_is_inside_selected_work_root(tmp_path: Path) -> None:
+    assert default_backup_root(tmp_path) == tmp_path / "wechat-app-backups"
+
+
+def test_default_work_root_does_not_read_another_apps_machine_settings(tmp_path: Path) -> None:
+    configured_output = tmp_path / "someone-elses-output"
+    configured_output.mkdir()
+    settings = (
+        tmp_path
+        / "Library"
+        / "Application Support"
+        / "wechat-data-analysis-desktop"
+        / "desktop-settings.json"
+    )
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        '{"outputDir":' + repr(str(configured_output)).replace("'", '"') + "}",
+        encoding="utf-8",
+    )
+
+    assert default_work_root(tmp_path) == (
+        tmp_path / "Library" / "Application Support" / "WeDataKeyExtractor" / "work"
+    )
+
+
+def test_fresh_capture_result_cannot_be_mistaken_for_old_cache() -> None:
+    key = "cd" * 32
+
+    result = merge_fresh_capture_result(
+        {"method": "macos_inplace_lldb_passphrase", "process_attached": True},
+        {"method": "safe_local_cache", "db_key": key, "validated": True},
+    )
+
+    assert result["db_key"] == key
+    assert result["method"] == "macos_inplace_lldb_passphrase"
+    assert result["fresh_capture"] is True
+
+
+def test_standalone_ui_does_not_short_circuit_through_existing_cache() -> None:
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            TOOL_ROOT / "key_extractor" / "app.py",
+            TOOL_ROOT / "key_extractor" / "core.py",
+        )
+    )
+
+    assert "正在校验已有密钥缓存" not in source
+    assert "_cached_key_found" not in source
+    assert "本次不会读取旧密钥缓存" in source
+    assert "discovered = discover_cached_key(database)" not in source
+    assert "显示微信窗口" in source
+    assert "self._wait_for_monitor_ready" in source
+    assert "监测已就绪，可以重新登录" in source
+
+
+class _FakeValue:
+    def __init__(self, value: str = "") -> None:
+        self.value = value
+
+    def set(self, value: str) -> None:
+        self.value = value
+
+    def get(self) -> str:
+        return self.value
+
+
+class _FakeButton:
+    def __init__(self) -> None:
+        self.options: dict[str, str] = {}
+
+    def configure(self, **options: str) -> None:
+        self.options.update(options)
+
+
+class _FakeCaptureRoot:
+    def __init__(self) -> None:
+        self.callbacks = {}
+        self.next_id = 0
+        self.destroy = Mock()
+
+    def after(self, _delay, callback):
+        self.next_id += 1
+        self.callbacks[self.next_id] = callback
+        return self.next_id
+
+    def after_cancel(self, callback_id):
+        self.callbacks.pop(callback_id, None)
+
+    def run_next(self):
+        callback_id = next(iter(self.callbacks))
+        self.callbacks.pop(callback_id)()
+
+
+def _capture_progress_ui(monkeypatch):
+    app = object.__new__(KeyExtractorApp)
+    app.root = _FakeCaptureRoot()
+    app.wechat_var = _FakeValue("/synthetic/WeChat.app")
+    app.database_var, app.work_root_var = _FakeValue(), _FakeValue()
+    app.status_var, app.detail_var = _FakeValue(), _FakeValue()
+    app.key_var = _FakeValue("尚未提取")
+    app.current_key = ""
+    app.primary_button, app.cancel_button, app.copy_button = _FakeButton(), _FakeButton(), _FakeButton()
+    app._busy = False
+    app._closing_after_cleanup = False
+    app.stage = "preflight"
+    app._capture_transaction_id = "transaction-current"
+    app._hide_wechat = Mock(return_value=True)
+    app._show_wechat = Mock()
+    app._show_success = Mock()
+    app._run_task = Mock(side_effect=lambda *_args, **_kwargs: setattr(app, "_busy", True))
+    threads = []
+    monkeypatch.setattr("key_extractor.app.threading.Thread", lambda *, target, daemon: Mock(start=lambda: threads.append(target)))
+    monkeypatch.setattr("key_extractor.app.messagebox.askokcancel", lambda *_args: True)
+    monkeypatch.setattr("key_extractor.app.messagebox.showerror", lambda *_args: None)
+    monkeypatch.setattr("key_extractor.app.capture_status", lambda _path: {"pending": False})
+    app._run_capture()
+    return app, threads
+
+
+def _deliver_capture_status(monkeypatch, app, threads, phase, *, ready=False, transaction="transaction-current", pending=True):
+    status = {
+        "pending": pending,
+        "capture_phase": phase,
+        "monitor_ready": ready,
+        "transaction_id": transaction,
+    }
+    monkeypatch.setattr("key_extractor.app.capture_status", lambda _path: status)
+    if not threads:
+        app.root.run_next()
+    assert len(threads) == 1, "status reads must be asynchronous and single-flight"
+    threads.pop(0)()
+    app.root.run_next()
+
+
+def test_capture_progress_continues_after_ready_and_explains_expected_wechat_close(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    assert "自动关闭" in app.detail_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "waiting_authorization")
+    assert "授权" in app.status_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=True)
+    app._show_wechat.assert_called_once()
+    assert "可以重新登录" in app.status_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "captured", ready=True)
+    assert "捕获" in app.status_var.get() and "校验" in app.status_var.get()
+    assert "自动关闭" in app.detail_var.get() and "无需重新登录" in app.detail_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "validating")
+    assert "复验" in app.status_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "restoring")
+    assert "正在恢复" in app.status_var.get()
+    assert "已恢复" not in app.detail_var.get()
+    app._show_wechat.assert_called_once()
+    app._show_success.assert_not_called()
+    assert app.current_key == ""
+
+
+def test_capture_ready_requires_current_transaction_and_cannot_regress_a_later_phase(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=True, transaction="transaction-old")
+    app._show_wechat.assert_not_called()
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=False)
+    assert "可以重新登录" not in app.status_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=True)
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=True)
+    app._show_wechat.assert_called_once()
+    _deliver_capture_status(monkeypatch, app, threads, "restoring")
+    restoring_text = app.status_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=True)
+    assert app.status_var.get() == restoring_text
+    app._show_wechat.assert_called_once()
+
+
+@pytest.mark.parametrize("phase", ["captured", "validating", "restoring"])
+def test_capture_can_skip_ready_without_reopening_wechat(monkeypatch, phase) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    _deliver_capture_status(monkeypatch, app, threads, phase, ready=True)
+    app._show_wechat.assert_not_called()
+    assert "重新登录" not in app.status_var.get()
+    app._show_success.assert_not_called()
+
+
+def test_cleared_capture_state_does_not_report_success_before_finish_result(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    _deliver_capture_status(monkeypatch, app, threads, "restoring")
+    _deliver_capture_status(monkeypatch, app, threads, None, transaction=None, pending=False)
+    app._show_success.assert_not_called()
+    assert "正在恢复" in app.status_var.get()
+    app._capture_finished({"fresh_capture": True, "process_attached": True, "official_wechat_verified": True, "db_key": "ab" * 32})
+    app._show_success.assert_called_once_with("ab" * 32)
+    assert not app.root.callbacks
+
+
+@pytest.mark.parametrize("terminal", ["finish", "failure", "close"])
+def test_capture_terminal_state_ignores_late_status_threads_and_callbacks(monkeypatch, terminal) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    app.root.run_next()
+    late_thread = threads.pop(0)
+    late_callback = next(iter(app.root.callbacks.values()))
+    if terminal == "finish":
+        app._capture_finished({"fresh_capture": True, "process_attached": True, "official_wechat_verified": True, "db_key": "ab" * 32})
+    elif terminal == "failure":
+        app._handle_error(RuntimeError("synthetic failure"))
+    else:
+        app._busy = False
+        app._on_close()
+        app.root.destroy.assert_called_once()
+    terminal_text = (app.status_var.get(), app.detail_var.get())
+    monkeypatch.setattr("key_extractor.app.capture_status", lambda _path: {
+        "pending": True, "capture_phase": "monitoring", "monitor_ready": True,
+        "transaction_id": "transaction-current",
+    })
+    late_thread()
+    late_callback()
+    assert not app.root.callbacks
+    assert (app.status_var.get(), app.detail_var.get()) == terminal_text
+    app._show_wechat.assert_not_called()
+
+
+def test_capture_confirmations_explain_successful_automatic_close(monkeypatch) -> None:
+    app, _threads = _capture_progress_ui(monkeypatch)
+    prompts = []
+    monkeypatch.setattr("key_extractor.app.messagebox.askokcancel", lambda title, text: prompts.append(text) or False)
+    app._busy = False
+    app._confirm_fresh_capture()
+    app._run_capture()
+    assert len(prompts) == 2
+    for prompt in prompts:
+        assert "自动关闭" in prompt and "恢复" in prompt and "无需重新登录" in prompt
+
+
+def test_slow_capture_status_does_not_block_tk_or_start_parallel_reads(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    status_reader = Mock(return_value={"pending": False})
+    monkeypatch.setattr("key_extractor.app.capture_status", status_reader)
+    for _ in range(5):
+        app.root.run_next()
+    status_reader.assert_not_called()
+    assert len(threads) == 1
+    threads.pop(0)()
+    status_reader.assert_called_once()
+    app.root.run_next()
+    assert len(threads) == 1
+
+
+def test_capture_polling_recovers_from_status_read_error(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    app.root.run_next()
+    monkeypatch.setattr("key_extractor.app.capture_status", Mock(side_effect=OSError("synthetic unavailable")))
+    threads.pop(0)()
+    app.root.run_next()
+    assert "synthetic unavailable" not in app.detail_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=True)
+    app._show_wechat.assert_called_once()
+
+
+def test_stale_capture_run_cannot_update_or_complete_a_new_run(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    app.root.run_next()
+    old_reader = threads.pop(0)
+    old_poll_callback = next(iter(app.root.callbacks.values()))
+    old_finish_callback = app._run_task.call_args.args[1]
+    app._stop_capture_polling()
+    app._busy = False
+    app._run_capture()
+    new_callbacks = dict(app.root.callbacks)
+    monkeypatch.setattr("key_extractor.app.capture_status", lambda _path: {
+        "pending": True, "capture_phase": "monitoring", "monitor_ready": True,
+        "transaction_id": "transaction-current",
+    })
+    old_reader()
+    old_poll_callback()
+    old_finish_callback({"fresh_capture": True, "process_attached": True, "official_wechat_verified": True, "db_key": "ab" * 32})
+    assert app.root.callbacks == new_callbacks
+    app._show_wechat.assert_not_called()
+    app._show_success.assert_not_called()
+    _deliver_capture_status(monkeypatch, app, threads, "restoring")
+    assert "正在恢复" in app.status_var.get()
+    app._show_wechat.assert_not_called()
+
+
+def test_readiness_is_not_trusted_without_preflight_transaction(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    app._capture_transaction_id = ""
+    _deliver_capture_status(monkeypatch, app, threads, "monitoring", ready=True)
+    app._show_wechat.assert_not_called()
+    app._preflight_ready({"transaction_id": "transaction-current", "method": "native"})
+    assert app._capture_transaction_id == "transaction-current"
+
+
+def test_busy_close_keeps_live_capture_polling_until_operation_finishes(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    callbacks = dict(app.root.callbacks)
+    monkeypatch.setattr("key_extractor.app.messagebox.showinfo", Mock())
+    app._on_close()
+    assert app._capture_poll_active
+    assert app.root.callbacks == callbacks
+    app.root.destroy.assert_not_called()
+    _deliver_capture_status(monkeypatch, app, threads, "restoring")
+    assert "正在恢复" in app.status_var.get()
+
+
+def test_native_capture_can_validate_before_reporting_a_validated_capture(monkeypatch) -> None:
+    app, threads = _capture_progress_ui(monkeypatch)
+    _deliver_capture_status(monkeypatch, app, threads, "validating")
+    assert "复验" in app.status_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "captured")
+    assert "捕获" in app.status_var.get() and "校验" in app.status_var.get()
+    _deliver_capture_status(monkeypatch, app, threads, "restoring")
+    _deliver_capture_status(monkeypatch, app, threads, "validating")
+    assert "正在恢复" in app.status_var.get()
+    app._show_wechat.assert_not_called()
+
+
+@pytest.mark.parametrize("verified", [None, False])
+def test_capture_finish_requires_official_wechat_verification(monkeypatch, verified) -> None:
+    app, _threads = _capture_progress_ui(monkeypatch)
+    app._handle_error = Mock()
+    result = {"fresh_capture": True, "process_attached": True, "db_key": "ab" * 32}
+    if verified is not None:
+        result["official_wechat_verified"] = verified
+    app._capture_finished(result)
+    app._show_success.assert_not_called()
+    app._handle_error.assert_called_once()
+    assert "腾讯官方微信" in str(app._handle_error.call_args.args[0])
+    assert not app.root.callbacks
+
+
+def test_failed_capture_without_pending_state_resets_retry_button(monkeypatch) -> None:
+    app = object.__new__(KeyExtractorApp)
+    app.wechat_var = _FakeValue("/synthetic/WeChat.app")
+    app.stage = "preflight"
+    app.status_var = _FakeValue()
+    app.detail_var = _FakeValue()
+    app.primary_button = _FakeButton()
+    app.cancel_button = _FakeButton()
+    app._closing_after_cleanup = False
+    monkeypatch.setattr("key_extractor.app.capture_status", lambda _path: {"pending": False, "stage": "idle"})
+    monkeypatch.setattr("key_extractor.app.messagebox.showerror", lambda *_args: None)
+
+    app._handle_error(RuntimeError("capture failed"))
+
+    assert app.stage == "idle"
+    assert app.primary_button.options == {"state": "normal", "text": "重新开始"}
+    assert app.cancel_button.options == {"state": "disabled"}
+
+
+def test_failed_capture_with_pending_state_requires_restore(monkeypatch) -> None:
+    app = object.__new__(KeyExtractorApp)
+    app.wechat_var = _FakeValue("/synthetic/WeChat.app")
+    app.stage = "preflight"
+    app.status_var = _FakeValue()
+    app.detail_var = _FakeValue()
+    app.primary_button = _FakeButton()
+    app.cancel_button = _FakeButton()
+    app._closing_after_cleanup = False
+    monkeypatch.setattr("key_extractor.app.capture_status", lambda _path: {"pending": True, "stage": "launched"})
+    monkeypatch.setattr("key_extractor.app.messagebox.showerror", lambda *_args: None)
+
+    app._handle_error(RuntimeError("capture failed"))
+
+    assert app.stage == "prepared"
+    assert app.primary_button.options == {"state": "disabled", "text": "等待恢复"}
+    assert app.cancel_button.options == {"state": "normal"}
+
+
+def _pending_ui(monkeypatch, stage: str) -> KeyExtractorApp:
+    app = object.__new__(KeyExtractorApp)
+    app.wechat_var = _FakeValue("/synthetic/WeChat.app")
+    app.stage = "idle"
+    app.status_var, app.detail_var = _FakeValue(), _FakeValue()
+    app.primary_button, app.cancel_button = _FakeButton(), _FakeButton()
+    app._busy = False
+    app._closing_after_cleanup = False
+    app.last_error = ""
+    app.root = Mock()
+    app._run_task = Mock()
+    monkeypatch.setattr("key_extractor.app.capture_status", lambda _path: {"pending": True, "stage": stage})
+    monkeypatch.setattr("key_extractor.app.messagebox.showerror", lambda *_args: None)
+    return app
+
+
+def test_startup_official_conflict_allows_explicit_new_baseline(monkeypatch) -> None:
+    app = _pending_ui(monkeypatch, "external_install_conflict")
+    app._check_pending_capture()
+    assert app.stage == "external_install_conflict"
+    assert app.primary_button.options == {"state": "normal", "text": "以当前版本重新开始"}
+    assert app.cancel_button.options == {"state": "disabled"}
+    assert "保留" in app.detail_var.get()
+    assert "已恢复" not in app.status_var.get()
+    app._run_task.assert_not_called()
+
+
+def test_conflict_error_does_not_strand_retry_or_claim_restore(monkeypatch) -> None:
+    app = _pending_ui(monkeypatch, "external_install_conflict")
+    app._handle_error(RuntimeError("official build changed"))
+    assert app.primary_button.options["state"] == "normal"
+    assert app.primary_button.options["text"] == "以当前版本重新开始"
+    assert "已恢复" not in app.status_var.get()
+    assert app.cancel_button.options["state"] == "disabled"
+
+
+def test_unknown_debug_identity_blocks_automatic_actions(monkeypatch) -> None:
+    app = _pending_ui(monkeypatch, "recovery_blocked")
+    app._check_pending_capture()
+    assert app.stage == "recovery_blocked"
+    assert app.primary_button.options == {"state": "disabled", "text": "需要手动处理"}
+    assert app.cancel_button.options == {"state": "disabled"}
+    assert "未覆盖" in app.detail_var.get()
+
+
+def test_close_conflict_preserves_install_without_requesting_restore(monkeypatch) -> None:
+    app = _pending_ui(monkeypatch, "external_install_conflict")
+    prompts = []
+    monkeypatch.setattr("key_extractor.app.messagebox.askokcancel", lambda title, text: prompts.append(text) or True)
+    app._on_close()
+    assert "保留" in prompts[0]
+    app._run_task.assert_not_called()
+    app.root.destroy.assert_called_once()
+    assert not app._closing_after_cleanup
+
+
+def test_conflict_restart_confirmation_explains_preserved_backup(monkeypatch) -> None:
+    app = _pending_ui(monkeypatch, "external_install_conflict")
+    app.stage = "external_install_conflict"
+    prompts = []
+    monkeypatch.setattr("key_extractor.app.messagebox.askokcancel", lambda title, text: prompts.append((title, text)) or True)
+    app._confirm_fresh_capture()
+    assert prompts[0][0] == "以当前版本重新开始"
+    assert "旧备份" in prompts[0][1]
+    assert "保留" in prompts[0][1]
+    app._run_task.assert_called_once()
+
+
+def test_cancel_without_replacement_reports_verification_not_restore(monkeypatch) -> None:
+    app = _pending_ui(monkeypatch, "idle")
+    app._cancelled({"official_wechat_verified": True, "official_wechat_restored": False})
+    assert "已恢复" not in app.status_var.get()
+    assert "未替换" in app.detail_var.get()
+
+
+def test_safe_status_unlocks_manual_official_reinstall_without_restoring(monkeypatch) -> None:
+    monkeypatch.setattr("wechat_decrypt_tool.macos_inplace_capture.get_in_place_capture_status", lambda: {"pending": True, "stage": "recovery_blocked"})
+    monkeypatch.setattr("wechat_decrypt_tool.macos_db_key_capture.normalize_wechat_app_path", lambda _path: Path("/synthetic/WeChat.app"))
+    monkeypatch.setattr("wechat_decrypt_tool.macos_db_key_capture.inspect_wechat_signature", lambda _path: {
+        "valid": True, "ad_hoc": False, "team_identifier": "5A4RE8SF68", "identifier": "com.tencent.xinWeChat",
+    })
+    restore = Mock(side_effect=AssertionError("status must not mutate the application"))
+    monkeypatch.setattr("wechat_decrypt_tool.macos_db_key_capture.restore_official_wechat_if_needed", restore)
+    status = capture_status()
+    assert status["stage"] == "external_install_conflict"
+    assert status["restart_allowed"] is True
+    restore.assert_not_called()
+
+
+def test_safe_status_does_not_trust_a_stale_official_conflict(monkeypatch) -> None:
+    monkeypatch.setattr("wechat_decrypt_tool.macos_inplace_capture.get_in_place_capture_status", lambda: {"pending": True, "stage": "external_install_conflict"})
+    monkeypatch.setattr("wechat_decrypt_tool.macos_db_key_capture.normalize_wechat_app_path", lambda _path: Path("/synthetic/WeChat.app"))
+    monkeypatch.setattr("wechat_decrypt_tool.macos_db_key_capture.inspect_wechat_signature", lambda _path: {"valid": True, "ad_hoc": True})
+    status = capture_status()
+    assert status["stage"] == "recovery_blocked"
+    assert status["restart_allowed"] is False
+
+
+def test_safe_status_verifies_selected_app_not_default_installation(monkeypatch) -> None:
+    monkeypatch.setattr("wechat_decrypt_tool.macos_inplace_capture.get_in_place_capture_status", lambda: {"pending": True, "stage": "external_install_conflict"})
+    selected = Path("/synthetic/selected/WeChat.app")
+    normalize = Mock(return_value=selected)
+    inspect = Mock(return_value={"valid": True, "ad_hoc": True})
+    monkeypatch.setattr("wechat_decrypt_tool.macos_db_key_capture.normalize_wechat_app_path", normalize)
+    monkeypatch.setattr("wechat_decrypt_tool.macos_db_key_capture.inspect_wechat_signature", inspect)
+    status = capture_status(selected)
+    normalize.assert_called_once_with(selected)
+    inspect.assert_called_once_with(selected)
+    assert status["restart_allowed"] is False
+
+
+def test_account_discovery_preserves_saved_active_path_when_access_is_temporarily_missing(monkeypatch) -> None:
+    active = "/private/current/app_data/xwechat_files/wxid_same/db_storage/message/message_0.db"
+    legacy = Path("/private/legacy/xwechat_files/wxid_same/db_storage/message/message_0.db")
+    app = object.__new__(KeyExtractorApp)
+    app.wechat_var = _FakeValue("/Applications/WeChat.app")
+    app.database_var = _FakeValue(active)
+    app.database_choice_var = _FakeValue()
+    app.account_combo = {}
+    app.db_choices = {}
+    monkeypatch.setattr("key_extractor.app.discover_default_probe_databases", lambda: [legacy])
+    monkeypatch.setattr(
+        "key_extractor.app.prefer_active_probe_database",
+        lambda path, **_kwargs: path,
+    )
+
+    app._discover_accounts()
+
+    assert app.database_var.get() == active
+    assert active in app.db_choices.values()
+    assert "已保存路径" in app.database_choice_var.get()
+
+
+def test_distribution_sources_do_not_contain_machine_specific_assumptions() -> None:
+    source_files = [
+        TOOL_ROOT / "README.md",
+        TOOL_ROOT / "key_extractor" / "app.py",
+        TOOL_ROOT / "key_extractor" / "core.py",
+        TOOL_ROOT.parent / "src" / "wechat_decrypt_tool" / "macos_db_key_capture.py",
+        TOOL_ROOT.parent / "src" / "wechat_decrypt_tool" / "macos_db_key_discovery.py",
+        TOOL_ROOT.parent / "src" / "wechat_decrypt_tool" / "macos_inplace_capture.py",
+    ]
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in source_files)
+
+    for forbidden in (
+        "/Users/",
+        "/Volumes/",
+        str(Path.home()),
+        "绿联",
+        "NAS",
+        "wechat-data-analysis-desktop",
+        "主程序",
+    ):
+        assert forbidden not in combined
+
+
+def test_release_audit_rejects_personal_paths_and_runtime_secrets(tmp_path: Path) -> None:
+    app = tmp_path / "Example.app"
+    app.mkdir()
+    (app / "binary").write_bytes(b"built from /Users/demo/private/source.py")
+    (app / "wechat-passphrase.json").write_text("{}", encoding="utf-8")
+
+    violations = audit_directory(app)
+
+    assert any("用户主目录绝对路径" in item for item in violations)
+    assert any("私密文件" in item for item in violations)
+
+
+def test_release_audit_accepts_clean_app_and_rejects_database_in_zip(tmp_path: Path) -> None:
+    import zipfile
+
+    app = tmp_path / "Clean.app"
+    app.mkdir()
+    (app / "binary").write_bytes(b"portable executable content")
+    assert audit_directory(app) == []
+
+    archive = tmp_path / "release.zip"
+    with zipfile.ZipFile(archive, "w") as output:
+        output.writestr("Clean.app/Contents/MacOS/binary", b"clean")
+        output.writestr("Clean.app/user/message_0.db", b"private")
+    assert any("私密文件" in item for item in audit_zip(archive))


### PR DESCRIPTION
## 背景与范围

作为已合并 #103 的后续修复，跟进 #103、#126、#134、#138 和 #101 的反馈。基于上游 main `ba9763f`，不修改默认受控 helper 的下载/完整性校验策略，不引入私人页面、聊天数据、媒体/AI 功能、用户配置或证书。相关问题仍需原反馈环境复测，本 PR 不自动关闭它们。

## 主要改动

- 原版恢复绑定本次版本、build、CDHash 和临时应用身份；遇到外部升级/降级/替换时停止旧事务覆盖并保留恢复资产。
- 预检、监测和进度绑定事务/PID/后端，拒绝旧就绪标记；macOS 27 优先软件 LLDB，原生调试状态不确定时先恢复，不在同一目标上盲目重试。
- 修复 LLDB 结束后保活/超时子进程仍占用输出管道造成的长时间等待；区分意外退出、已捕获、复验、恢复与最终完成。
- 复用 UUID 绑定的断点计划、运行地址校验、非敏感退出诊断与有界参数计数。PBKDF 候选须匹配目标数据库，并同时通过消息库/会话库首页 HMAC；单库派生密钥不能冒充账号密钥。
- 保留上游本机 HTTP 访问限制、并发控制、默认 helper 与网页交互；网页持续展示事务阶段，不把捕获后的计划关闭当作需要再次登录。
- 提交可选独立验证工具源码 `macos-key-extractor/`，与主程序共享捕获/恢复模块。新增手动启动检查：系统安全授权由用户本人确认，不修改 SIP/Gatekeeper，不自动放行应用。主程序原有启动调用保持不变。

## 验证

2026-09-06 在当前公开提交重跑：**283 passed、32 subtests passed、2 deselected**；`node --test tests/macos-capture-progress.test.mjs` 为 **10 passed**。

Python 命令见 [捕获说明](docs/MACOS_KEY_CAPTURE.md) 的回归测试段，另包含 `tests/test_keys_saved_db_key_source_validation.py` 与 `tests/test_wechat_decrypt_key_modes.py`。2 项 APFS 实盘克隆测试在沙盒环境排除，不记作通过。Vue script/template 编译、原生 C 的 arm64 `clang -fsyntax-only`、`zsh -n macos-key-extractor/build-macos.sh` 和 `git diff --check` 也已通过。

这些是合成数据库、伪进程/LLDB 和 UI 回归，不等于每个微信版本的真实登录测试。使用者于 2026-09-05 反馈：Apple Silicon / macOS 27 / 微信 **4.1.7**，独立工具 1.1.11 正确获取密钥并恢复官方版本。**4.1.12/4.1.13 对应反馈环境仍待验收，不承诺 100% 成功或零账号风险。** 本公开分支没有额外重签或运行真实微信。

另行检查发现上游已有的 `test_decrypt_guides_replace_native_confirms_and_cover_media_choices` 会因语音引导中的 `window.confirm` 失败；上游 `ba9763f` 已包含该调用，本次未改动该语音逻辑，因此不宣称全仓测试通过。

## 发布与隐私

目前是源码修复 PR，**尚未进入上游 Release**。懂源码构建的用户可选本分支复测；安装包用户请等待包含本提交的正式版本，不应将重新安装旧包视为已经更新。

仅提交源码、文档、构建/审计脚本和合成测试。没有真实密钥、数据库、聊天内容、个人路径、日志、安装产物或私有签名证书。复测反馈只需系统/微信完整 build、阶段、后端、错误码与脱敏计数，不需要上传密钥或数据库。

